### PR TITLE
Toolkit integration: launcher delegation, Module system, settings + resources editors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build & Test (Linux)
+    name: Build & Unit Tests (Linux)
 
     steps:
       - name: Checkout
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.1
+          version: 0.15.2
 
       - name: Install dependencies
         run: |
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         run: zig build -Dcpu=baseline
 
-      - name: Unit Tests
+      - name: Unit Tests (zspec)
         run: zig build test -Dcpu=baseline
 
       - name: Upload artifact
@@ -38,9 +38,43 @@ jobs:
           path: zig-out/bin/
           if-no-files-found: error
 
-  gui-test:
+  # ImGui Test Engine harness — `zig build gui-test`. Drives real menu
+  # actions against a hidden GLFW window and asserts on App state. Still
+  # needs an X display on Linux because zglfw.init touches X even with
+  # the window kept invisible.
+  ui-tests:
     runs-on: ubuntu-latest
-    name: GUI Smoke Test
+    name: ImGui Test Engine
+    needs: build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libgtk-3-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+
+      - name: Run UI tests under Xvfb
+        run: |
+          export DISPLAY=:99
+          Xvfb :99 -screen 0 1280x720x24 &
+          sleep 1
+          zig build gui-test -Dcpu=baseline
+
+  # Process-launch sanity check — confirms the production binary starts,
+  # doesn't crash for a few seconds, and renders something. Separate from
+  # `zig build gui-test` because that runs a *different* binary (the
+  # test runner) that has its own with-test-engine zgui module.
+  launch-check:
+    runs-on: ubuntu-latest
+    name: Launch Smoke (Linux)
     needs: build
 
     steps:
@@ -70,7 +104,7 @@ jobs:
             wmctrl \
             imagemagick
 
-      - name: Run GUI Smoke Test
+      - name: Launch and screenshot
         run: |
           # Start Xvfb
           export DISPLAY=:99
@@ -96,7 +130,7 @@ jobs:
             kill $APP_PID 2>/dev/null || true
             wait $APP_PID 2>/dev/null || true
 
-            echo "GUI test passed!"
+            echo "Launch smoke passed!"
             exit 0
           else
             echo "FAILED: Application did not start or crashed"
@@ -107,6 +141,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: gui-test-screenshot
+          name: launch-screenshot
           path: screenshot.png
           if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,9 @@ managed fields, so external projects round-trip without data loss.
 
 Known limitations of the pass-through:
 
-- **Detached top-level comments** (those between fields, not attached
-  to a particular value) are not preserved — the scanner walks
-  field-by-field.
+- **Comments above managed fields** are dropped. Comments above
+  unmodeled fields ride along with that field's verbatim block — the
+  scanner captures the comment block as part of the field's text.
 - **Multi-line strings (`\\...`)** and **`'...'` character literals**
   aren't handled because the assembler's schema doesn't use them. If
   either appears in a future schema, grow `scanValue` in `project.zig`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md — labelle-gui
+
+Guidance for Claude Code when working in this directory. See `../CLAUDE.md` for toolkit-wide context.
+
+## What this app does
+
+GUI editor for `labelle-toolkit` game projects. The editable artifact is a `project.labelle` ZON file at the project root (schema = `labelle-assembler`'s `ProjectConfig`). The gui scaffolds the project tree and drives `build` / `run` via the `labelle` CLI launcher — it does **not** generate `build.zig` / `build.zig.zon` / `main.zig` itself; the assembler (invoked by the launcher) owns those.
+
+## Build commands
+
+```bash
+zig build           # build the gui exe
+zig build run       # build + run the gui
+zig build test      # zspec unit/filesystem tests (hermetic)
+zig build gui-test  # ImGui Test Engine UI tests (hidden GLFW window)
+zig build smoke     # end-to-end against the real `labelle` launcher — env-dependent
+```
+
+`zig build smoke` requires `labelle` on PATH and either a populated `~/.labelle/packages/` cache or network. It's the only test that proves the launcher integration actually works. Run it after touching `src/project.zig` or `src/compiler.zig`.
+
+## Source map
+
+| File | Role |
+|------|------|
+| `src/main.zig` | GLFW + zgui main loop; menu and dialog handling. State lives inline; Phase 2 of the TE work will refactor this into an `App` struct. |
+| `src/project.zig` | `ProjectConfig` (mirrors a subset of `labelle-assembler/src/config.zig:ProjectConfig`), `ProjectManager`, `project.labelle` read/write. Each `Project` owns an `ArenaAllocator` so the parsed config strings free uniformly in `deinit`. |
+| `src/compiler.zig` | Wraps `labelle generate/build/run` as a child process. `syncProjectFiles` calls `ProjectManager.saveProject`. `buildOrRun` spawns; `pollBuild` waits and captures stdout/stderr. |
+| `src/tree_view.zig` | Project tree widget. |
+| `src/tests.zig` | zspec test root; covers `ProjectConfig`, `ProjectManager`, scaffold folders, save/load round-trip, `Compiler` state. |
+| `src/gui_tests.zig` | UI test runner using zgui's bundled ImGui Test Engine (`with_te=true`). See "TE quirks" below. |
+| `src/smoke.zig` | End-to-end smoke harness — temp dir, `ProjectManager.saveProject`, `Compiler.build`, asserts `.labelle/<target>/` appears. |
+
+## Key invariants
+
+1. **`project.labelle` must pin all four versions** — `core_version`, `engine_version`, `gfx_version`, `assembler_version`. The launcher's resolver falls back to its own version for missing fields (`labelle-cli/src/cli/cache.zig:29`: `cfg.assembler_version orelse cfg.labelle_version`), which 404s when CLI and assembler aren't lockstep. Defaults in `ProjectConfig` track `labelle-cli/versions.zon` and the CLI's own assembler pin.
+2. **Project = directory.** `Project.dir` holds the project directory; `<dir>/project.labelle` is the editable file. Open / Save dialogs use `nfd.openFolderDialog`, not file dialogs.
+3. **Don't reintroduce `build.zig` template generation.** The assembler owns that. If you find yourself writing build files from the gui, you're going the wrong direction.
+
+## TE (Test Engine) quirks
+
+When zgui is built with `with_te = true`:
+
+- `zgui.init(allocator)` **already calls `zgui.te.init()`** (gui.zig:60). A second explicit `te.init()` double-registers the `TestEnginePerfTool` settings handler and trips an imgui assertion. Just use `zgui.te.getTestEngine()` to retrieve the engine zgui created.
+- `engine.queueTests(.tests, "", .{})` matches nothing — the empty string filter falls through to "include nothing". Use the literal `"all"` to match every registered test (`imgui_test_engine/imgui_te_engine.cpp:1382`).
+
+## Dep pinning notes
+
+`build.zig.zon` pins the three zig-gamedev deps (`zgui`, `zglfw`, `zopengl`) to specific pre-Zig-0.16 commits. Upstream main moved to Zig 0.16 in early 2026; this project targets 0.15.2 (toolkit-wide). If you bump these, verify against:
+
+- `zopengl` must not use `@Enum` (added when upstream switched to 0.16).
+- `zglfw` 5-arg `createWindow` signature is what `main.zig:67` expects.
+- `zgui` must predate the `0.16.x` branch merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ zig build smoke     # end-to-end against the real `labelle` launcher — env-dep
 | `src/main.zig` | GLFW init, window + GL context, font + DPI setup, frame loop. Delegates per-frame UI to `App.renderFrame()`. Stays slim on purpose. |
 | `src/app.zig` | `App` struct: owns `ProjectManager`, `Compiler`, `TreeView`, status bar, dialog state, and the `Module.Registry`. `App.renderFrame()` is the single function the test runner can call to drive the real UI. |
 | `src/module.zig` | `Module` and `Registry` (issue #22). Modules expose a togglable panel; the Registry renders the View menu and dispatches `render_panel(*App)` for every open module. Each module's `is_open` points into App state so the menu toggle and the panel's `popen` flag are the same memory. |
-| `src/modules/` | One file per panel. `compiler_output.zig` is the first; add more by writing a `makeModule(*App)` factory and appending to `App.modules`. |
+| `src/modules/` | One file per togglable panel. Each exports `makeModule(*App) module.Module` and gets appended to `App.modules` in `App.init`. Current: `compiler_output`, `project_settings`, `project_tree`. |
+| `src/dialogs/` | Modal popups — transient, not part of the Registry because they're not togglable panels. Each exports `pub fn render(*App) void` called once per frame from `App.renderFrame`. Current: `new_scene`, `dpi_warning`. |
 | `src/project.zig` | `ProjectConfig` (mirrors a subset of `labelle-assembler/src/config.zig:ProjectConfig`), `ProjectManager`, `project.labelle` read/write. Each `Project` owns an `ArenaAllocator` so the parsed config strings free uniformly in `deinit`. |
 | `src/compiler.zig` | Wraps `labelle generate/build/run` as a child process. `syncProjectFiles` calls `ProjectManager.saveProject`. `buildOrRun` spawns; `pollBuild` waits and captures stdout/stderr. |
 | `src/tree_view.zig` | Project tree widget. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,15 @@ zig build smoke     # end-to-end against the real `labelle` launcher — env-dep
 
 | File | Role |
 |------|------|
-| `src/main.zig` | GLFW + zgui main loop; menu and dialog handling. State lives inline; Phase 2 of the TE work will refactor this into an `App` struct. |
+| `src/main.zig` | GLFW init, window + GL context, font + DPI setup, frame loop. Delegates per-frame UI to `App.renderFrame()`. Stays slim on purpose. |
+| `src/app.zig` | `App` struct: owns `ProjectManager`, `Compiler`, `TreeView`, status bar, dialog state, and the `Module.Registry`. `App.renderFrame()` is the single function the test runner can call to drive the real UI. |
+| `src/module.zig` | `Module` and `Registry` (issue #22). Modules expose a togglable panel; the Registry renders the View menu and dispatches `render_panel(*App)` for every open module. Each module's `is_open` points into App state so the menu toggle and the panel's `popen` flag are the same memory. |
+| `src/modules/` | One file per panel. `compiler_output.zig` is the first; add more by writing a `makeModule(*App)` factory and appending to `App.modules`. |
 | `src/project.zig` | `ProjectConfig` (mirrors a subset of `labelle-assembler/src/config.zig:ProjectConfig`), `ProjectManager`, `project.labelle` read/write. Each `Project` owns an `ArenaAllocator` so the parsed config strings free uniformly in `deinit`. |
 | `src/compiler.zig` | Wraps `labelle generate/build/run` as a child process. `syncProjectFiles` calls `ProjectManager.saveProject`. `buildOrRun` spawns; `pollBuild` waits and captures stdout/stderr. |
 | `src/tree_view.zig` | Project tree widget. |
 | `src/tests.zig` | zspec test root; covers `ProjectConfig`, `ProjectManager`, scaffold folders, save/load round-trip, `Compiler` state. |
-| `src/gui_tests.zig` | UI test runner using zgui's bundled ImGui Test Engine (`with_te=true`). See "TE quirks" below. |
+| `src/gui_tests.zig` | UI test runner using zgui's bundled ImGui Test Engine (`with_te=true`). Constructs an `App` against a hidden window and drives it with `TestContext.menuAction(...)`. See "TE quirks" below. |
 | `src/smoke.zig` | End-to-end smoke harness — temp dir, `ProjectManager.saveProject`, `Compiler.build`, asserts `.labelle/<target>/` appears. |
 
 ## Key invariants
@@ -35,6 +38,13 @@ zig build smoke     # end-to-end against the real `labelle` launcher — env-dep
 1. **`project.labelle` must pin all four versions** — `core_version`, `engine_version`, `gfx_version`, `assembler_version`. The launcher's resolver falls back to its own version for missing fields (`labelle-cli/src/cli/cache.zig:29`: `cfg.assembler_version orelse cfg.labelle_version`), which 404s when CLI and assembler aren't lockstep. Defaults in `ProjectConfig` track `labelle-cli/versions.zon` and the CLI's own assembler pin.
 2. **Project = directory.** `Project.dir` holds the project directory; `<dir>/project.labelle` is the editable file. Open / Save dialogs use `nfd.openFolderDialog`, not file dialogs.
 3. **Don't reintroduce `build.zig` template generation.** The assembler owns that. If you find yourself writing build files from the gui, you're going the wrong direction.
+
+## Adding a new module
+
+1. Create `src/modules/<name>.zig` with `pub fn makeModule(app: *App) module.Module`. Return `.is_open = &app.<field>` (state lives in `App`, not the module file) and `.render_panel = render` where `render(*App)` does its own `zgui.begin`/`end`.
+2. Add a `bool` field to `App` for the panel's open state. Toggle it from menu actions or other code paths as needed.
+3. Grow `App.modules: [N]Module` in `app.zig` and assign the new module's slot in `App.init`.
+4. The View menu auto-builds from the Registry. The panel renders only when `is_open.*` is true.
 
 ## TE (Test Engine) quirks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,15 @@ zig build smoke     # end-to-end against the real `labelle` launcher — env-dep
 | `src/gui_tests.zig` | UI test runner using zgui's bundled ImGui Test Engine (`with_te=true`). Constructs an `App` against a hidden window and drives it with `TestContext.menuAction(...)`. See "TE quirks" below. |
 | `src/smoke.zig` | End-to-end smoke harness — temp dir, `ProjectManager.saveProject`, `Compiler.build`, asserts `.labelle/<target>/` appears. |
 
+## Reference example project
+
+`../flying-platform-labelle/` is the canonical real-world project the
+toolkit is currently developed against. Look there for current `project.labelle`,
+`scenes/*.jsonc`, prefab/component shapes, and resource manifests rather
+than guessing or grabbing from older examples in this tree. The
+assembler's `examples/` directory has stripped-down minimal projects for
+each backend (`raylib`, `sokol`, etc.) that are also kept current.
+
 ## Key invariants
 
 1. **`project.labelle` must pin all four versions** — `core_version`, `engine_version`, `gfx_version`, `assembler_version`. The launcher's resolver falls back to its own version for missing fields (`labelle-cli/src/cli/cache.zig:29`: `cfg.assembler_version orelse cfg.labelle_version`), which 404s when CLI and assembler aren't lockstep. Defaults in `ProjectConfig` track `labelle-cli/versions.zon` and the CLI's own assembler pin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,28 @@ than guessing or grabbing from older examples in this tree. The
 assembler's `examples/` directory has stripped-down minimal projects for
 each backend (`raylib`, `sokol`, etc.) that are also kept current.
 
+## project.labelle pass-through
+
+External projects (e.g. `../flying-platform-labelle/`) carry top-level
+fields the gui doesn't model — `states`, `layers`, `plugins`, `gui`,
+`ios`, `android`, `labelle_version`, `hidden`. On `loadProject`,
+`extractUnmodeledFields` (a small ZON top-level scanner in `project.zig`)
+captures the verbatim source text for each of those into `Project.extras`.
+`renderProjectLabelle` re-emits them inside the closing `}` after the
+managed fields, so external projects round-trip without data loss.
+
+Known limitations of the pass-through:
+
+- **Detached top-level comments** (those between fields, not attached
+  to a particular value) are not preserved — the scanner walks
+  field-by-field.
+- **Multi-line strings (`\\...`)** and **`'...'` character literals**
+  aren't handled because the assembler's schema doesn't use them. If
+  either appears in a future schema, grow `scanValue` in `project.zig`.
+- **Field order shifts** — managed fields are re-emitted first, then
+  extras. Functionally equivalent but the file isn't byte-identical
+  to its loaded form.
+
 ## Key invariants
 
 1. **`project.labelle` must pin all four versions** — `core_version`, `engine_version`, `gfx_version`, `assembler_version`. The launcher's resolver falls back to its own version for missing fields (`labelle-cli/src/cli/cache.zig:29`: `cfg.assembler_version orelse cfg.labelle_version`), which 404s when CLI and assembler aren't lockstep. Defaults in `ProjectConfig` track `labelle-cli/versions.zon` and the CLI's own assembler pin.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,17 @@ Version pins (`core_version`, `engine_version`, `gfx_version`, `assembler_versio
 
 ```
 src/
-  main.zig         # GLFW + zgui main loop, menu/dialog handling
-  project.zig      # ProjectConfig, ProjectManager, project.labelle ZON I/O
-  compiler.zig    # Launches `labelle generate/build/run` and polls the child
-  tree_view.zig    # Project tree view widget
-  config.zig       # UI constants
-  icons.zig        # FontAwesome icon codepoints
-  tests.zig        # zspec test entry point
-  gui_tests.zig    # ImGui Test Engine harness (gui-test target)
-  smoke.zig        # End-to-end launcher integration check (smoke target)
+  main.zig                       # GLFW + zgui setup, swaps frame loop into App.renderFrame
+  app.zig                        # App struct: per-instance state + per-frame rendering
+  module.zig                     # Module + Registry — togglable panels and View menu (issue #22)
+  modules/
+    compiler_output.zig          # Bottom-dock compiler output panel
+  project.zig                    # ProjectConfig, ProjectManager, project.labelle ZON I/O
+  compiler.zig                   # Launches `labelle generate/build/run` and polls the child
+  tree_view.zig                  # Project tree view widget
+  config.zig                     # UI constants
+  icons.zig                      # FontAwesome icon codepoints
+  tests.zig                      # zspec test entry point
+  gui_tests.zig                  # ImGui Test Engine harness (gui-test target)
+  smoke.zig                      # End-to-end launcher integration check (smoke target)
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ src/
   modules/
     compiler_output.zig          # Bottom-dock compiler output panel
     project_settings.zig         # Edit ProjectConfig fields and persist via ProjectManager
+    project_tree.zig             # Project sidebar (file tree)
+  dialogs/
+    new_scene.zig                # New Scene modal + scene-file writer
+    dpi_warning.zig              # One-shot DPI-changed warning modal
   project.zig                    # ProjectConfig, ProjectManager, project.labelle ZON I/O
   compiler.zig                   # Launches `labelle generate/build/run` and polls the child
   tree_view.zig                  # Project tree view widget

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ src/
     compiler_output.zig          # Bottom-dock compiler output panel
     project_settings.zig         # Edit ProjectConfig fields and persist via ProjectManager
     project_tree.zig             # Project sidebar (file tree)
+    resources.zig                # Edit `resources` block (sprite atlases)
   dialogs/
     new_scene.zig                # New Scene modal + scene-file writer
     dpi_warning.zig              # One-shot DPI-changed warning modal

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ src/
   module.zig                     # Module + Registry — togglable panels and View menu (issue #22)
   modules/
     compiler_output.zig          # Bottom-dock compiler output panel
+    project_settings.zig         # Edit ProjectConfig fields and persist via ProjectManager
   project.zig                    # ProjectConfig, ProjectManager, project.labelle ZON I/O
   compiler.zig                   # Launches `labelle generate/build/run` and polls the child
   tree_view.zig                  # Project tree view widget

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# labelle-gui
+
+Desktop GUI for authoring [labelle-toolkit](https://github.com/labelle-toolkit) game projects.
+
+Edits `project.labelle`, scaffolds the project tree, and drives the `labelle` CLI launcher to generate / build / run the project.
+
+## Requirements
+
+- Zig 0.15.2
+- The [`labelle` CLI](https://labelle.games) on PATH (install via `curl -fsSL https://labelle.games/install.sh | bash`)
+
+## Build
+
+```bash
+zig build         # build the gui binary into zig-out/bin/labelle-gui
+zig build run     # build and launch the gui
+```
+
+## Tests
+
+```bash
+zig build test       # zspec unit + filesystem tests (hermetic, ~42 tests)
+zig build gui-test   # ImGui Test Engine UI tests (runs in a hidden GLFW window)
+zig build smoke      # end-to-end integration check against the real `labelle` launcher
+```
+
+### `zig build smoke`
+
+Drives the gui's own `project.zig` and `compiler.zig` against the installed `labelle` launcher: writes a temp project, runs `labelle generate` and `labelle build`, asserts `.labelle/<backend>_<platform>/` appears and the build succeeds. **Not** part of `zig build test` because it requires `labelle` on PATH and either a populated `~/.labelle/packages/` cache or network access to fetch packages.
+
+Run it whenever changes touch `src/project.zig` (project.labelle schema) or `src/compiler.zig` (launcher invocation).
+
+## How it talks to the rest of the toolkit
+
+The gui doesn't generate `build.zig`, `build.zig.zon`, or `main.zig` itself. It writes a `project.labelle` (ZON, schema-compatible with `labelle-assembler`'s `ProjectConfig`) and shells out to the `labelle` launcher, which prims the package cache, resolves the right `labelle-assembler` binary, runs codegen, and runs `zig build`.
+
+Version pins (`core_version`, `engine_version`, `gfx_version`, `assembler_version`) are required fields on the project file — without `assembler_version` the launcher falls back to its own version when fetching the assembler binary, which 404s if the CLI and assembler aren't in lockstep. Defaults in `src/project.zig` match `labelle-cli/versions.zon` + the CLI's `build.zig.zon` assembler pin.
+
+## Project layout
+
+```
+src/
+  main.zig         # GLFW + zgui main loop, menu/dialog handling
+  project.zig      # ProjectConfig, ProjectManager, project.labelle ZON I/O
+  compiler.zig    # Launches `labelle generate/build/run` and polls the child
+  tree_view.zig    # Project tree view widget
+  config.zig       # UI constants
+  icons.zig        # FontAwesome icon codepoints
+  tests.zig        # zspec test entry point
+  gui_tests.zig    # ImGui Test Engine harness (gui-test target)
+  smoke.zig        # End-to-end launcher integration check (smoke target)
+```

--- a/build.zig
+++ b/build.zig
@@ -80,4 +80,54 @@ pub fn build(b: *std.Build) void {
     const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&run_tests.step);
+
+    // UI test runner ------------------------------------------------------
+    //
+    // A separate exe linking a second zgui instance built with the bundled
+    // Dear ImGui Test Engine (`with_te = true`). It opens a hidden GLFW
+    // window, drives the imgui frame loop, and runs registered TE tests to
+    // completion. Not part of the default install — only `zig build gui-test`
+    // builds and runs it, so the production exe stays free of TE overhead.
+    const zgui_te = b.dependency("zgui", .{
+        .target = target,
+        .optimize = optimize,
+        .backend = .glfw_opengl3,
+        .with_te = true,
+    });
+
+    const gui_tests_exe = b.addExecutable(.{
+        .name = "gui-tests",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/gui_tests.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    gui_tests_exe.root_module.addImport("zglfw", zglfw.module("root"));
+    gui_tests_exe.linkLibrary(zglfw.artifact("glfw"));
+    gui_tests_exe.root_module.addImport("zopengl", zopengl.module("root"));
+    gui_tests_exe.root_module.addImport("zgui", zgui_te.module("root"));
+    gui_tests_exe.linkLibrary(zgui_te.artifact("imgui"));
+
+    const run_gui_tests = b.addRunArtifact(gui_tests_exe);
+    const gui_test_step = b.step("gui-test", "Run the UI test runner");
+    gui_test_step.dependOn(&run_gui_tests.step);
+
+    // End-to-end smoke check ----------------------------------------------
+    //
+    // Drives the gui's project writer + Compiler.launcherGenerate against
+    // the real `labelle` launcher to confirm the chain works on this
+    // machine. Not part of `zig build test` because it requires `labelle`
+    // on PATH and a populated package cache (or at least network).
+    const smoke_exe = b.addExecutable(.{
+        .name = "gui-smoke",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/smoke.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const run_smoke = b.addRunArtifact(smoke_exe);
+    const smoke_step = b.step("smoke", "End-to-end smoke check against `labelle` launcher");
+    smoke_step.dependOn(&run_smoke.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,24 +4,24 @@
     .fingerprint = 0x3fd05a33857eec15,
     .dependencies = .{
         .zgui = .{
-            .url = "https://github.com/zig-gamedev/zgui/archive/refs/heads/main.tar.gz",
-            .hash = "zgui-0.6.0-dev--L6sZBHybQAZLl719GjSlogZC3MhuGRf4wI48tjbnW3z",
+            .url = "https://github.com/zig-gamedev/zgui/archive/f1c6c5bab.tar.gz",
+            .hash = "zgui-0.6.0-dev--L6sZCLzbQBM1I4oIbtd5_ClKk9rNExPOCYkCMP_TZad",
         },
         .zglfw = .{
-            .url = "https://github.com/zig-gamedev/zglfw/archive/refs/heads/main.tar.gz",
-            .hash = "zglfw-0.10.0-dev-zgVDNHO2IQDy_fSdwY5U4z42rHUuKgt7T9f-qmQ3FnuL",
+            .url = "https://github.com/zig-gamedev/zglfw/archive/0dd29d807.tar.gz",
+            .hash = "zglfw-0.10.0-dev-zgVDNIG4IQBWN_sfMD-xfC9bJS2hbBN2W7jNlDLovcdC",
         },
         .zopengl = .{
-            .url = "https://github.com/zig-gamedev/zopengl/archive/refs/heads/main.tar.gz",
-            .hash = "zopengl-0.6.0-dev-5-tnz6-mCgD65lY7NrNAU4haXCpVHUpTUEznTwfmBB96",
+            .url = "https://github.com/zig-gamedev/zopengl/archive/db9d615c7.tar.gz",
+            .hash = "zopengl-0.6.0-dev-5-tnz36mDgBuU9pDfag6_B-qCWOJQc5GXiXuZ6z41zQM",
         },
         .nfd = .{
             .url = "https://github.com/fabioarnold/nfd-zig/archive/refs/heads/master.tar.gz",
-            .hash = "nfdzig-0.1.0-11fxvN6IBgD5rvvfjrw1wPqibMsbUJ-h2ZcGR6FOEvrm",
+            .hash = "nfd-0.1.0-y82kbsSLBgBgSEauGFsHxH7RmcL4AEOqZEqOvA8-NEFq",
         },
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
-            .hash = "zspec-0.3.0-jaKLbbqZAgAB-MBfy6M3HKB3jSTQ-TsNW9OxpLhLlav5",
+            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
         },
     },
     .paths = .{

--- a/src/app.zig
+++ b/src/app.zig
@@ -95,10 +95,13 @@ pub const App = struct {
         self.status_timer = config.ui.status_message_duration;
     }
 
-    /// One UI frame. Caller is responsible for `backend.newFrame`/`backend.draw`
+    /// One UI frame. `dt_seconds` is the wall-clock time since the last
+    /// frame, used to decrement transient timers (status messages, etc.)
+    /// so they last a consistent duration regardless of frame rate.
+    /// Caller is responsible for `backend.newFrame`/`backend.draw`
     /// around this; the test harness needs that boundary to inject events.
-    pub fn renderFrame(self: *Self) void {
-        if (self.status_timer > 0) self.status_timer -= 1.0 / 60.0;
+    pub fn renderFrame(self: *Self, dt_seconds: f32) void {
+        if (self.status_timer > 0) self.status_timer -= dt_seconds;
 
         self.renderMenuBar();
         self.pollCompiler();

--- a/src/app.zig
+++ b/src/app.zig
@@ -18,6 +18,7 @@ const module = @import("module.zig");
 const compiler_output = @import("modules/compiler_output.zig");
 const project_settings_mod = @import("modules/project_settings.zig");
 const project_tree_mod = @import("modules/project_tree.zig");
+const resources_mod = @import("modules/resources.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
 const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
 
@@ -43,6 +44,9 @@ pub const App = struct {
     show_project_settings: bool = false,
     project_settings: project_settings_mod.ProjectSettings = .{},
 
+    show_resources: bool = false,
+    resources_editor: resources_mod.ResourcesEditor = .{},
+
     show_project_tree: bool = true,
 
     show_new_scene_dialog: bool = false,
@@ -51,7 +55,7 @@ pub const App = struct {
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [3]module.Module = undefined,
+    modules: [4]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -71,6 +75,7 @@ pub const App = struct {
         app.modules[0] = project_tree_mod.makeModule(app);
         app.modules[1] = compiler_output.makeModule(app);
         app.modules[2] = project_settings_mod.makeModule(app);
+        app.modules[3] = resources_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
 
         return app;

--- a/src/app.zig
+++ b/src/app.zig
@@ -1,0 +1,437 @@
+//! `App` holds the GUI's per-instance state and drives one frame of UI.
+//!
+//! `main.zig` and `gui_tests.zig` both construct an `App`: the former in a
+//! visible GLFW window with a real event loop, the latter in a hidden one
+//! driven by the ImGui Test Engine. Anything that should be reachable from
+//! tests (project state, compiler state, panel toggles) lives here.
+
+const std = @import("std");
+const zglfw = @import("zglfw");
+const zgui = @import("zgui");
+const nfd = @import("nfd");
+
+const project = @import("project.zig");
+const tree_view = @import("tree_view.zig");
+const compiler = @import("compiler.zig");
+const config = @import("config.zig");
+const module = @import("module.zig");
+const compiler_output = @import("modules/compiler_output.zig");
+
+const STATUS_BUF_LEN = 256;
+const SCENE_NAME_BUF_LEN = 128;
+
+pub const App = struct {
+    allocator: std.mem.Allocator,
+    window: *zglfw.Window,
+
+    project_manager: project.ProjectManager,
+    tree_view: tree_view.TreeView,
+    compiler: compiler.Compiler,
+
+    status_message: [STATUS_BUF_LEN]u8 = [_]u8{0} ** STATUS_BUF_LEN,
+    status_timer: f32 = 0,
+
+    /// Toggled by the View menu, the Build menu, and the Compiler Output
+    /// module. The module reads this via its `Module.is_open` pointer.
+    show_compiler_output: bool = false,
+    compiler_output_scroll_to_bottom: bool = false,
+
+    show_new_scene_dialog: bool = false,
+    new_scene_name: [SCENE_NAME_BUF_LEN:0]u8 = [_:0]u8{0} ** SCENE_NAME_BUF_LEN,
+    show_dpi_warning: bool = false,
+
+    /// Fixed-size storage for registered modules. Grow the array literal
+    /// when adding modules; Zig will tell you if it overflows.
+    modules: [1]module.Module = undefined,
+    registry: module.Registry = .{ .modules = &.{} },
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !*Self {
+        const app = try allocator.create(Self);
+        errdefer allocator.destroy(app);
+
+        app.* = .{
+            .allocator = allocator,
+            .window = window,
+            .project_manager = project.ProjectManager.init(allocator),
+            .tree_view = tree_view.TreeView.init(allocator),
+            .compiler = compiler.Compiler.init(allocator),
+        };
+
+        app.modules[0] = compiler_output.makeModule(app);
+        app.registry = .{ .modules = &app.modules };
+
+        return app;
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.project_manager.deinit();
+        self.tree_view.deinit();
+        self.compiler.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn setStatus(self: *Self, message: []const u8) void {
+        @memset(&self.status_message, 0);
+        const n = @min(message.len, self.status_message.len - 1);
+        @memcpy(self.status_message[0..n], message[0..n]);
+        self.status_timer = config.ui.status_message_duration;
+    }
+
+    /// One UI frame. Caller is responsible for `backend.newFrame`/`backend.draw`
+    /// around this; the test harness needs that boundary to inject events.
+    pub fn renderFrame(self: *Self) void {
+        if (self.status_timer > 0) self.status_timer -= 1.0 / 60.0;
+
+        self.renderMenuBar();
+        self.pollCompiler();
+        self.renderProjectSidebar();
+        self.renderMainContent();
+        self.registry.renderAllPanels(self);
+        self.renderStatusBar();
+        self.renderNewSceneDialog();
+        self.renderDpiWarning();
+    }
+
+    // ─── Menu bar ───────────────────────────────────────────────────────
+
+    fn renderMenuBar(self: *Self) void {
+        if (!zgui.beginMainMenuBar()) return;
+        defer zgui.endMainMenuBar();
+
+        self.renderFileMenu();
+        self.renderBuildMenu();
+        self.registry.renderViewMenu();
+        self.renderHelpMenu();
+    }
+
+    fn renderFileMenu(self: *Self) void {
+        if (!zgui.beginMenu("File", true)) return;
+        defer zgui.endMenu();
+
+        if (zgui.menuItem("New Project...", .{})) self.pickFolderAndCreateProject();
+        if (zgui.menuItem("Open Project...", .{})) self.pickFolderAndOpenProject();
+        zgui.separator();
+        if (zgui.menuItem("New Scene...", .{ .enabled = self.project_manager.current_project != null })) {
+            self.show_new_scene_dialog = true;
+            @memset(&self.new_scene_name, 0);
+        }
+        zgui.separator();
+        if (zgui.menuItem("Save", .{})) self.saveProject();
+        if (zgui.menuItem("Save As...", .{})) self.saveProjectAs();
+        zgui.separator();
+        if (zgui.menuItem("Close Project", .{})) {
+            self.project_manager.closeProject();
+            self.setStatus("Project closed");
+        }
+        zgui.separator();
+        if (zgui.menuItem("Exit", .{})) self.window.setShouldClose(true);
+    }
+
+    fn renderBuildMenu(self: *Self) void {
+        if (!zgui.beginMenu("Build", self.project_manager.current_project != null)) return;
+        defer zgui.endMenu();
+
+        const can_build = self.compiler.isIdle();
+        if (zgui.menuItem("Sync Project Files", .{ .enabled = can_build })) {
+            if (self.compiler.syncProjectFiles(&self.project_manager)) {
+                self.setStatus("Project files synced!");
+                self.tree_view.refresh();
+            } else |err| {
+                std.log.err("Error syncing project files: {}", .{err});
+                self.setStatus("Error syncing project files!");
+            }
+        }
+        zgui.separator();
+        if (zgui.menuItem("Build", .{ .enabled = can_build })) self.startBuildOrRun(.build);
+        if (zgui.menuItem("Run", .{ .enabled = can_build })) self.startBuildOrRun(.run);
+    }
+
+    fn renderHelpMenu(_: *Self) void {
+        if (!zgui.beginMenu("Help", true)) return;
+        defer zgui.endMenu();
+        if (zgui.menuItem("About", .{})) {}
+    }
+
+    // ─── Menu actions ───────────────────────────────────────────────────
+
+    fn pickFolderAndCreateProject(self: *Self) void {
+        const maybe = nfd.openFolderDialog(null) catch {
+            self.setStatus("Error opening folder dialog!");
+            return;
+        };
+        const folder = maybe orelse return;
+        defer nfd.freePath(folder);
+
+        const name = std.fs.path.basename(folder);
+        self.project_manager.newProject(name) catch |err| {
+            std.log.err("Error creating project: {}", .{err});
+            self.setStatus("Error creating project!");
+            return;
+        };
+        self.project_manager.saveProject(folder) catch |err| {
+            std.log.err("Error saving project: {}", .{err});
+            self.setStatus("Error saving project!");
+            return;
+        };
+        self.setStatus("New project created!");
+        self.tree_view.refresh();
+    }
+
+    fn pickFolderAndOpenProject(self: *Self) void {
+        const maybe = nfd.openFolderDialog(null) catch {
+            self.setStatus("Error opening folder dialog!");
+            return;
+        };
+        const folder = maybe orelse return;
+        defer nfd.freePath(folder);
+
+        self.project_manager.loadProject(folder) catch |err| {
+            std.log.err("Error loading project: {}", .{err});
+            self.setStatus("Error loading project!");
+            return;
+        };
+        self.setStatus("Project loaded!");
+        self.tree_view.refresh();
+    }
+
+    fn saveProject(self: *Self) void {
+        const proj = self.project_manager.current_project orelse return;
+        if (proj.dir) |dir| {
+            self.project_manager.saveProject(dir) catch |err| {
+                std.log.err("Save error: {}", .{err});
+                self.setStatus("Error saving project!");
+                return;
+            };
+            self.setStatus("Project saved!");
+        } else {
+            self.saveProjectAs();
+        }
+    }
+
+    fn saveProjectAs(self: *Self) void {
+        if (self.project_manager.current_project == null) return;
+        const maybe = nfd.openFolderDialog(null) catch {
+            self.setStatus("Error opening save dialog!");
+            return;
+        };
+        const folder = maybe orelse return;
+        defer nfd.freePath(folder);
+
+        self.project_manager.saveProject(folder) catch |err| {
+            std.log.err("Save error: {}", .{err});
+            self.setStatus("Error saving project!");
+            return;
+        };
+        self.setStatus("Project saved!");
+    }
+
+    const BuildKind = enum { build, run };
+    fn startBuildOrRun(self: *Self, kind: BuildKind) void {
+        const proj = self.project_manager.current_project orelse return;
+        self.compiler.syncProjectFiles(&self.project_manager) catch |err| {
+            std.log.err("Error syncing project files: {}", .{err});
+            self.setStatus("Error syncing project files!");
+            return;
+        };
+        const spawn_result = switch (kind) {
+            .build => self.compiler.build(proj),
+            .run => self.compiler.run(proj),
+        };
+        spawn_result catch |err| {
+            std.log.err("Error starting {s}: {}", .{ @tagName(kind), err });
+            self.setStatus("Error starting build!");
+            return;
+        };
+        self.setStatus(if (kind == .run) "Running game..." else "Building...");
+        self.show_compiler_output = true;
+        self.compiler_output_scroll_to_bottom = true;
+    }
+
+    fn pollCompiler(self: *Self) void {
+        if (self.compiler.pollBuild()) |result| {
+            self.setStatus(if (result.success) "Build successful!" else "Build failed!");
+            self.compiler_output_scroll_to_bottom = true;
+        }
+    }
+
+    // ─── Panels ─────────────────────────────────────────────────────────
+
+    fn renderProjectSidebar(self: *Self) void {
+        const viewport = zgui.getMainViewport();
+        const work_pos = viewport.getWorkPos();
+        const work_size = viewport.getWorkSize();
+        zgui.setNextWindowPos(.{ .x = work_pos[0], .y = work_pos[1] });
+        zgui.setNextWindowSize(.{ .w = config.ui.sidebar_width, .h = work_size[1] - config.ui.status_bar_height });
+
+        if (zgui.begin("Project", .{ .flags = .{ .no_resize = true, .no_move = true, .no_collapse = true } })) {
+            if (self.project_manager.current_project) |proj| {
+                _ = self.tree_view.render(proj.getProjectDir());
+            } else {
+                zgui.textDisabled("No project open", .{});
+            }
+        }
+        zgui.end();
+    }
+
+    fn renderMainContent(self: *Self) void {
+        const viewport = zgui.getMainViewport();
+        const work_pos = viewport.getWorkPos();
+        const work_size = viewport.getWorkSize();
+        zgui.setNextWindowPos(.{ .x = work_pos[0] + config.ui.sidebar_width, .y = work_pos[1] });
+        zgui.setNextWindowSize(.{ .w = work_size[0] - config.ui.sidebar_width, .h = work_size[1] - config.ui.status_bar_height });
+
+        if (!zgui.begin("##main", .{ .flags = .{
+            .no_title_bar = true,
+            .no_resize = true,
+            .no_move = true,
+            .no_collapse = true,
+            .menu_bar = false,
+        } })) {
+            zgui.end();
+            return;
+        }
+        defer zgui.end();
+
+        if (self.project_manager.current_project) |proj| {
+            zgui.text("Project: {s}", .{proj.config.name});
+            if (proj.is_dirty) {
+                zgui.sameLine(.{});
+                zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
+            }
+            zgui.separator();
+            if (self.tree_view.getSelectedPath()) |selected| {
+                zgui.text("Selected: {s}", .{std.fs.path.basename(selected)});
+                zgui.separator();
+            }
+            zgui.text("Ready to work!", .{});
+        } else {
+            zgui.text("Welcome to Labelle!", .{});
+            zgui.spacing();
+            zgui.text("Create a new project or open an existing one.", .{});
+            zgui.spacing();
+            if (zgui.button("New Project...", .{ .w = 150 })) self.pickFolderAndCreateProject();
+            if (zgui.button("Open Project...", .{ .w = 150 })) self.pickFolderAndOpenProject();
+        }
+    }
+
+    fn renderStatusBar(self: *Self) void {
+        const viewport = zgui.getMainViewport();
+        const work_pos = viewport.getWorkPos();
+        const work_size = viewport.getWorkSize();
+        zgui.setNextWindowPos(.{ .x = work_pos[0], .y = work_pos[1] + work_size[1] - config.ui.status_bar_height });
+        zgui.setNextWindowSize(.{ .w = work_size[0], .h = config.ui.status_bar_height });
+
+        if (zgui.begin("##statusbar", .{ .flags = .{
+            .no_title_bar = true,
+            .no_resize = true,
+            .no_move = true,
+            .no_collapse = true,
+            .no_scrollbar = true,
+        } })) {
+            if (self.status_timer > 0) {
+                zgui.text("{s}", .{std.mem.sliceTo(&self.status_message, 0)});
+            } else if (self.project_manager.current_project) |proj| {
+                if (proj.dir) |dir| {
+                    zgui.text("{s}", .{dir});
+                } else {
+                    zgui.text("Unsaved project", .{});
+                }
+            } else {
+                zgui.text("No project open", .{});
+            }
+        }
+        zgui.end();
+    }
+
+    fn renderNewSceneDialog(self: *Self) void {
+        if (self.show_new_scene_dialog) zgui.openPopup("New Scene", .{});
+        if (!zgui.beginPopupModal("New Scene", .{ .popen = &self.show_new_scene_dialog, .flags = .{ .always_auto_resize = true } })) return;
+        defer zgui.endPopup();
+
+        zgui.text("Enter scene name:", .{});
+        zgui.spacing();
+        if (zgui.isWindowAppearing()) zgui.setKeyboardFocusHere(0);
+
+        const enter_pressed = zgui.inputText("##scene_name", .{
+            .buf = &self.new_scene_name,
+            .flags = .{ .enter_returns_true = true },
+        });
+
+        zgui.spacing();
+        zgui.separator();
+        zgui.spacing();
+
+        if (zgui.button("Create", .{ .w = 120 }) or enter_pressed) {
+            const scene_name = std.mem.sliceTo(&self.new_scene_name, 0);
+            if (scene_name.len > 0) self.createScene(scene_name);
+            zgui.closeCurrentPopup();
+            self.show_new_scene_dialog = false;
+        }
+        zgui.sameLine(.{});
+        if (zgui.button("Cancel", .{ .w = 120 })) {
+            zgui.closeCurrentPopup();
+            self.show_new_scene_dialog = false;
+        }
+    }
+
+    fn createScene(self: *Self, scene_name: []const u8) void {
+        const proj = self.project_manager.current_project orelse return;
+        const proj_dir = proj.getProjectDir() orelse return;
+
+        var path_buf: [512]u8 = undefined;
+        const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.scene", .{
+            proj_dir,
+            project.ProjectFolders.scenes,
+            scene_name,
+        }) catch {
+            self.setStatus("Path too long!");
+            return;
+        };
+
+        const file = std.fs.cwd().createFile(scene_path, .{ .exclusive = true }) catch |err| {
+            self.setStatus(if (err == error.PathAlreadyExists) "Scene already exists!" else "Error creating scene!");
+            return;
+        };
+        defer file.close();
+
+        var content_buf: [512]u8 = undefined;
+        const content = std.fmt.bufPrint(&content_buf,
+            \\# {s}
+            \\# Scene created by Labelle GUI
+            \\
+            \\[scene]
+            \\name = "{s}"
+            \\
+            \\[entities]
+            \\# Define your entities here
+            \\
+        , .{ scene_name, scene_name }) catch {
+            self.setStatus("Error formatting scene content!");
+            return;
+        };
+        file.writeAll(content) catch {
+            self.setStatus("Error writing scene file!");
+            return;
+        };
+        self.setStatus("Scene created!");
+        self.tree_view.refresh();
+    }
+
+    fn renderDpiWarning(self: *Self) void {
+        if (self.show_dpi_warning) zgui.openPopup("Display Scale Changed", .{});
+        if (!zgui.beginPopupModal("Display Scale Changed", .{
+            .popen = &self.show_dpi_warning,
+            .flags = .{ .always_auto_resize = true },
+        })) return;
+        defer zgui.endPopup();
+
+        zgui.text("The display scale has changed.", .{});
+        zgui.text("For best results, please restart the application.", .{});
+        zgui.spacing();
+        zgui.separator();
+        zgui.spacing();
+        if (zgui.button("OK", .{ .w = 120 })) self.show_dpi_warning = false;
+    }
+};

--- a/src/app.zig
+++ b/src/app.zig
@@ -17,6 +17,9 @@ const config = @import("config.zig");
 const module = @import("module.zig");
 const compiler_output = @import("modules/compiler_output.zig");
 const project_settings_mod = @import("modules/project_settings.zig");
+const project_tree_mod = @import("modules/project_tree.zig");
+const new_scene_dialog = @import("dialogs/new_scene.zig");
+const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
 
 const STATUS_BUF_LEN = 256;
 const SCENE_NAME_BUF_LEN = 128;
@@ -40,13 +43,15 @@ pub const App = struct {
     show_project_settings: bool = false,
     project_settings: project_settings_mod.ProjectSettings = .{},
 
+    show_project_tree: bool = true,
+
     show_new_scene_dialog: bool = false,
     new_scene_name: [SCENE_NAME_BUF_LEN:0]u8 = [_:0]u8{0} ** SCENE_NAME_BUF_LEN,
     show_dpi_warning: bool = false,
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [2]module.Module = undefined,
+    modules: [3]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -63,8 +68,9 @@ pub const App = struct {
             .compiler = compiler.Compiler.init(allocator),
         };
 
-        app.modules[0] = compiler_output.makeModule(app);
-        app.modules[1] = project_settings_mod.makeModule(app);
+        app.modules[0] = project_tree_mod.makeModule(app);
+        app.modules[1] = compiler_output.makeModule(app);
+        app.modules[2] = project_settings_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
 
         return app;
@@ -91,12 +97,11 @@ pub const App = struct {
 
         self.renderMenuBar();
         self.pollCompiler();
-        self.renderProjectSidebar();
         self.renderMainContent();
         self.registry.renderAllPanels(self);
         self.renderStatusBar();
-        self.renderNewSceneDialog();
-        self.renderDpiWarning();
+        new_scene_dialog.render(self);
+        dpi_warning_dialog.render(self);
     }
 
     // ─── Menu bar ───────────────────────────────────────────────────────
@@ -263,23 +268,6 @@ pub const App = struct {
 
     // ─── Panels ─────────────────────────────────────────────────────────
 
-    fn renderProjectSidebar(self: *Self) void {
-        const viewport = zgui.getMainViewport();
-        const work_pos = viewport.getWorkPos();
-        const work_size = viewport.getWorkSize();
-        zgui.setNextWindowPos(.{ .x = work_pos[0], .y = work_pos[1] });
-        zgui.setNextWindowSize(.{ .w = config.ui.sidebar_width, .h = work_size[1] - config.ui.status_bar_height });
-
-        if (zgui.begin("Project", .{ .flags = .{ .no_resize = true, .no_move = true, .no_collapse = true } })) {
-            if (self.project_manager.current_project) |proj| {
-                _ = self.tree_view.render(proj.getProjectDir());
-            } else {
-                zgui.textDisabled("No project open", .{});
-            }
-        }
-        zgui.end();
-    }
-
     fn renderMainContent(self: *Self) void {
         const viewport = zgui.getMainViewport();
         const work_pos = viewport.getWorkPos();
@@ -350,93 +338,4 @@ pub const App = struct {
         zgui.end();
     }
 
-    fn renderNewSceneDialog(self: *Self) void {
-        if (self.show_new_scene_dialog) zgui.openPopup("New Scene", .{});
-        if (!zgui.beginPopupModal("New Scene", .{ .popen = &self.show_new_scene_dialog, .flags = .{ .always_auto_resize = true } })) return;
-        defer zgui.endPopup();
-
-        zgui.text("Enter scene name:", .{});
-        zgui.spacing();
-        if (zgui.isWindowAppearing()) zgui.setKeyboardFocusHere(0);
-
-        const enter_pressed = zgui.inputText("##scene_name", .{
-            .buf = &self.new_scene_name,
-            .flags = .{ .enter_returns_true = true },
-        });
-
-        zgui.spacing();
-        zgui.separator();
-        zgui.spacing();
-
-        if (zgui.button("Create", .{ .w = 120 }) or enter_pressed) {
-            const scene_name = std.mem.sliceTo(&self.new_scene_name, 0);
-            if (scene_name.len > 0) self.createScene(scene_name);
-            zgui.closeCurrentPopup();
-            self.show_new_scene_dialog = false;
-        }
-        zgui.sameLine(.{});
-        if (zgui.button("Cancel", .{ .w = 120 })) {
-            zgui.closeCurrentPopup();
-            self.show_new_scene_dialog = false;
-        }
-    }
-
-    fn createScene(self: *Self, scene_name: []const u8) void {
-        const proj = self.project_manager.current_project orelse return;
-        const proj_dir = proj.getProjectDir() orelse return;
-
-        var path_buf: [512]u8 = undefined;
-        const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.scene", .{
-            proj_dir,
-            project.ProjectFolders.scenes,
-            scene_name,
-        }) catch {
-            self.setStatus("Path too long!");
-            return;
-        };
-
-        const file = std.fs.cwd().createFile(scene_path, .{ .exclusive = true }) catch |err| {
-            self.setStatus(if (err == error.PathAlreadyExists) "Scene already exists!" else "Error creating scene!");
-            return;
-        };
-        defer file.close();
-
-        var content_buf: [512]u8 = undefined;
-        const content = std.fmt.bufPrint(&content_buf,
-            \\# {s}
-            \\# Scene created by Labelle GUI
-            \\
-            \\[scene]
-            \\name = "{s}"
-            \\
-            \\[entities]
-            \\# Define your entities here
-            \\
-        , .{ scene_name, scene_name }) catch {
-            self.setStatus("Error formatting scene content!");
-            return;
-        };
-        file.writeAll(content) catch {
-            self.setStatus("Error writing scene file!");
-            return;
-        };
-        self.setStatus("Scene created!");
-        self.tree_view.refresh();
-    }
-
-    fn renderDpiWarning(self: *Self) void {
-        if (self.show_dpi_warning) zgui.openPopup("Display Scale Changed", .{});
-        if (!zgui.beginPopupModal("Display Scale Changed", .{
-            .popen = &self.show_dpi_warning,
-            .flags = .{ .always_auto_resize = true },
-        })) return;
-        defer zgui.endPopup();
-
-        zgui.text("The display scale has changed.", .{});
-        zgui.text("For best results, please restart the application.", .{});
-        zgui.spacing();
-        zgui.separator();
-        zgui.spacing();
-        if (zgui.button("OK", .{ .w = 120 })) self.show_dpi_warning = false;
-    }
 };

--- a/src/app.zig
+++ b/src/app.zig
@@ -16,6 +16,7 @@ const compiler = @import("compiler.zig");
 const config = @import("config.zig");
 const module = @import("module.zig");
 const compiler_output = @import("modules/compiler_output.zig");
+const project_settings_mod = @import("modules/project_settings.zig");
 
 const STATUS_BUF_LEN = 256;
 const SCENE_NAME_BUF_LEN = 128;
@@ -36,13 +37,16 @@ pub const App = struct {
     show_compiler_output: bool = false,
     compiler_output_scroll_to_bottom: bool = false,
 
+    show_project_settings: bool = false,
+    project_settings: project_settings_mod.ProjectSettings = .{},
+
     show_new_scene_dialog: bool = false,
     new_scene_name: [SCENE_NAME_BUF_LEN:0]u8 = [_:0]u8{0} ** SCENE_NAME_BUF_LEN,
     show_dpi_warning: bool = false,
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [1]module.Module = undefined,
+    modules: [2]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -60,6 +64,7 @@ pub const App = struct {
         };
 
         app.modules[0] = compiler_output.makeModule(app);
+        app.modules[1] = project_settings_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
 
         return app;

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -5,8 +5,8 @@ pub const CompilerError = error{
     NoProjectOpen,
     NoProjectPath,
     InvalidProjectPath,
-    FailedToCreateBuildFiles,
-    FailedToRunBuild,
+    LauncherNotFound,
+    LauncherFailed,
     CompilationFailed,
     OutOfMemory,
 } || std.fs.File.OpenError || std.fs.File.WriteError;
@@ -31,6 +31,21 @@ pub const CompilerState = enum {
     success,
 };
 
+/// Drives the `labelle` CLI launcher to generate/build/run a project.
+///
+/// We invoke the launcher rather than the bare `labelle-assembler` binary
+/// because the assembler's `generate` step depends on a populated package
+/// cache at `~/.labelle/packages/<name>/<version>/` and on the right
+/// assembler binary being resolved at `~/.labelle/assembler/<version>/`.
+/// The launcher is what wires those layers up — see
+/// `labelle-cli/src/cli/cache.zig` for the resolution logic. Calling the
+/// bare assembler from here fails on any machine that hasn't already run
+/// the launcher to prime the cache, which is unworkable as a default flow.
+///
+/// Versions are pinned in `project.labelle` (set by `ProjectConfig`'s
+/// defaults). The launcher reads them via `assembler_version`,
+/// `core_version`, `engine_version`, `gfx_version` and fetches matching
+/// artifacts on demand.
 pub const Compiler = struct {
     allocator: std.mem.Allocator,
     state: CompilerState,
@@ -49,425 +64,114 @@ pub const Compiler = struct {
     }
 
     pub fn deinit(self: *Self) void {
-        if (self.last_result) |*result| {
-            result.deinit(self.allocator);
-        }
+        if (self.last_result) |*result| result.deinit(self.allocator);
         if (self.build_process) |*proc| {
             _ = proc.kill() catch {};
         }
     }
 
-    /// Generate build.zig for the project (only if it doesn't exist)
-    pub fn generateBuildZig(self: *Self, proj: *const project.Project) !void {
+    /// Ensure the project on disk reflects the in-memory config: writes
+    /// `project.labelle` and creates the scaffold folders. Idempotent.
+    pub fn syncProjectFiles(self: *Self, pm: *project.ProjectManager) !void {
         _ = self;
-        const project_dir = proj.getProjectDir() orelse return error.NoProjectPath;
-
-        const build_path = try std.fs.path.join(proj.allocator, &.{ project_dir, "build.zig" });
-        defer proj.allocator.free(build_path);
-
-        // Don't overwrite existing build.zig to preserve user modifications
-        if (std.fs.cwd().access(build_path, .{})) {
-            return;
-        } else |_| {}
-
-        const file = try std.fs.cwd().createFile(build_path, .{});
-        defer file.close();
-
-        const build_content = try std.fmt.allocPrint(proj.allocator,
-            \\const std = @import("std");
-            \\
-            \\pub fn build(b: *std.Build) void {{
-            \\    const target = b.standardTargetOptions(.{{}});
-            \\    const optimize = b.standardOptimizeOption(.{{}});
-            \\
-            \\    // Dependencies
-            \\    const labelle_engine_dep = b.dependency("labelle_engine", .{{
-            \\        .target = target,
-            \\        .optimize = optimize,
-            \\    }});
-            \\    const labelle_engine = labelle_engine_dep.module("labelle-engine");
-            \\
-            \\    const labelle_dep = b.dependency("labelle-gfx", .{{
-            \\        .target = target,
-            \\        .optimize = optimize,
-            \\    }});
-            \\    const labelle = labelle_dep.module("labelle");
-            \\
-            \\    const ecs_dep = b.dependency("zig_ecs", .{{
-            \\        .target = target,
-            \\        .optimize = optimize,
-            \\    }});
-            \\    const ecs = ecs_dep.module("zig-ecs");
-            \\
-            \\    // Main executable
-            \\    const exe = b.addExecutable(.{{
-            \\        .name = "{s}",
-            \\        .root_module = b.createModule(.{{
-            \\            .root_source_file = b.path("main.zig"),
-            \\            .target = target,
-            \\            .optimize = optimize,
-            \\            .imports = &.{{
-            \\                .{{ .name = "labelle-engine", .module = labelle_engine }},
-            \\                .{{ .name = "labelle", .module = labelle }},
-            \\                .{{ .name = "ecs", .module = ecs }},
-            \\            }},
-            \\        }}),
-            \\    }});
-            \\
-            \\    b.installArtifact(exe);
-            \\
-            \\    const run_exe = b.addRunArtifact(exe);
-            \\    run_exe.step.dependOn(b.getInstallStep());
-            \\
-            \\    if (b.args) |args| {{
-            \\        run_exe.addArgs(args);
-            \\    }}
-            \\
-            \\    const run_step = b.step("run", "Run the game");
-            \\    run_step.dependOn(&run_exe.step);
-            \\}}
-            \\
-        , .{proj.metadata.name});
-        defer proj.allocator.free(build_content);
-
-        try file.writeAll(build_content);
+        const dir = blk: {
+            const proj = pm.current_project orelse return error.NoProjectOpen;
+            break :blk proj.dir orelse return error.NoProjectPath;
+        };
+        try pm.saveProject(dir);
     }
 
-    /// Generate build.zig.zon for the project (only if it doesn't exist)
-    pub fn generateBuildZigZon(self: *Self, proj: *const project.Project) !void {
-        _ = self;
-        const project_dir = proj.getProjectDir() orelse return error.NoProjectPath;
+    /// Run `labelle generate <project_dir>` synchronously. Surfaces output
+    /// via the returned result; the caller frees with `result.deinit`.
+    pub fn launcherGenerate(self: *Self, proj: *const project.Project) !CompilationResult {
+        const dir = proj.dir orelse return error.NoProjectPath;
 
-        const zon_path = try std.fs.path.join(proj.allocator, &.{ project_dir, "build.zig.zon" });
-        defer proj.allocator.free(zon_path);
-
-        // Don't overwrite existing build.zig.zon to preserve fingerprint and user modifications
-        if (std.fs.cwd().access(zon_path, .{})) {
-            return;
-        } else |_| {}
-
-        const file = try std.fs.cwd().createFile(zon_path, .{});
-        defer file.close();
-
-        // Generate a deterministic fingerprint from the project name using Wyhash
-        // This ensures the fingerprint doesn't change between runs
-        // Note: Zig may still suggest a different fingerprint on first build
-        const fingerprint = std.hash.Wyhash.hash(0xcafe_babe_dead_beef, proj.metadata.name);
-
-        const zon_content = try std.fmt.allocPrint(proj.allocator,
-            \\.{{
-            \\    .fingerprint = 0x{x},
-            \\    .name = .{s},
-            \\    .version = "0.1.0",
-            \\    .minimum_zig_version = "0.15.2",
-            \\    .dependencies = .{{
-            \\        .labelle_engine = .{{
-            \\            .url = "git+https://github.com/labelle-toolkit/labelle-engine#main",
-            \\            .hash = "labelle_engine-0.2.0-rhO5vroRAgBDibpf32FtJr-Z7YFVzvDgEg_UftNxYbpg",
-            \\        }},
-            \\        .@"labelle-gfx" = .{{
-            \\            .url = "git+https://github.com/labelle-toolkit/labelle-gfx?ref=v0.10.0#2bc00d41de2f067f72aa55629167b0b61e3f4d42",
-            \\            .hash = "labelle-0.10.0-2bWPIhW2BAB16mnfjuJYX1meUv3k_EQPzY-oJQXjBL76",
-            \\        }},
-            \\        .zig_ecs = .{{
-            \\            .url = "git+https://github.com/prime31/zig-ecs#dbf3647c2cc4f327fe87067e40f8436c7f87f209",
-            \\            .hash = "entt-1.0.0-qJPtbNLVAgDPXaUbyRSsBTK75Cr1WujUA92kToJugWry",
-            \\        }},
-            \\    }},
-            \\    .paths = .{{
-            \\        "build.zig",
-            \\        "build.zig.zon",
-            \\        "main.zig",
-            \\        "scenes",
-            \\        "components",
-            \\        "scripts",
-            \\        "prefabs",
-            \\        "assets",
-            \\    }},
-            \\}}
-            \\
-        , .{ fingerprint, proj.metadata.name });
-        defer proj.allocator.free(zon_content);
-
-        try file.writeAll(zon_content);
-    }
-
-    /// Generate main.zig entry point (at project root, following engine example_5 pattern)
-    /// Only generates if the file doesn't exist
-    pub fn generateMainZig(self: *Self, proj: *const project.Project) !void {
-        _ = self;
-        const project_dir = proj.getProjectDir() orelse return error.NoProjectPath;
-
-        const main_path = try std.fs.path.join(proj.allocator, &.{ project_dir, "main.zig" });
-        defer proj.allocator.free(main_path);
-
-        // Don't overwrite existing main.zig to preserve user modifications
-        if (std.fs.cwd().access(main_path, .{})) {
-            return;
-        } else |_| {}
-
-        const file = try std.fs.cwd().createFile(main_path, .{});
-        defer file.close();
-
-        const main_content = try std.fmt.allocPrint(proj.allocator,
-            \\// {s} - Generated by Labelle GUI
-            \\//
-            \\// This is the main entry point for your game.
-            \\// Edit this file to customize game initialization and behavior.
-            \\
-            \\const std = @import("std");
-            \\const engine = @import("labelle-engine");
-            \\const labelle = @import("labelle");
-            \\
-            \\// Import components from the components/ folder
-            \\// Example: const velocity = @import("components/velocity.zig");
-            \\
-            \\// Component registry - add your components here
-            \\const Components = engine.ComponentRegistry(struct {{
-            \\    // Example: pub const Velocity = velocity.Velocity;
-            \\}});
-            \\
-            \\// Prefab registry - add your prefabs here
-            \\const Prefabs = engine.PrefabRegistry(.{{}});
-            \\
-            \\// Script registry - add your scripts here
-            \\const Scripts = engine.ScriptRegistry(struct {{}});
-            \\
-            \\// Scene loader type
-            \\const Loader = engine.SceneLoader(Prefabs, Components, Scripts);
-            \\
-            \\pub fn main() !void {{
-            \\    var gpa = std.heap.GeneralPurposeAllocator(.{{}}){{}};
-            \\    defer _ = gpa.deinit();
-            \\    const allocator = gpa.allocator();
-            \\
-            \\    // Initialize game with the Game facade
-            \\    var game = try engine.Game.init(allocator, .{{
-            \\        .window = .{{
-            \\            .width = 1280,
-            \\            .height = 720,
-            \\            .title = "{s}",
-            \\        }},
-            \\        .clear_color = .{{ .r = 30, .g = 35, .b = 45 }},
-            \\    }});
-            \\    defer game.deinit();
-            \\
-            \\    // Register scenes - import your scene .zon files here
-            \\    try game.registerSceneSimple("main", Loader, @import("scenes/main.zon"));
-            \\
-            \\    // Start with main scene
-            \\    try game.setScene("main");
-            \\
-            \\    // Run the game loop
-            \\    try game.run();
-            \\}}
-            \\
-        , .{ proj.metadata.name, proj.metadata.name });
-        defer proj.allocator.free(main_content);
-
-        try file.writeAll(main_content);
-    }
-
-    /// Create project folder structure using ProjectFolders.all
-    pub fn createProjectFolders(self: *Self, proj: *const project.Project) !void {
-        _ = self;
-        const project_dir = proj.getProjectDir() orelse return error.NoProjectPath;
-
-        // Create all folders defined in ProjectFolders.all
-        for (project.ProjectFolders.all) |folder| {
-            const folder_path = try std.fs.path.join(proj.allocator, &.{ project_dir, folder });
-            defer proj.allocator.free(folder_path);
-
-            std.fs.cwd().makeDir(folder_path) catch |err| {
-                if (err != error.PathAlreadyExists) return err;
-            };
-
-            // Create a .gitkeep file to preserve empty directories in git
-            const gitkeep_path = try std.fs.path.join(proj.allocator, &.{ folder_path, ".gitkeep" });
-            defer proj.allocator.free(gitkeep_path);
-
-            // Attempt to create gitkeep, ignore if it already exists or fails
-            if (std.fs.cwd().createFile(gitkeep_path, .{ .exclusive = true })) |gitkeep| {
-                gitkeep.close();
-            } else |_| {}
-        }
-    }
-
-    /// Generate a default scene .zon file (compile-time scene format)
-    pub fn generateDefaultScene(self: *Self, proj: *const project.Project) !void {
-        _ = self;
-        const project_dir = proj.getProjectDir() orelse return error.NoProjectPath;
-
-        const scenes_dir = try std.fs.path.join(proj.allocator, &.{ project_dir, project.ProjectFolders.scenes });
-        defer proj.allocator.free(scenes_dir);
-
-        const scene_path = try std.fs.path.join(proj.allocator, &.{ scenes_dir, "main.zon" });
-        defer proj.allocator.free(scene_path);
-
-        // Check if scene already exists
-        if (std.fs.cwd().access(scene_path, .{})) {
-            return;
-        } else |_| {}
-
-        const file = try std.fs.cwd().createFile(scene_path, .{});
-        defer file.close();
-
-        // Generate a .zon scene file in the format expected by labelle-engine
-        const scene_content =
-            \\.{
-            \\    .name = "main",
-            \\    .entities = .{
-            \\        // Example entity: a blue rectangle
-            \\        .{
-            \\            .shape = .{
-            \\                .type = .rectangle,
-            \\                .x = 400,
-            \\                .y = 300,
-            \\                .width = 100,
-            \\                .height = 100,
-            \\                .color = .{ .r = 100, .g = 149, .b = 237, .a = 255 },
-            \\                .filled = true,
-            \\            },
-            \\            // Add components here:
-            \\            // .components = .{
-            \\            //     .Velocity = .{ .x = 0, .y = 0 },
-            \\            // },
-            \\        },
-            \\    },
-            \\}
-            \\
-        ;
-
-        try file.writeAll(scene_content);
-    }
-
-    /// Generate all build files for the project
-    pub fn generateAllBuildFiles(self: *Self, proj: *const project.Project) !void {
         self.state = .generating;
         errdefer self.state = .failed;
 
-        try self.generateBuildZig(proj);
-        try self.generateBuildZigZon(proj);
-        try self.generateMainZig(proj);
-        try self.createProjectFolders(proj);
-        try self.generateDefaultScene(proj);
-
-        self.state = .idle;
-    }
-
-    /// Build the project using zig build
-    pub fn build(self: *Self, proj: *const project.Project) !void {
-        const project_dir = proj.getProjectDir() orelse return error.NoProjectPath;
-
-        self.state = .building;
-        errdefer self.state = .failed;
-
-        // Clear previous result
-        if (self.last_result) |*result| {
-            result.deinit(self.allocator);
-            self.last_result = null;
-        }
-
-        var child = std.process.Child.init(&.{ "zig", "build" }, self.allocator);
-        child.cwd = project_dir;
-        child.stderr_behavior = .Pipe;
+        var child = std.process.Child.init(&.{ "labelle", "generate", dir }, self.allocator);
         child.stdout_behavior = .Pipe;
-
-        try child.spawn();
-        self.build_process = child;
-    }
-
-    /// Check if build is complete and get result.
-    /// Note: This uses a blocking wait. For long builds, the UI may briefly pause.
-    pub fn pollBuild(self: *Self) ?CompilationResult {
-        if (self.state != .building) {
-            return null;
-        }
-
-        if (self.build_process) |*proc| {
-            // Wait for process to complete (blocking)
-            const result = proc.wait() catch |err| {
-                self.state = .failed;
-                self.build_process = null;
-                self.last_result = .{
-                    .success = false,
-                    .output = "",
-                    .errors = std.fmt.allocPrint(self.allocator, "Process error: {}", .{err}) catch "",
-                };
-                return self.last_result;
-            };
-
-            // Read output
-            const stdout = if (proc.stdout) |stdout_file| blk: {
-                break :blk stdout_file.readToEndAlloc(self.allocator, 1024 * 1024) catch "";
-            } else "";
-            const stderr = if (proc.stderr) |stderr_file| blk: {
-                break :blk stderr_file.readToEndAlloc(self.allocator, 1024 * 1024) catch "";
-            } else "";
-
-            self.build_process = null;
-            const success = result == .Exited and result.Exited == 0;
-            self.state = if (success) .success else .failed;
-            self.last_result = .{
-                .success = success,
-                .output = stdout,
-                .errors = stderr,
-            };
-            return self.last_result;
-        }
-        return null;
-    }
-
-    /// Run the built game
-    pub fn run(self: *Self, proj: *const project.Project) !void {
-        const project_dir = proj.getProjectDir() orelse return error.NoProjectPath;
-
-        self.state = .running;
-
-        var child = std.process.Child.init(&.{ "zig", "build", "run" }, self.allocator);
-        child.cwd = project_dir;
-        child.stderr_behavior = .Inherit;
-        child.stdout_behavior = .Inherit;
-
-        try child.spawn();
-        self.build_process = child;
-    }
-
-    /// Build and run synchronously (blocking)
-    pub fn buildSync(self: *Self, proj: *const project.Project) !CompilationResult {
-        const project_dir = proj.getProjectDir() orelse return error.NoProjectPath;
-
-        self.state = .building;
-        errdefer self.state = .failed;
-
-        // Clear previous result
-        if (self.last_result) |*result| {
-            result.deinit(self.allocator);
-            self.last_result = null;
-        }
-
-        var child = std.process.Child.init(&.{ "zig", "build" }, self.allocator);
-        child.cwd = project_dir;
         child.stderr_behavior = .Pipe;
-        child.stdout_behavior = .Pipe;
 
-        try child.spawn();
-
-        const result = try child.wait();
-
-        // Read output
-        const stdout = if (child.stdout) |stdout_file| try stdout_file.readToEndAlloc(self.allocator, 1024 * 1024) else "";
-        const stderr = if (child.stderr) |stderr_file| try stderr_file.readToEndAlloc(self.allocator, 1024 * 1024) else "";
-
-        const success = result == .Exited and result.Exited == 0;
-        self.state = if (success) .success else .failed;
-        self.last_result = .{
-            .success = success,
-            .output = stdout,
-            .errors = stderr,
+        child.spawn() catch |err| switch (err) {
+            error.FileNotFound => return error.LauncherNotFound,
+            else => return err,
         };
 
-        return self.last_result.?;
+        const result = try child.wait();
+        const stdout = if (child.stdout) |f| try f.readToEndAlloc(self.allocator, 1024 * 1024) else "";
+        const stderr = if (child.stderr) |f| try f.readToEndAlloc(self.allocator, 1024 * 1024) else "";
+
+        const success = result == .Exited and result.Exited == 0;
+        if (!success) self.state = .failed;
+        return .{ .success = success, .output = stdout, .errors = stderr };
+    }
+
+    /// Spawn `labelle build` or `labelle run` in the project directory.
+    /// Returns once the child is spawned; the caller polls via `pollBuild`.
+    fn buildOrRun(self: *Self, proj: *const project.Project, comptime is_run: bool) !void {
+        const dir = proj.dir orelse return error.NoProjectPath;
+
+        if (self.last_result) |*r| {
+            r.deinit(self.allocator);
+            self.last_result = null;
+        }
+
+        self.state = if (is_run) .running else .building;
+        errdefer self.state = .failed;
+
+        const argv: []const []const u8 = if (is_run)
+            &.{ "labelle", "run", dir }
+        else
+            &.{ "labelle", "build", dir };
+
+        var child = std.process.Child.init(argv, self.allocator);
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Pipe;
+
+        child.spawn() catch |err| switch (err) {
+            error.FileNotFound => return error.LauncherNotFound,
+            else => return err,
+        };
+        self.build_process = child;
+    }
+
+    pub fn build(self: *Self, proj: *const project.Project) !void {
+        return self.buildOrRun(proj, false);
+    }
+
+    pub fn run(self: *Self, proj: *const project.Project) !void {
+        return self.buildOrRun(proj, true);
+    }
+
+    /// Wait for the spawned `labelle build`/`labelle run` child to exit and
+    /// capture its output. The launcher already handles cache priming and
+    /// fingerprint patching internally, so a non-zero exit is final — no
+    /// retry pass needed.
+    pub fn pollBuild(self: *Self) ?CompilationResult {
+        if (self.state != .building and self.state != .running) return null;
+        if (self.build_process == null) return null;
+
+        var child = self.build_process.?;
+        const wait_result = child.wait() catch |err| {
+            self.build_process = null;
+            self.state = .failed;
+            self.last_result = .{
+                .success = false,
+                .output = "",
+                .errors = std.fmt.allocPrint(self.allocator, "Process error: {}", .{err}) catch "",
+            };
+            return self.last_result;
+        };
+
+        const stdout = if (child.stdout) |f| f.readToEndAlloc(self.allocator, 1024 * 1024) catch "" else "";
+        const stderr = if (child.stderr) |f| f.readToEndAlloc(self.allocator, 1024 * 1024) catch "" else "";
+        self.build_process = null;
+
+        const success = wait_result == .Exited and wait_result.Exited == 0;
+        self.state = if (success) .success else .failed;
+        self.last_result = .{ .success = success, .output = stdout, .errors = stderr };
+        return self.last_result;
     }
 
     pub fn getState(self: *const Self) CompilerState {

--- a/src/dialogs/dpi_warning.zig
+++ b/src/dialogs/dpi_warning.zig
@@ -1,0 +1,23 @@
+//! DPI change warning modal. Set `app.show_dpi_warning = true` from the
+//! GLFW content-scale callback in `main.zig`; this dialog handles the
+//! one-shot display + dismiss.
+
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+
+pub fn render(app: *App) void {
+    if (app.show_dpi_warning) zgui.openPopup("Display Scale Changed", .{});
+    if (!zgui.beginPopupModal("Display Scale Changed", .{
+        .popen = &app.show_dpi_warning,
+        .flags = .{ .always_auto_resize = true },
+    })) return;
+    defer zgui.endPopup();
+
+    zgui.text("The display scale has changed.", .{});
+    zgui.text("For best results, please restart the application.", .{});
+    zgui.spacing();
+    zgui.separator();
+    zgui.spacing();
+    if (zgui.button("OK", .{ .w = 120 })) app.show_dpi_warning = false;
+}

--- a/src/dialogs/new_scene.zig
+++ b/src/dialogs/new_scene.zig
@@ -1,10 +1,12 @@
 //! New Scene modal — opened from File > New Scene.
 //!
-//! Owns the file-creation side-effect because nothing else needs it.
-//! Writes a minimal `.scene` stub next to the project's `scenes/` folder
-//! and refreshes the tree view on success. Note: the stub format is the
-//! pre-engine TOML-ish placeholder; migrating it to engine-compatible
-//! `.zon` is tracked separately as issue #21.
+//! Writes a `<project>/scenes/<name>.zon` file in the format
+//! `labelle-engine`'s `SceneLoader` expects: a top-level ZON struct with
+//! `name` and `entities` (with `scripts` reserved for future use). New
+//! scenes are seeded with one commented-out entity so the user has the
+//! shape in front of them — they're not loadable until the user fills
+//! the entities list, which is fine for now (this is just the file
+//! scaffold; rich editing is a later issue).
 
 const std = @import("std");
 const zgui = @import("zgui");
@@ -51,7 +53,7 @@ fn createScene(app: *App, scene_name: []const u8) void {
     const proj_dir = proj.getProjectDir() orelse return;
 
     var path_buf: [512]u8 = undefined;
-    const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.scene", .{
+    const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.zon", .{
         proj_dir,
         project.ProjectFolders.scenes,
         scene_name,
@@ -66,25 +68,43 @@ fn createScene(app: *App, scene_name: []const u8) void {
     };
     defer file.close();
 
-    var content_buf: [512]u8 = undefined;
-    const content = std.fmt.bufPrint(&content_buf,
-        \\# {s}
-        \\# Scene created by Labelle GUI
-        \\
-        \\[scene]
-        \\name = "{s}"
-        \\
-        \\[entities]
-        \\# Define your entities here
-        \\
-    , .{ scene_name, scene_name }) catch {
+    const content = renderSceneZon(app.allocator, scene_name) catch {
         app.setStatus("Error formatting scene content!");
         return;
     };
+    defer app.allocator.free(content);
+
     file.writeAll(content) catch {
         app.setStatus("Error writing scene file!");
         return;
     };
     app.setStatus("Scene created!");
     app.tree_view.refresh();
+}
+
+/// Format an engine-compatible ZON scene scaffold for `scene_name`.
+/// Top-level shape matches `labelle-engine`'s `SceneLoader` expectations
+/// (see `labelle-engine/scene/src/types.zig`): `name`, `entities`, and
+/// optional `scripts`. The `entities` list is empty but accompanied by
+/// one commented-out example so the user can see how prefab + component
+/// entries are written without us guessing which prefabs they registered.
+///
+/// Pure / no I/O so it can be exercised from zspec without touching the
+/// filesystem.
+pub fn renderSceneZon(allocator: std.mem.Allocator, scene_name: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator,
+        \\.{{
+        \\    .name = "{s}",
+        \\    // .scripts = .{{ "my_script" }},
+        \\    .entities = .{{
+        \\        // .{{
+        \\        //     .prefab = "my_prefab",
+        \\        //     .components = .{{
+        \\        //         .Position = .{{ .x = 0, .y = 0 }},
+        \\        //     }},
+        \\        // }},
+        \\    }},
+        \\}}
+        \\
+    , .{scene_name});
 }

--- a/src/dialogs/new_scene.zig
+++ b/src/dialogs/new_scene.zig
@@ -1,0 +1,90 @@
+//! New Scene modal — opened from File > New Scene.
+//!
+//! Owns the file-creation side-effect because nothing else needs it.
+//! Writes a minimal `.scene` stub next to the project's `scenes/` folder
+//! and refreshes the tree view on success. Note: the stub format is the
+//! pre-engine TOML-ish placeholder; migrating it to engine-compatible
+//! `.zon` is tracked separately as issue #21.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const project = @import("../project.zig");
+
+pub fn render(app: *App) void {
+    if (app.show_new_scene_dialog) zgui.openPopup("New Scene", .{});
+    if (!zgui.beginPopupModal("New Scene", .{
+        .popen = &app.show_new_scene_dialog,
+        .flags = .{ .always_auto_resize = true },
+    })) return;
+    defer zgui.endPopup();
+
+    zgui.text("Enter scene name:", .{});
+    zgui.spacing();
+    if (zgui.isWindowAppearing()) zgui.setKeyboardFocusHere(0);
+
+    const enter_pressed = zgui.inputText("##scene_name", .{
+        .buf = &app.new_scene_name,
+        .flags = .{ .enter_returns_true = true },
+    });
+
+    zgui.spacing();
+    zgui.separator();
+    zgui.spacing();
+
+    if (zgui.button("Create", .{ .w = 120 }) or enter_pressed) {
+        const scene_name = std.mem.sliceTo(&app.new_scene_name, 0);
+        if (scene_name.len > 0) createScene(app, scene_name);
+        zgui.closeCurrentPopup();
+        app.show_new_scene_dialog = false;
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("Cancel", .{ .w = 120 })) {
+        zgui.closeCurrentPopup();
+        app.show_new_scene_dialog = false;
+    }
+}
+
+fn createScene(app: *App, scene_name: []const u8) void {
+    const proj = app.project_manager.current_project orelse return;
+    const proj_dir = proj.getProjectDir() orelse return;
+
+    var path_buf: [512]u8 = undefined;
+    const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.scene", .{
+        proj_dir,
+        project.ProjectFolders.scenes,
+        scene_name,
+    }) catch {
+        app.setStatus("Path too long!");
+        return;
+    };
+
+    const file = std.fs.cwd().createFile(scene_path, .{ .exclusive = true }) catch |err| {
+        app.setStatus(if (err == error.PathAlreadyExists) "Scene already exists!" else "Error creating scene!");
+        return;
+    };
+    defer file.close();
+
+    var content_buf: [512]u8 = undefined;
+    const content = std.fmt.bufPrint(&content_buf,
+        \\# {s}
+        \\# Scene created by Labelle GUI
+        \\
+        \\[scene]
+        \\name = "{s}"
+        \\
+        \\[entities]
+        \\# Define your entities here
+        \\
+    , .{ scene_name, scene_name }) catch {
+        app.setStatus("Error formatting scene content!");
+        return;
+    };
+    file.writeAll(content) catch {
+        app.setStatus("Error writing scene file!");
+        return;
+    };
+    app.setStatus("Scene created!");
+    app.tree_view.refresh();
+}

--- a/src/dialogs/new_scene.zig
+++ b/src/dialogs/new_scene.zig
@@ -1,12 +1,12 @@
 //! New Scene modal — opened from File > New Scene.
 //!
-//! Writes a `<project>/scenes/<name>.zon` file in the format
-//! `labelle-engine`'s `SceneLoader` expects: a top-level ZON struct with
-//! `name` and `entities` (with `scripts` reserved for future use). New
-//! scenes are seeded with one commented-out entity so the user has the
-//! shape in front of them — they're not loadable until the user fills
-//! the entities list, which is fine for now (this is just the file
-//! scaffold; rich editing is a later issue).
+//! Writes a `<project>/scenes/<name>.jsonc` file in the format
+//! `labelle-engine`'s scene loader expects: a top-level JSON object with
+//! `name` and `entities` (with `include` and `assets` reserved for
+//! future use). New scenes are seeded with one commented-out entity so
+//! the user has the shape in front of them — they're not loadable until
+//! the user fills the entities list, which is fine for now (this is
+//! just the file scaffold; rich editing is a later issue).
 
 const std = @import("std");
 const zgui = @import("zgui");
@@ -53,7 +53,7 @@ fn createScene(app: *App, scene_name: []const u8) void {
     const proj_dir = proj.getProjectDir() orelse return;
 
     var path_buf: [512]u8 = undefined;
-    const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.zon", .{
+    const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.jsonc", .{
         proj_dir,
         project.ProjectFolders.scenes,
         scene_name,
@@ -68,7 +68,7 @@ fn createScene(app: *App, scene_name: []const u8) void {
     };
     defer file.close();
 
-    const content = renderSceneZon(app.allocator, scene_name) catch {
+    const content = renderSceneJsonc(app.allocator, scene_name) catch {
         app.setStatus("Error formatting scene content!");
         return;
     };
@@ -82,28 +82,30 @@ fn createScene(app: *App, scene_name: []const u8) void {
     app.tree_view.refresh();
 }
 
-/// Format an engine-compatible ZON scene scaffold for `scene_name`.
-/// Top-level shape matches `labelle-engine`'s `SceneLoader` expectations
-/// (see `labelle-engine/scene/src/types.zig`): `name`, `entities`, and
-/// optional `scripts`. The `entities` list is empty but accompanied by
-/// one commented-out example so the user can see how prefab + component
-/// entries are written without us guessing which prefabs they registered.
+/// Format an engine-compatible JSONC scene scaffold for `scene_name`.
+/// Top-level shape matches `labelle-engine`'s scene loader (see
+/// `labelle-assembler/examples/*/scenes/main.jsonc` for canonical
+/// examples): `name` and `entities`, with `include` reserved for
+/// composition. The `entities` array is empty but accompanied by one
+/// commented-out example so the user can see how prefab + component
+/// entries are written without us guessing which prefabs they
+/// registered.
 ///
 /// Pure / no I/O so it can be exercised from zspec without touching the
 /// filesystem.
-pub fn renderSceneZon(allocator: std.mem.Allocator, scene_name: []const u8) ![]u8 {
+pub fn renderSceneJsonc(allocator: std.mem.Allocator, scene_name: []const u8) ![]u8 {
     return std.fmt.allocPrint(allocator,
-        \\.{{
-        \\    .name = "{s}",
-        \\    // .scripts = .{{ "my_script" }},
-        \\    .entities = .{{
-        \\        // .{{
-        \\        //     .prefab = "my_prefab",
-        \\        //     .components = .{{
-        \\        //         .Position = .{{ .x = 0, .y = 0 }},
-        \\        //     }},
-        \\        // }},
-        \\    }},
+        \\{{
+        \\    "name": "{s}",
+        \\    // "include": ["scenes/other.jsonc"],
+        \\    "entities": [
+        \\        // {{
+        \\        //     "prefab": "my_prefab",
+        \\        //     "components": {{
+        \\        //         "Position": {{ "x": 0, "y": 0 }}
+        \\        //     }}
+        \\        // }}
+        \\    ]
         \\}}
         \\
     , .{scene_name});

--- a/src/dialogs/new_scene.zig
+++ b/src/dialogs/new_scene.zig
@@ -52,15 +52,23 @@ fn createScene(app: *App, scene_name: []const u8) void {
     const proj = app.project_manager.current_project orelse return;
     const proj_dir = proj.getProjectDir() orelse return;
 
-    var path_buf: [512]u8 = undefined;
-    const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.jsonc", .{
-        proj_dir,
-        project.ProjectFolders.scenes,
-        scene_name,
-    }) catch {
-        app.setStatus("Path too long!");
+    // Allocate via std.fs.path.join — handles arbitrary-length project
+    // dirs and uses the platform's native separator.
+    // App.new_scene_name is 128 bytes; ".jsonc" + slack lands inside 160.
+    var file_name_buf: [160]u8 = undefined;
+    const file_name = std.fmt.bufPrint(&file_name_buf, "{s}.jsonc", .{scene_name}) catch {
+        app.setStatus("Scene name too long!");
         return;
     };
+    const scene_path = std.fs.path.join(app.allocator, &.{
+        proj_dir,
+        project.ProjectFolders.scenes,
+        file_name,
+    }) catch {
+        app.setStatus("Out of memory!");
+        return;
+    };
+    defer app.allocator.free(scene_path);
 
     const file = std.fs.cwd().createFile(scene_path, .{ .exclusive = true }) catch |err| {
         app.setStatus(if (err == error.PathAlreadyExists) "Scene already exists!" else "Error creating scene!");

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -115,6 +115,48 @@ pub fn main() !void {
         }
     });
 
+    _ = engine.registerTest("phase3", "resources_add_and_save", @src(), struct {
+        fn gui(_: *zgui.te.TestContext) !void {
+            if (g_app) |a| a.renderFrame();
+        }
+        fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            ctx.menuAction(.click, "View/Resources");
+            _ = zgui.te.check(@src(), .{}, a.show_resources, "panel opened");
+
+            ctx.itemAction(.click, "Resources/Add", .{}, null);
+            _ = zgui.te.check(@src(), .{}, a.resources_editor.count == 1, "Add created a slot");
+
+            // Row 0's inputs live under the pushStrIdZ("row0") scope.
+            ctx.itemInputStrValue("Resources/row0/name", "sprites");
+            ctx.itemInputStrValue("Resources/row0/json", "assets/sprites.json");
+            ctx.itemInputStrValue("Resources/row0/texture", "assets/sprites.png");
+
+            ctx.itemAction(.click, "Resources/Save", .{}, null);
+
+            const proj = a.project_manager.current_project.?;
+            const in_memory = proj.config.resources.len == 1 and
+                std.mem.eql(u8, proj.config.resources[0].name, "sprites");
+            _ = zgui.te.check(@src(), .{}, in_memory, "config.resources updated in memory");
+
+            // Read project.labelle off disk and confirm the resource line is there.
+            const dir = g_settings_project_dir.?;
+            var path_buf: [512]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "{s}/project.labelle", .{dir}) catch return;
+            var file_buf: [4096]u8 = undefined;
+            const file = std.fs.cwd().openFile(path, .{}) catch return;
+            defer file.close();
+            const n = file.read(&file_buf) catch return;
+            const on_disk = std.mem.indexOf(u8, file_buf[0..n], "\"sprites\"") != null and
+                std.mem.indexOf(u8, file_buf[0..n], "assets/sprites.json") != null;
+            _ = zgui.te.check(@src(), .{}, on_disk, "project.labelle on disk has the resource");
+        }
+    });
+
     _ = engine.registerTest("phase3", "project_settings_edit_save", @src(), struct {
         fn gui(_: *zgui.te.TestContext) !void {
             if (g_app) |a| a.renderFrame();

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -1,0 +1,105 @@
+//! UI test runner — Phase 1 hello-world for Dear ImGui Test Engine integration.
+//!
+//! Spins up a hidden GLFW window, initializes zgui with the bundled
+//! Test Engine (`with_te = true`), registers a single trivial check,
+//! drives the frame loop until the test queue drains, and exits with
+//! the engine's pass/fail tally.
+//!
+//! Phase 2 will refactor `main.zig` so the real App can be driven from
+//! here. For now this only proves the build wiring works end-to-end.
+
+const std = @import("std");
+const zglfw = @import("zglfw");
+const zopengl = @import("zopengl");
+const zgui = @import("zgui");
+
+const gl_major = 4;
+const gl_minor = 1;
+
+pub fn main() !void {
+    try zglfw.init();
+    defer zglfw.terminate();
+
+    zglfw.windowHint(.context_version_major, gl_major);
+    zglfw.windowHint(.context_version_minor, gl_minor);
+    zglfw.windowHint(.opengl_profile, .opengl_core_profile);
+    zglfw.windowHint(.opengl_forward_compat, true);
+    zglfw.windowHint(.client_api, .opengl_api);
+    zglfw.windowHint(.doublebuffer, true);
+    // Hidden window — we need a real GL context but no on-screen presentation.
+    zglfw.windowHint(.visible, false);
+
+    const window = try zglfw.createWindow(640, 480, "labelle-gui tests", null, null);
+    defer zglfw.destroyWindow(window);
+
+    zglfw.makeContextCurrent(window);
+    zglfw.swapInterval(0);
+
+    try zopengl.loadCoreProfile(zglfw.getProcAddress, gl_major, gl_minor);
+    const gl = zopengl.bindings;
+
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // zgui.init() also brings up the Test Engine when zgui was built with
+    // `with_te = true` (gui.zig: init() → te.init()). Calling te.init() a
+    // second time here double-registers the "TestEnginePerfTool" settings
+    // handler and trips an imgui assertion. So we just grab the engine
+    // zgui already created.
+    zgui.init(allocator);
+    defer zgui.deinit();
+    zgui.io.setIniFilename(null);
+
+    zgui.backend.init(window);
+    defer zgui.backend.deinit();
+
+    const engine = zgui.te.getTestEngine().?;
+    engine.setRunSpeed(.fast);
+
+    _ = engine.registerTest("phase1", "hello_world", @src(), struct {
+        // No `gui` callback — this test doesn't need to render any widgets.
+        // The `run` callback drives the assertions.
+        fn run(ctx: *zgui.te.TestContext) !void {
+            _ = ctx;
+            _ = zgui.te.check(@src(), .{}, true, "trivially true");
+        }
+    });
+
+    engine.queueTests(.tests, "all", .{});
+
+    // Frame loop — drive imgui + the test engine until the queue drains.
+    // 600 frames is ~10s at 60Hz; ample for any sensible Phase-1 test
+    // and a guardrail against hangs.
+    var frame: usize = 0;
+    while (frame < 600) : (frame += 1) {
+        zglfw.pollEvents();
+
+        const fb = window.getFramebufferSize();
+        gl.viewport(0, 0, fb[0], fb[1]);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+
+        zgui.backend.newFrame(@intCast(fb[0]), @intCast(fb[1]));
+        zgui.backend.draw();
+
+        zglfw.swapBuffers(window);
+        engine.postSwap();
+
+        if (engine.isTestQueueEmpty()) break;
+    }
+
+    var tested: c_int = 0;
+    var succeeded: c_int = 0;
+    engine.getResult(&tested, &succeeded);
+    engine.printResultSummary();
+
+    if (tested == 0) {
+        std.log.err("no tests ran (frame budget exhausted)", .{});
+        std.process.exit(2);
+    }
+    if (tested != succeeded) {
+        std.log.err("{d}/{d} tests failed", .{ tested - succeeded, tested });
+        std.process.exit(1);
+    }
+    std.log.info("all {d} tests passed", .{tested});
+}

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -76,10 +76,18 @@ pub fn main() !void {
 
     // Project Settings test owns its own temp project on disk, written
     // via the gui's own ProjectManager so the test exercises the real
-    // save path. Cleanup runs after engine drains.
+    // save path. Cleanup runs after engine drains. Honors $TMPDIR
+    // (macOS sets it; most Unix shells respect it) with a /tmp fallback.
+    const tmp_base = std.process.getEnvVarOwned(allocator, "TMPDIR") catch try allocator.dupe(u8, "/tmp");
+    defer allocator.free(tmp_base);
     var prng = std.Random.DefaultPrng.init(@intCast(std.time.nanoTimestamp()));
-    var tmp_buf: [64]u8 = undefined;
-    const tmp = try std.fmt.bufPrint(&tmp_buf, "/tmp/labelle_gui_te_{x}", .{prng.random().int(u64)});
+    const dir_name = try std.fmt.allocPrint(allocator, "labelle_gui_te_{x}", .{prng.random().int(u64)});
+    defer allocator.free(dir_name);
+    const tmp = try std.fs.path.join(allocator, &.{
+        std.mem.trimRight(u8, tmp_base, "/\\"),
+        dir_name,
+    });
+    defer allocator.free(tmp);
     try std.fs.cwd().makePath(tmp);
     defer std.fs.cwd().deleteTree(tmp) catch {};
 
@@ -90,7 +98,8 @@ pub fn main() !void {
 
     _ = engine.registerTest("phase3", "view_compiler_output_toggle", @src(), struct {
         fn gui(_: *zgui.te.TestContext) !void {
-            if (g_app) |a| a.renderFrame();
+            // Synthetic dt; tests don't observe status_timer decay.
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
         }
         fn run(ctx: *zgui.te.TestContext) !void {
             const a = g_app orelse {
@@ -117,7 +126,8 @@ pub fn main() !void {
 
     _ = engine.registerTest("phase3", "resources_add_and_save", @src(), struct {
         fn gui(_: *zgui.te.TestContext) !void {
-            if (g_app) |a| a.renderFrame();
+            // Synthetic dt; tests don't observe status_timer decay.
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
         }
         fn run(ctx: *zgui.te.TestContext) !void {
             const a = g_app orelse {
@@ -159,7 +169,8 @@ pub fn main() !void {
 
     _ = engine.registerTest("phase3", "project_settings_edit_save", @src(), struct {
         fn gui(_: *zgui.te.TestContext) !void {
-            if (g_app) |a| a.renderFrame();
+            // Synthetic dt; tests don't observe status_timer decay.
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
         }
         fn run(ctx: *zgui.te.TestContext) !void {
             const a = g_app orelse {

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -19,6 +19,12 @@ const gl_minor = 1;
 /// before queueing tests, clear in the deferred teardown.
 var g_app: ?*App = null;
 
+/// Path to a temp project directory created for the project_settings
+/// test. The test's `run` callback reads the file back from disk to
+/// verify the Save button actually persisted, so the path needs to be
+/// reachable from the C-ABI callback.
+var g_settings_project_dir: ?[]const u8 = null;
+
 pub fn main() !void {
     try zglfw.init();
     defer zglfw.terminate();
@@ -68,6 +74,20 @@ pub fn main() !void {
         }
     });
 
+    // Project Settings test owns its own temp project on disk, written
+    // via the gui's own ProjectManager so the test exercises the real
+    // save path. Cleanup runs after engine drains.
+    var prng = std.Random.DefaultPrng.init(@intCast(std.time.nanoTimestamp()));
+    var tmp_buf: [64]u8 = undefined;
+    const tmp = try std.fmt.bufPrint(&tmp_buf, "/tmp/labelle_gui_te_{x}", .{prng.random().int(u64)});
+    try std.fs.cwd().makePath(tmp);
+    defer std.fs.cwd().deleteTree(tmp) catch {};
+
+    try app.project_manager.newProject("settings_te");
+    try app.project_manager.saveProject(tmp);
+    g_settings_project_dir = tmp;
+    defer g_settings_project_dir = null;
+
     _ = engine.registerTest("phase3", "view_compiler_output_toggle", @src(), struct {
         fn gui(_: *zgui.te.TestContext) !void {
             if (g_app) |a| a.renderFrame();
@@ -92,6 +112,44 @@ pub fn main() !void {
             // Toggle off again to confirm the menu reflects current state.
             ctx.menuAction(.click, "View/Compiler Output");
             _ = zgui.te.check(@src(), .{}, !a.show_compiler_output, "View/Compiler Output closes panel");
+        }
+    });
+
+    _ = engine.registerTest("phase3", "project_settings_edit_save", @src(), struct {
+        fn gui(_: *zgui.te.TestContext) !void {
+            if (g_app) |a| a.renderFrame();
+        }
+        fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            // Open the panel.
+            ctx.menuAction(.click, "View/Project Settings");
+            _ = zgui.te.check(@src(), .{}, a.show_project_settings, "panel opened");
+
+            // Type into the Title field and click Save. The button click
+            // also drives the on-disk write via ProjectManager.saveProject.
+            ctx.itemInputStrValue("Project Settings/Title", "Edited By TE");
+            ctx.itemAction(.click, "Project Settings/Save", .{}, null);
+
+            const proj = a.project_manager.current_project.?;
+            const in_memory = std.mem.eql(u8, proj.config.title, "Edited By TE");
+            _ = zgui.te.check(@src(), .{}, in_memory, "config.title updated in memory");
+
+            // Reread project.labelle from disk and confirm the new title
+            // landed there. Failure here means Save ran but didn't
+            // persist (the integration we actually care about).
+            const dir = g_settings_project_dir.?;
+            var path_buf: [512]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "{s}/project.labelle", .{dir}) catch return;
+            var file_buf: [4096]u8 = undefined;
+            const file = std.fs.cwd().openFile(path, .{}) catch return;
+            defer file.close();
+            const n = file.read(&file_buf) catch return;
+            const on_disk = std.mem.indexOf(u8, file_buf[0..n], "Edited By TE") != null;
+            _ = zgui.te.check(@src(), .{}, on_disk, "project.labelle on disk has new title");
         }
     });
 

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -1,20 +1,23 @@
-//! UI test runner — Phase 1 hello-world for Dear ImGui Test Engine integration.
+//! UI test runner — drives the real `App` against the ImGui Test Engine.
 //!
-//! Spins up a hidden GLFW window, initializes zgui with the bundled
-//! Test Engine (`with_te = true`), registers a single trivial check,
-//! drives the frame loop until the test queue drains, and exits with
-//! the engine's pass/fail tally.
-//!
-//! Phase 2 will refactor `main.zig` so the real App can be driven from
-//! here. For now this only proves the build wiring works end-to-end.
+//! Boots a hidden GLFW window, constructs an `App`, registers TE tests
+//! that drive menu actions and assert on App state, runs the frame loop
+//! until the test queue drains. Exit code reflects pass/fail.
 
 const std = @import("std");
 const zglfw = @import("zglfw");
 const zopengl = @import("zopengl");
 const zgui = @import("zgui");
 
+const App = @import("app.zig").App;
+
 const gl_major = 4;
 const gl_minor = 1;
+
+/// Test callbacks run via a C ABI, so they reach the App through a
+/// module-local pointer rather than a parameter. Set this once in `main`
+/// before queueing tests, clear in the deferred teardown.
+var g_app: ?*App = null;
 
 pub fn main() !void {
     try zglfw.init();
@@ -26,10 +29,9 @@ pub fn main() !void {
     zglfw.windowHint(.opengl_forward_compat, true);
     zglfw.windowHint(.client_api, .opengl_api);
     zglfw.windowHint(.doublebuffer, true);
-    // Hidden window — we need a real GL context but no on-screen presentation.
     zglfw.windowHint(.visible, false);
 
-    const window = try zglfw.createWindow(640, 480, "labelle-gui tests", null, null);
+    const window = try zglfw.createWindow(1280, 720, "labelle-gui tests", null, null);
     defer zglfw.destroyWindow(window);
 
     zglfw.makeContextCurrent(window);
@@ -42,11 +44,6 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    // zgui.init() also brings up the Test Engine when zgui was built with
-    // `with_te = true` (gui.zig: init() → te.init()). Calling te.init() a
-    // second time here double-registers the "TestEnginePerfTool" settings
-    // handler and trips an imgui assertion. So we just grab the engine
-    // zgui already created.
     zgui.init(allocator);
     defer zgui.deinit();
     zgui.io.setIniFilename(null);
@@ -54,29 +51,63 @@ pub fn main() !void {
     zgui.backend.init(window);
     defer zgui.backend.deinit();
 
+    // zgui.init() already started the Test Engine because the test runner
+    // builds zgui with `with_te = true`. Don't call te.init() again — it
+    // double-registers settings handlers and trips an imgui assertion.
     const engine = zgui.te.getTestEngine().?;
     engine.setRunSpeed(.fast);
 
+    const app = try App.init(allocator, window);
+    defer app.deinit();
+    g_app = app;
+    defer g_app = null;
+
     _ = engine.registerTest("phase1", "hello_world", @src(), struct {
-        // No `gui` callback — this test doesn't need to render any widgets.
-        // The `run` callback drives the assertions.
-        fn run(ctx: *zgui.te.TestContext) !void {
-            _ = ctx;
+        fn run(_: *zgui.te.TestContext) !void {
             _ = zgui.te.check(@src(), .{}, true, "trivially true");
         }
     });
 
+    _ = engine.registerTest("phase3", "view_compiler_output_toggle", @src(), struct {
+        fn gui(_: *zgui.te.TestContext) !void {
+            if (g_app) |a| a.renderFrame();
+        }
+        fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            // Sanity: panel starts closed.
+            _ = zgui.te.check(@src(), .{}, !a.show_compiler_output, "panel starts closed");
+
+            // Drive View > Compiler Output.
+            ctx.menuAction(.click, "View/Compiler Output");
+
+            // The toggle flips the same `bool` the panel reads, so the
+            // assertion below sees the update without waiting on another
+            // frame.
+            _ = zgui.te.check(@src(), .{}, a.show_compiler_output, "View/Compiler Output opens panel");
+
+            // Toggle off again to confirm the menu reflects current state.
+            ctx.menuAction(.click, "View/Compiler Output");
+            _ = zgui.te.check(@src(), .{}, !a.show_compiler_output, "View/Compiler Output closes panel");
+        }
+    });
+
+    // `"all"` is the canonical match-everything filter — passing "" matches
+    // nothing because the filter parser treats it as "no include rule".
     engine.queueTests(.tests, "all", .{});
 
-    // Frame loop — drive imgui + the test engine until the queue drains.
-    // 600 frames is ~10s at 60Hz; ample for any sensible Phase-1 test
-    // and a guardrail against hangs.
+    // Frame loop. 1500 frames ≈ ample for any reasonable Phase-3 test;
+    // the queue-empty check below is the real terminator.
     var frame: usize = 0;
-    while (frame < 600) : (frame += 1) {
+    while (frame < 1500) : (frame += 1) {
         zglfw.pollEvents();
 
         const fb = window.getFramebufferSize();
         gl.viewport(0, 0, fb[0], fb[1]);
+        gl.clearColor(0.1, 0.1, 0.1, 1.0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         zgui.backend.newFrame(@intCast(fb[0]), @intCast(fb[1]));

--- a/src/main.zig
+++ b/src/main.zig
@@ -91,6 +91,8 @@ pub fn main() !void {
 
     std.log.info("Labelle started", .{});
 
+    var prev_time = zglfw.getTime();
+
     while (!window.shouldClose()) {
         zglfw.pollEvents();
 
@@ -101,6 +103,10 @@ pub fn main() !void {
             }
         }
 
+        const now = zglfw.getTime();
+        const dt_seconds: f32 = @floatCast(now - prev_time);
+        prev_time = now;
+
         const win_size = window.getSize();
         const fb_size = window.getFramebufferSize();
         zgui.backend.newFrame(@intCast(win_size[0]), @intCast(win_size[1]));
@@ -109,7 +115,7 @@ pub fn main() !void {
         const fb_scale_y = @as(f32, @floatFromInt(fb_size[1])) / @as(f32, @floatFromInt(win_size[1]));
         zgui.io.setDisplayFramebufferScale(fb_scale_x, fb_scale_y);
 
-        app.renderFrame();
+        app.renderFrame(dt_seconds);
 
         gl.viewport(0, 0, fb_size[0], fb_size[1]);
         gl.clearColor(0.1, 0.1, 0.1, 1.0);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,25 +2,21 @@ const std = @import("std");
 const zglfw = @import("zglfw");
 const zopengl = @import("zopengl");
 const zgui = @import("zgui");
-const nfd = @import("nfd");
-const project = @import("project.zig");
-const tree_view = @import("tree_view.zig");
+
 const icons = @import("icons.zig");
 const config = @import("config.zig");
-const compiler = @import("compiler.zig");
+const App = @import("app.zig").App;
 
 const gl = zopengl.bindings;
 
-// Configure logging level for the application
-pub const std_options: std.Options = .{
-    .log_level = .info,
-};
+pub const std_options: std.Options = .{ .log_level = .info };
 
-// DPI handling constants
+// ── DPI ───────────────────────────────────────────────────────────────
+// GLFW's content-scale callback fires on a background thread, so we hand
+// the change off via atomics; the next renderFrame() reads them.
 const dpi_epsilon: f32 = 1e-6;
-const dpi_change_threshold: f32 = 0.05; // 5% change considered significant
+const dpi_change_threshold: f32 = 0.05;
 
-// DPI state for handling dynamic scale changes
 var g_initial_scale: f32 = 1.0;
 var g_current_scale: std.atomic.Value(f32) = std.atomic.Value(f32).init(1.0);
 var g_dpi_changed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
@@ -30,40 +26,22 @@ fn contentScaleCallback(_: *zglfw.Window, xscale: f32, _: f32) callconv(.c) void
     g_dpi_changed.store(true, .release);
 }
 
-const AppState = struct {
-    project_manager: project.ProjectManager,
-    tree_view: tree_view.TreeView,
-    compiler: compiler.Compiler,
-    status_message: [256]u8 = [_]u8{0} ** 256,
-    status_timer: f32 = 0,
-    show_compiler_output: bool = false,
-    compiler_output_scroll_to_bottom: bool = false,
-    // New scene dialog
-    show_new_scene_dialog: bool = false,
-    new_scene_name: [128:0]u8 = [_:0]u8{0} ** 128,
-    // DPI change notification
-    show_dpi_warning: bool = false,
-};
-
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    // Initialize GLFW
     zglfw.init() catch {
         std.log.err("Failed to initialize GLFW", .{});
         return error.GlfwInitFailed;
     };
     defer zglfw.terminate();
 
-    // Set window hints for OpenGL
     zglfw.windowHint(.context_version_major, 3);
     zglfw.windowHint(.context_version_minor, 3);
     zglfw.windowHint(.opengl_profile, .opengl_core_profile);
     zglfw.windowHint(.opengl_forward_compat, true);
 
-    // Create window
     const window = zglfw.createWindow(1280, 720, "Labelle", null, null) catch {
         std.log.err("Failed to create GLFW window", .{});
         return error.WindowCreationFailed;
@@ -73,37 +51,29 @@ pub fn main() !void {
     zglfw.makeContextCurrent(window);
     zglfw.swapInterval(1);
 
-    // Load OpenGL
     zopengl.loadCoreProfile(zglfw.getProcAddress, 3, 3) catch {
         std.log.err("Failed to load OpenGL", .{});
         return error.OpenGLLoadFailed;
     };
 
-    // Initialize ImGui
     zgui.init(allocator);
     defer zgui.deinit();
-
-    // Disable ini file to avoid memory leak warning on exit
     zgui.io.setIniFilename(null);
 
     const scale_factor = window.getContentScale()[0];
-
-    // Store initial scale and set up callback for dynamic DPI changes
     g_initial_scale = scale_factor;
     g_current_scale.store(scale_factor, .release);
     _ = window.setContentScaleCallback(contentScaleCallback);
     const font_size = config.ui.base_font_size * scale_factor;
 
-    // Add default font at scaled size for Retina displays
     var default_config = zgui.FontConfig.init();
     default_config.size_pixels = font_size;
     _ = zgui.io.addFontDefault(default_config);
 
-    // Add FontAwesome icons (merged into the default font)
     var fa_config = zgui.FontConfig.init();
     fa_config.merge_mode = true;
     fa_config.pixel_snap_h = true;
-    fa_config.glyph_min_advance_x = font_size; // Fixed width for icons
+    fa_config.glyph_min_advance_x = font_size;
     _ = zgui.io.addFontFromFileWithConfig(
         "assets/fonts/fa-solid-900.ttf",
         font_size,
@@ -111,537 +81,43 @@ pub fn main() !void {
         &icons.FA_ICON_RANGES,
     );
 
-    // Scale UI elements for high-DPI displays
     zgui.getStyle().scaleAllSizes(scale_factor);
 
     zgui.backend.init(window);
     defer zgui.backend.deinit();
 
-    // Initialize app state
-    var state = AppState{
-        .project_manager = project.ProjectManager.init(allocator),
-        .tree_view = tree_view.TreeView.init(allocator),
-        .compiler = compiler.Compiler.init(allocator),
-    };
-    defer state.project_manager.deinit();
-    defer state.tree_view.deinit();
-    defer state.compiler.deinit();
+    const app = try App.init(allocator, window);
+    defer app.deinit();
 
     std.log.info("Labelle started", .{});
 
-    // Main loop
     while (!window.shouldClose()) {
         zglfw.pollEvents();
 
-        // Check for DPI changes (e.g., window moved to monitor with different scale)
         if (g_dpi_changed.swap(false, .acquire)) {
             const new_scale = g_current_scale.load(.acquire);
-            // Only show warning if scale changed significantly
             if (g_initial_scale > dpi_epsilon and @abs(new_scale - g_initial_scale) / g_initial_scale > dpi_change_threshold) {
-                state.show_dpi_warning = true;
+                app.show_dpi_warning = true;
             }
         }
 
-        // Pass window size (not framebuffer size) to ImGui for correct mouse coordinates
-        // The backend sets framebuffer scale to 1.0, so we need window coordinates
         const win_size = window.getSize();
         const fb_size = window.getFramebufferSize();
         zgui.backend.newFrame(@intCast(win_size[0]), @intCast(win_size[1]));
 
-        // Manually set the correct framebuffer scale for Retina displays
         const fb_scale_x = @as(f32, @floatFromInt(fb_size[0])) / @as(f32, @floatFromInt(win_size[0]));
         const fb_scale_y = @as(f32, @floatFromInt(fb_size[1])) / @as(f32, @floatFromInt(win_size[1]));
         zgui.io.setDisplayFramebufferScale(fb_scale_x, fb_scale_y);
 
-        // Update status timer
-        if (state.status_timer > 0) {
-            state.status_timer -= 1.0 / 60.0; // Assuming 60fps
-        }
+        app.renderFrame();
 
-        // Main menu bar
-        if (zgui.beginMainMenuBar()) {
-            if (zgui.beginMenu("File", true)) {
-                if (zgui.menuItem("New Project...", .{})) {
-                    // Open folder picker to select where to create project
-                    if (nfd.openFolderDialog(null)) |maybe_path| {
-                        if (maybe_path) |folder_path| {
-                            defer nfd.freePath(folder_path);
-                            const name = std.fs.path.basename(folder_path);
-                            state.project_manager.newProject(name) catch |err| {
-                                std.log.err("Error creating project: {}", .{err});
-                                setStatus(&state, "Error creating project!");
-                            };
-                            state.project_manager.saveProject(folder_path) catch |err| {
-                                std.log.err("Error saving project: {}", .{err});
-                                setStatus(&state, "Error saving project!");
-                            };
-                            setStatus(&state, "New project created!");
-                            state.tree_view.refresh();
-                        }
-                    } else |_| {
-                        setStatus(&state, "Error opening folder dialog!");
-                    }
-                }
-                if (zgui.menuItem("Open Project...", .{})) {
-                    if (nfd.openFolderDialog(null)) |maybe_path| {
-                        if (maybe_path) |folder_path| {
-                            defer nfd.freePath(folder_path);
-                            state.project_manager.loadProject(folder_path) catch |err| {
-                                std.log.err("Error loading project: {}", .{err});
-                                setStatus(&state, "Error loading project!");
-                            };
-                            setStatus(&state, "Project loaded!");
-                            state.tree_view.refresh();
-                        }
-                    } else |_| {
-                        setStatus(&state, "Error opening folder dialog!");
-                    }
-                }
-                zgui.separator();
-                if (zgui.menuItem("New Scene...", .{ .enabled = state.project_manager.current_project != null })) {
-                    state.show_new_scene_dialog = true;
-                    @memset(&state.new_scene_name, 0);
-                }
-                zgui.separator();
-                if (zgui.menuItem("Save", .{})) {
-                    if (state.project_manager.current_project) |proj| {
-                        if (proj.dir) |dir| {
-                            state.project_manager.saveProject(dir) catch |err| {
-                                setStatus(&state, "Error saving project!");
-                                std.log.err("Save error: {}", .{err});
-                            };
-                            setStatus(&state, "Project saved!");
-                        } else {
-                            if (nfd.openFolderDialog(null)) |maybe_path| {
-                                if (maybe_path) |folder_path| {
-                                    defer nfd.freePath(folder_path);
-                                    state.project_manager.saveProject(folder_path) catch |err| {
-                                        std.log.err("Save error: {}", .{err});
-                                        setStatus(&state, "Error saving project!");
-                                    };
-                                    setStatus(&state, "Project saved!");
-                                }
-                            } else |_| {
-                                setStatus(&state, "Error opening save dialog!");
-                            }
-                        }
-                    }
-                }
-                if (zgui.menuItem("Save As...", .{})) {
-                    if (state.project_manager.current_project != null) {
-                        if (nfd.openFolderDialog(null)) |maybe_path| {
-                            if (maybe_path) |folder_path| {
-                                defer nfd.freePath(folder_path);
-                                state.project_manager.saveProject(folder_path) catch |err| {
-                                    std.log.err("Save error: {}", .{err});
-                                    setStatus(&state, "Error saving project!");
-                                };
-                                setStatus(&state, "Project saved!");
-                            }
-                        } else |_| {
-                            setStatus(&state, "Error opening save dialog!");
-                        }
-                    }
-                }
-                zgui.separator();
-                if (zgui.menuItem("Close Project", .{})) {
-                    state.project_manager.closeProject();
-                    setStatus(&state, "Project closed");
-                }
-                zgui.separator();
-                if (zgui.menuItem("Exit", .{})) {
-                    window.setShouldClose(true);
-                }
-                zgui.endMenu();
-            }
-            if (zgui.beginMenu("Build", state.project_manager.current_project != null)) {
-                const can_build = state.compiler.isIdle();
-                if (zgui.menuItem("Sync Project Files", .{ .enabled = can_build })) {
-                    if (state.compiler.syncProjectFiles(&state.project_manager)) {
-                        setStatus(&state, "Project files synced!");
-                        state.tree_view.refresh();
-                    } else |err| {
-                        std.log.err("Error syncing project files: {}", .{err});
-                        setStatus(&state, "Error syncing project files!");
-                    }
-                }
-                zgui.separator();
-                if (zgui.menuItem("Build", .{ .enabled = can_build })) {
-                    if (state.project_manager.current_project) |proj| {
-                        const sync_ok = if (state.compiler.syncProjectFiles(&state.project_manager)) true else |err| blk: {
-                            std.log.err("Error syncing project files: {}", .{err});
-                            setStatus(&state, "Error syncing project files!");
-                            break :blk false;
-                        };
-                        if (sync_ok) {
-                            if (state.compiler.build(proj)) {
-                                setStatus(&state, "Building...");
-                                state.show_compiler_output = true;
-                                state.compiler_output_scroll_to_bottom = true;
-                            } else |err| {
-                                std.log.err("Error starting build: {}", .{err});
-                                setStatus(&state, "Error starting build!");
-                            }
-                        }
-                    }
-                }
-                if (zgui.menuItem("Run", .{ .enabled = can_build })) {
-                    if (state.project_manager.current_project) |proj| {
-                        const sync_ok = if (state.compiler.syncProjectFiles(&state.project_manager)) true else |err| blk: {
-                            std.log.err("Error syncing project files: {}", .{err});
-                            setStatus(&state, "Error syncing project files!");
-                            break :blk false;
-                        };
-                        if (sync_ok) {
-                            if (state.compiler.run(proj)) {
-                                setStatus(&state, "Running game...");
-                                state.show_compiler_output = true;
-                                state.compiler_output_scroll_to_bottom = true;
-                            } else |err| {
-                                std.log.err("Error running game: {}", .{err});
-                                setStatus(&state, "Error running game!");
-                            }
-                        }
-                    }
-                }
-                zgui.separator();
-                if (zgui.menuItem("Show Output", .{ .selected = state.show_compiler_output })) {
-                    state.show_compiler_output = !state.show_compiler_output;
-                }
-                zgui.endMenu();
-            }
-            if (zgui.beginMenu("Help", true)) {
-                if (zgui.menuItem("About", .{})) {}
-                zgui.endMenu();
-            }
-            zgui.endMainMenuBar();
-        }
-
-        // Poll compiler for build completion
-        if (state.compiler.pollBuild()) |result| {
-            if (result.success) {
-                setStatus(&state, "Build successful!");
-            } else {
-                setStatus(&state, "Build failed!");
-            }
-            state.compiler_output_scroll_to_bottom = true;
-        }
-
-        // Main window
-        const viewport = zgui.getMainViewport();
-        const work_pos = viewport.getWorkPos();
-        const work_size = viewport.getWorkSize();
-
-        // Left sidebar - Project Tree View
-        zgui.setNextWindowPos(.{ .x = work_pos[0], .y = work_pos[1] });
-        zgui.setNextWindowSize(.{ .w = config.ui.sidebar_width, .h = work_size[1] - config.ui.status_bar_height });
-
-        if (zgui.begin("Project", .{
-            .flags = .{
-                .no_resize = true,
-                .no_move = true,
-                .no_collapse = true,
-            },
-        })) {
-            if (state.project_manager.current_project) |proj| {
-                // Get project directory
-                const project_dir = proj.getProjectDir();
-
-                // Render tree view
-                if (state.tree_view.render(project_dir)) {
-                    // File was selected
-                    if (state.tree_view.getSelectedPath()) |selected| {
-                        std.log.debug("Selected: {s}", .{selected});
-                    }
-                }
-            } else {
-                zgui.textDisabled("No project open", .{});
-            }
-        }
-        zgui.end();
-
-        // Main content area
-        zgui.setNextWindowPos(.{ .x = work_pos[0] + config.ui.sidebar_width, .y = work_pos[1] });
-        zgui.setNextWindowSize(.{ .w = work_size[0] - config.ui.sidebar_width, .h = work_size[1] - config.ui.status_bar_height });
-
-        if (zgui.begin("##main", .{
-            .flags = .{
-                .no_title_bar = true,
-                .no_resize = true,
-                .no_move = true,
-                .no_collapse = true,
-                .menu_bar = false,
-            },
-        })) {
-            if (state.project_manager.current_project) |proj| {
-                // Project is open
-                zgui.text("Project: {s}", .{proj.config.name});
-                if (proj.is_dirty) {
-                    zgui.sameLine(.{});
-                    zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
-                }
-
-                zgui.separator();
-
-                // Show selected file info
-                if (state.tree_view.getSelectedPath()) |selected| {
-                    zgui.text("Selected: {s}", .{std.fs.path.basename(selected)});
-                    zgui.separator();
-                }
-
-                zgui.text("Ready to work!", .{});
-            } else {
-                // No project open
-                zgui.text("Welcome to Labelle!", .{});
-                zgui.spacing();
-                zgui.text("Create a new project or open an existing one.", .{});
-                zgui.spacing();
-
-                if (zgui.button("New Project...", .{ .w = 150 })) {
-                    if (nfd.openFolderDialog(null)) |maybe_path| {
-                        if (maybe_path) |folder_path| {
-                            defer nfd.freePath(folder_path);
-                            const name = std.fs.path.basename(folder_path);
-                            state.project_manager.newProject(name) catch |err| {
-                                std.log.err("Error creating project: {}", .{err});
-                                setStatus(&state, "Error creating project!");
-                            };
-                            state.project_manager.saveProject(folder_path) catch |err| {
-                                std.log.err("Error saving project: {}", .{err});
-                                setStatus(&state, "Error saving project!");
-                            };
-                            setStatus(&state, "New project created!");
-                            state.tree_view.refresh();
-                        }
-                    } else |_| {
-                        setStatus(&state, "Error opening folder dialog!");
-                    }
-                }
-                if (zgui.button("Open Project...", .{ .w = 150 })) {
-                    if (nfd.openFolderDialog(null)) |maybe_path| {
-                        if (maybe_path) |folder_path| {
-                            defer nfd.freePath(folder_path);
-                            state.project_manager.loadProject(folder_path) catch |err| {
-                                std.log.err("Error loading project: {}", .{err});
-                                setStatus(&state, "Error loading project!");
-                            };
-                            setStatus(&state, "Project loaded!");
-                            state.tree_view.refresh();
-                        }
-                    } else |_| {
-                        setStatus(&state, "Error opening folder dialog!");
-                    }
-                }
-            }
-        }
-        zgui.end();
-
-        // Compiler output panel (shown when building or when user toggles it)
-        const compiler_output_height: f32 = if (state.show_compiler_output) 200 else 0;
-        if (state.show_compiler_output) {
-            zgui.setNextWindowPos(.{ .x = work_pos[0], .y = work_pos[1] + work_size[1] - config.ui.status_bar_height - compiler_output_height });
-            zgui.setNextWindowSize(.{ .w = work_size[0], .h = compiler_output_height });
-
-            if (zgui.begin("Compiler Output", .{
-                .popen = &state.show_compiler_output,
-                .flags = .{
-                    .no_resize = true,
-                    .no_move = true,
-                    .no_collapse = true,
-                },
-            })) {
-                // Show compiler state
-                const compiler_state = state.compiler.getState();
-                switch (compiler_state) {
-                    .idle => zgui.textDisabled("Ready", .{}),
-                    .generating => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Generating...", .{}),
-                    .building => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Building...", .{}),
-                    .running => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Running...", .{}),
-                    .success => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Success", .{}),
-                    .failed => zgui.textColored(.{ 1.0, 0.0, 0.0, 1.0 }, "Failed", .{}),
-                }
-                zgui.separator();
-
-                // Show output/errors
-                if (zgui.beginChild("##output", .{ .h = -1 })) {
-                    if (state.compiler.last_result) |result| {
-                        if (result.errors.len > 0) {
-                            zgui.textColored(.{ 1.0, 0.3, 0.3, 1.0 }, "{s}", .{result.errors});
-                        }
-                        if (result.output.len > 0) {
-                            zgui.text("{s}", .{result.output});
-                        }
-                    } else {
-                        zgui.textDisabled("No output", .{});
-                    }
-
-                    // Auto-scroll to bottom
-                    if (state.compiler_output_scroll_to_bottom) {
-                        zgui.setScrollHereY(.{ .center_y_ratio = 1.0 });
-                        state.compiler_output_scroll_to_bottom = false;
-                    }
-                }
-                zgui.endChild();
-            }
-            zgui.end();
-        }
-
-        // Status bar at bottom
-        zgui.setNextWindowPos(.{ .x = work_pos[0], .y = work_pos[1] + work_size[1] - config.ui.status_bar_height });
-        zgui.setNextWindowSize(.{ .w = work_size[0], .h = config.ui.status_bar_height });
-
-        if (zgui.begin("##statusbar", .{
-            .flags = .{
-                .no_title_bar = true,
-                .no_resize = true,
-                .no_move = true,
-                .no_collapse = true,
-                .no_scrollbar = true,
-            },
-        })) {
-            if (state.status_timer > 0) {
-                const status = std.mem.sliceTo(&state.status_message, 0);
-                zgui.text("{s}", .{status});
-            } else {
-                if (state.project_manager.current_project) |proj| {
-                    if (proj.dir) |dir| {
-                        zgui.text("{s}", .{dir});
-                    } else {
-                        zgui.text("Unsaved project", .{});
-                    }
-                } else {
-                    zgui.text("No project open", .{});
-                }
-            }
-        }
-        zgui.end();
-
-        // New Scene Dialog
-        if (state.show_new_scene_dialog) {
-            zgui.openPopup("New Scene", .{});
-        }
-        if (zgui.beginPopupModal("New Scene", .{ .popen = &state.show_new_scene_dialog, .flags = .{ .always_auto_resize = true } })) {
-            zgui.text("Enter scene name:", .{});
-            zgui.spacing();
-
-            // Auto-focus the input field when dialog opens
-            if (zgui.isWindowAppearing()) {
-                zgui.setKeyboardFocusHere(0);
-            }
-
-            const enter_pressed = zgui.inputText("##scene_name", .{ .buf = &state.new_scene_name, .flags = .{ .enter_returns_true = true } });
-
-            zgui.spacing();
-            zgui.separator();
-            zgui.spacing();
-
-            if (zgui.button("Create", .{ .w = 120 }) or enter_pressed) {
-                const scene_name = std.mem.sliceTo(&state.new_scene_name, 0);
-                if (scene_name.len > 0) {
-                    if (state.project_manager.current_project) |proj| {
-                        if (proj.getProjectDir()) |proj_dir| {
-                            // Create scene file
-                            var path_buf: [512]u8 = undefined;
-                            const scene_path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.scene", .{
-                                proj_dir,
-                                project.ProjectFolders.scenes,
-                                scene_name,
-                            }) catch {
-                                setStatus(&state, "Path too long!");
-                                zgui.closeCurrentPopup();
-                                state.show_new_scene_dialog = false;
-                                zgui.endPopup();
-                                continue;
-                            };
-
-                            // Create the scene file
-                            const file = std.fs.cwd().createFile(scene_path, .{ .exclusive = true }) catch |err| {
-                                if (err == error.PathAlreadyExists) {
-                                    setStatus(&state, "Scene already exists!");
-                                } else {
-                                    setStatus(&state, "Error creating scene!");
-                                }
-                                zgui.closeCurrentPopup();
-                                state.show_new_scene_dialog = false;
-                                zgui.endPopup();
-                                continue;
-                            };
-                            defer file.close();
-
-                            // Write default scene content
-                            var content_buf: [512]u8 = undefined;
-                            const content = std.fmt.bufPrint(&content_buf,
-                                \\# {s}
-                                \\# Scene created by Labelle GUI
-                                \\
-                                \\[scene]
-                                \\name = "{s}"
-                                \\
-                                \\[entities]
-                                \\# Define your entities here
-                                \\
-                            , .{ scene_name, scene_name }) catch {
-                                setStatus(&state, "Error formatting scene content!");
-                                state.show_new_scene_dialog = false;
-                                zgui.endPopup();
-                                continue;
-                            };
-                            file.writeAll(content) catch {
-                                setStatus(&state, "Error writing scene file!");
-                                state.show_new_scene_dialog = false;
-                                zgui.endPopup();
-                                continue;
-                            };
-
-                            setStatus(&state, "Scene created!");
-                            state.tree_view.refresh();
-                        }
-                    }
-                    zgui.closeCurrentPopup();
-                    state.show_new_scene_dialog = false;
-                }
-            }
-            zgui.sameLine(.{});
-            if (zgui.button("Cancel", .{ .w = 120 })) {
-                zgui.closeCurrentPopup();
-                state.show_new_scene_dialog = false;
-            }
-
-            zgui.endPopup();
-        }
-
-        // DPI Change Warning Dialog
-        if (state.show_dpi_warning) {
-            zgui.openPopup("Display Scale Changed", .{});
-        }
-        if (zgui.beginPopupModal("Display Scale Changed", .{ .popen = &state.show_dpi_warning, .flags = .{ .always_auto_resize = true } })) {
-            zgui.text("The display scale has changed.", .{});
-            zgui.text("For best results, please restart the application.", .{});
-            zgui.spacing();
-            zgui.separator();
-            zgui.spacing();
-
-            if (zgui.button("OK", .{ .w = 120 * g_initial_scale })) {
-                state.show_dpi_warning = false;
-            }
-            zgui.endPopup();
-        }
-
-        // Render
         gl.viewport(0, 0, fb_size[0], fb_size[1]);
         gl.clearColor(0.1, 0.1, 0.1, 1.0);
         gl.clear(gl.COLOR_BUFFER_BIT);
 
         zgui.backend.draw();
-
         window.swapBuffers();
     }
 
     std.log.info("Labelle closed", .{});
-}
-
-fn setStatus(state: *AppState, message: []const u8) void {
-    @memset(&state.status_message, 0);
-    @memcpy(state.status_message[0..message.len], message);
-    state.status_timer = config.ui.status_message_duration;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -64,7 +64,7 @@ pub fn main() !void {
     zglfw.windowHint(.opengl_forward_compat, true);
 
     // Create window
-    const window = zglfw.createWindow(1280, 720, "Labelle", null) catch {
+    const window = zglfw.createWindow(1280, 720, "Labelle", null, null) catch {
         std.log.err("Failed to create GLFW window", .{});
         return error.WindowCreationFailed;
     };
@@ -166,19 +166,12 @@ pub fn main() !void {
                     if (nfd.openFolderDialog(null)) |maybe_path| {
                         if (maybe_path) |folder_path| {
                             defer nfd.freePath(folder_path);
-                            // Create new project with folder name as project name
                             const name = std.fs.path.basename(folder_path);
                             state.project_manager.newProject(name) catch |err| {
                                 std.log.err("Error creating project: {}", .{err});
                                 setStatus(&state, "Error creating project!");
                             };
-                            // Auto-save to the selected folder
-                            const save_path = std.fmt.allocPrint(allocator, "{s}/project", .{folder_path}) catch {
-                                setStatus(&state, "Memory error!");
-                                continue;
-                            };
-                            defer allocator.free(save_path);
-                            state.project_manager.saveProject(save_path) catch |err| {
+                            state.project_manager.saveProject(folder_path) catch |err| {
                                 std.log.err("Error saving project: {}", .{err});
                                 setStatus(&state, "Error saving project!");
                             };
@@ -190,11 +183,10 @@ pub fn main() !void {
                     }
                 }
                 if (zgui.menuItem("Open Project...", .{})) {
-                    // Open file picker for .labelle files
-                    if (nfd.openFileDialog("labelle", null)) |maybe_path| {
-                        if (maybe_path) |file_path| {
-                            defer nfd.freePath(file_path);
-                            state.project_manager.loadProject(file_path) catch |err| {
+                    if (nfd.openFolderDialog(null)) |maybe_path| {
+                        if (maybe_path) |folder_path| {
+                            defer nfd.freePath(folder_path);
+                            state.project_manager.loadProject(folder_path) catch |err| {
                                 std.log.err("Error loading project: {}", .{err});
                                 setStatus(&state, "Error loading project!");
                             };
@@ -202,7 +194,7 @@ pub fn main() !void {
                             state.tree_view.refresh();
                         }
                     } else |_| {
-                        setStatus(&state, "Error opening file dialog!");
+                        setStatus(&state, "Error opening folder dialog!");
                     }
                 }
                 zgui.separator();
@@ -213,18 +205,17 @@ pub fn main() !void {
                 zgui.separator();
                 if (zgui.menuItem("Save", .{})) {
                     if (state.project_manager.current_project) |proj| {
-                        if (proj.path) |path| {
-                            state.project_manager.saveProject(path) catch |err| {
+                        if (proj.dir) |dir| {
+                            state.project_manager.saveProject(dir) catch |err| {
                                 setStatus(&state, "Error saving project!");
                                 std.log.err("Save error: {}", .{err});
                             };
                             setStatus(&state, "Project saved!");
                         } else {
-                            // No path yet, use Save As
-                            if (nfd.saveFileDialog("labelle", null)) |maybe_path| {
-                                if (maybe_path) |file_path| {
-                                    defer nfd.freePath(file_path);
-                                    state.project_manager.saveProject(file_path) catch |err| {
+                            if (nfd.openFolderDialog(null)) |maybe_path| {
+                                if (maybe_path) |folder_path| {
+                                    defer nfd.freePath(folder_path);
+                                    state.project_manager.saveProject(folder_path) catch |err| {
                                         std.log.err("Save error: {}", .{err});
                                         setStatus(&state, "Error saving project!");
                                     };
@@ -238,10 +229,10 @@ pub fn main() !void {
                 }
                 if (zgui.menuItem("Save As...", .{})) {
                     if (state.project_manager.current_project != null) {
-                        if (nfd.saveFileDialog("labelle", null)) |maybe_path| {
-                            if (maybe_path) |file_path| {
-                                defer nfd.freePath(file_path);
-                                state.project_manager.saveProject(file_path) catch |err| {
+                        if (nfd.openFolderDialog(null)) |maybe_path| {
+                            if (maybe_path) |folder_path| {
+                                defer nfd.freePath(folder_path);
+                                state.project_manager.saveProject(folder_path) catch |err| {
                                     std.log.err("Save error: {}", .{err});
                                     setStatus(&state, "Error saving project!");
                                 };
@@ -265,27 +256,24 @@ pub fn main() !void {
             }
             if (zgui.beginMenu("Build", state.project_manager.current_project != null)) {
                 const can_build = state.compiler.isIdle();
-                if (zgui.menuItem("Generate Build Files", .{ .enabled = can_build })) {
-                    if (state.project_manager.current_project) |proj| {
-                        if (state.compiler.generateAllBuildFiles(proj)) {
-                            setStatus(&state, "Build files generated!");
-                            state.tree_view.refresh();
-                        } else |err| {
-                            std.log.err("Error generating build files: {}", .{err});
-                            setStatus(&state, "Error generating build files!");
-                        }
+                if (zgui.menuItem("Sync Project Files", .{ .enabled = can_build })) {
+                    if (state.compiler.syncProjectFiles(&state.project_manager)) {
+                        setStatus(&state, "Project files synced!");
+                        state.tree_view.refresh();
+                    } else |err| {
+                        std.log.err("Error syncing project files: {}", .{err});
+                        setStatus(&state, "Error syncing project files!");
                     }
                 }
                 zgui.separator();
                 if (zgui.menuItem("Build", .{ .enabled = can_build })) {
                     if (state.project_manager.current_project) |proj| {
-                        // First ensure build files exist
-                        const gen_ok = if (state.compiler.generateAllBuildFiles(proj)) true else |err| blk: {
-                            std.log.err("Error generating build files: {}", .{err});
-                            setStatus(&state, "Error generating build files!");
+                        const sync_ok = if (state.compiler.syncProjectFiles(&state.project_manager)) true else |err| blk: {
+                            std.log.err("Error syncing project files: {}", .{err});
+                            setStatus(&state, "Error syncing project files!");
                             break :blk false;
                         };
-                        if (gen_ok) {
+                        if (sync_ok) {
                             if (state.compiler.build(proj)) {
                                 setStatus(&state, "Building...");
                                 state.show_compiler_output = true;
@@ -299,11 +287,20 @@ pub fn main() !void {
                 }
                 if (zgui.menuItem("Run", .{ .enabled = can_build })) {
                     if (state.project_manager.current_project) |proj| {
-                        if (state.compiler.run(proj)) {
-                            setStatus(&state, "Running game...");
-                        } else |err| {
-                            std.log.err("Error running game: {}", .{err});
-                            setStatus(&state, "Error running game!");
+                        const sync_ok = if (state.compiler.syncProjectFiles(&state.project_manager)) true else |err| blk: {
+                            std.log.err("Error syncing project files: {}", .{err});
+                            setStatus(&state, "Error syncing project files!");
+                            break :blk false;
+                        };
+                        if (sync_ok) {
+                            if (state.compiler.run(proj)) {
+                                setStatus(&state, "Running game...");
+                                state.show_compiler_output = true;
+                                state.compiler_output_scroll_to_bottom = true;
+                            } else |err| {
+                                std.log.err("Error running game: {}", .{err});
+                                setStatus(&state, "Error running game!");
+                            }
                         }
                     }
                 }
@@ -378,7 +375,7 @@ pub fn main() !void {
         })) {
             if (state.project_manager.current_project) |proj| {
                 // Project is open
-                zgui.text("Project: {s}", .{proj.metadata.name});
+                zgui.text("Project: {s}", .{proj.config.name});
                 if (proj.is_dirty) {
                     zgui.sameLine(.{});
                     zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
@@ -409,12 +406,7 @@ pub fn main() !void {
                                 std.log.err("Error creating project: {}", .{err});
                                 setStatus(&state, "Error creating project!");
                             };
-                            const save_path = std.fmt.allocPrint(allocator, "{s}/project", .{folder_path}) catch {
-                                setStatus(&state, "Memory error!");
-                                continue;
-                            };
-                            defer allocator.free(save_path);
-                            state.project_manager.saveProject(save_path) catch |err| {
+                            state.project_manager.saveProject(folder_path) catch |err| {
                                 std.log.err("Error saving project: {}", .{err});
                                 setStatus(&state, "Error saving project!");
                             };
@@ -426,10 +418,10 @@ pub fn main() !void {
                     }
                 }
                 if (zgui.button("Open Project...", .{ .w = 150 })) {
-                    if (nfd.openFileDialog("labelle", null)) |maybe_path| {
-                        if (maybe_path) |file_path| {
-                            defer nfd.freePath(file_path);
-                            state.project_manager.loadProject(file_path) catch |err| {
+                    if (nfd.openFolderDialog(null)) |maybe_path| {
+                        if (maybe_path) |folder_path| {
+                            defer nfd.freePath(folder_path);
+                            state.project_manager.loadProject(folder_path) catch |err| {
                                 std.log.err("Error loading project: {}", .{err});
                                 setStatus(&state, "Error loading project!");
                             };
@@ -437,7 +429,7 @@ pub fn main() !void {
                             state.tree_view.refresh();
                         }
                     } else |_| {
-                        setStatus(&state, "Error opening file dialog!");
+                        setStatus(&state, "Error opening folder dialog!");
                     }
                 }
             }
@@ -512,8 +504,8 @@ pub fn main() !void {
                 zgui.text("{s}", .{status});
             } else {
                 if (state.project_manager.current_project) |proj| {
-                    if (proj.path) |path| {
-                        zgui.text("{s}", .{path});
+                    if (proj.dir) |dir| {
+                        zgui.text("{s}", .{dir});
                     } else {
                         zgui.text("Unsaved project", .{});
                     }

--- a/src/module.zig
+++ b/src/module.zig
@@ -1,0 +1,51 @@
+//! Compile-time module / panel registry (issue #22).
+//!
+//! Each module owns a togglable panel and reports its display label to the
+//! main menu bar's View menu. The `is_open` pointer is shared between the
+//! menu toggle and the panel's `popen` flag, so closing the panel window
+//! and unchecking the menu item stay in sync.
+//!
+//! State backing `is_open` is held by `App` (so two `App` instances — main
+//! window and the TE test runner — don't fight over a single global). Each
+//! module's `makeModule(app)` wires up the pointers when the App is
+//! constructed.
+
+const zgui = @import("zgui");
+const App = @import("app.zig").App;
+
+pub const Module = struct {
+    name: []const u8,
+    display_name: [:0]const u8,
+    is_open: *bool,
+    render_panel: ?*const fn (*App) void = null,
+    on_init: ?*const fn (*App) void = null,
+    on_deinit: ?*const fn (*App) void = null,
+};
+
+pub const Registry = struct {
+    modules: []const Module,
+
+    pub fn initAll(self: Registry, app: *App) void {
+        for (self.modules) |m| if (m.on_init) |f| f(app);
+    }
+
+    pub fn deinitAll(self: Registry, app: *App) void {
+        for (self.modules) |m| if (m.on_deinit) |f| f(app);
+    }
+
+    pub fn renderViewMenu(self: Registry) void {
+        if (!zgui.beginMenu("View", true)) return;
+        defer zgui.endMenu();
+        for (self.modules) |m| {
+            if (zgui.menuItem(m.display_name, .{ .selected = m.is_open.* })) {
+                m.is_open.* = !m.is_open.*;
+            }
+        }
+    }
+
+    pub fn renderAllPanels(self: Registry, app: *App) void {
+        for (self.modules) |m| {
+            if (m.is_open.*) if (m.render_panel) |f| f(app);
+        }
+    }
+};

--- a/src/modules/compiler_output.zig
+++ b/src/modules/compiler_output.zig
@@ -1,0 +1,67 @@
+//! Compiler Output panel — first module wired through the Registry.
+//!
+//! The panel docks to the bottom edge of the work area when open, shows the
+//! current compiler state, and streams the last `labelle build/run`
+//! invocation's stdout/stderr. The `Build` menu also flips `is_open` to
+//! true when the user starts a build, which auto-surfaces the panel.
+
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const config = @import("../config.zig");
+
+const panel_height: f32 = 200;
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "compiler_output",
+        .display_name = "Compiler Output",
+        .is_open = &app.show_compiler_output,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    const viewport = zgui.getMainViewport();
+    const work_pos = viewport.getWorkPos();
+    const work_size = viewport.getWorkSize();
+    zgui.setNextWindowPos(.{
+        .x = work_pos[0],
+        .y = work_pos[1] + work_size[1] - config.ui.status_bar_height - panel_height,
+    });
+    zgui.setNextWindowSize(.{ .w = work_size[0], .h = panel_height });
+
+    if (!zgui.begin("Compiler Output", .{
+        .popen = &app.show_compiler_output,
+        .flags = .{ .no_resize = true, .no_move = true, .no_collapse = true },
+    })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    switch (app.compiler.getState()) {
+        .idle => zgui.textDisabled("Ready", .{}),
+        .generating => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Generating...", .{}),
+        .building => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Building...", .{}),
+        .running => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Running...", .{}),
+        .success => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Success", .{}),
+        .failed => zgui.textColored(.{ 1.0, 0.0, 0.0, 1.0 }, "Failed", .{}),
+    }
+    zgui.separator();
+
+    if (zgui.beginChild("##output", .{ .h = -1 })) {
+        if (app.compiler.last_result) |result| {
+            if (result.errors.len > 0) zgui.textColored(.{ 1.0, 0.3, 0.3, 1.0 }, "{s}", .{result.errors});
+            if (result.output.len > 0) zgui.text("{s}", .{result.output});
+        } else {
+            zgui.textDisabled("No output", .{});
+        }
+        if (app.compiler_output_scroll_to_bottom) {
+            zgui.setScrollHereY(.{ .center_y_ratio = 1.0 });
+            app.compiler_output_scroll_to_bottom = false;
+        }
+    }
+    zgui.endChild();
+}

--- a/src/modules/project_settings.zig
+++ b/src/modules/project_settings.zig
@@ -1,0 +1,176 @@
+//! Project Settings panel — edits the current `ProjectConfig` and writes
+//! `project.labelle` back to disk.
+//!
+//! The panel keeps its own sentinel-terminated string buffers because
+//! `zgui.inputText` writes into the buffer in-place; we can't hand it
+//! the arena-allocated `[]const u8` slices stored on `Project.config`.
+//! Buffers re-sync from the live config whenever the active project
+//! pointer changes. Save dupes the buffers back into `Project.arena`
+//! (old strings stay in the arena until project close — acceptable
+//! since the arena is short-lived).
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const project = @import("../project.zig");
+
+const name_cap = 128;
+const description_cap = 256;
+const title_cap = 128;
+const scene_cap = 64;
+const version_cap = 32;
+
+pub const ProjectSettings = struct {
+    name: [name_cap:0]u8 = [_:0]u8{0} ** name_cap,
+    description: [description_cap:0]u8 = [_:0]u8{0} ** description_cap,
+    title: [title_cap:0]u8 = [_:0]u8{0} ** title_cap,
+    initial_scene: [scene_cap:0]u8 = [_:0]u8{0} ** scene_cap,
+    core_version: [version_cap:0]u8 = [_:0]u8{0} ** version_cap,
+    engine_version: [version_cap:0]u8 = [_:0]u8{0} ** version_cap,
+    gfx_version: [version_cap:0]u8 = [_:0]u8{0} ** version_cap,
+    assembler_version: [version_cap:0]u8 = [_:0]u8{0} ** version_cap,
+
+    width: i32 = 800,
+    height: i32 = 600,
+    target_fps: i32 = 60,
+
+    backend: project.Backend = .raylib,
+    ecs: project.EcsChoice = .zig_ecs,
+
+    /// Project pointer the buffers were last synced from. When this
+    /// changes (different project opened, project closed) we re-sync.
+    last_synced: ?*const project.Project = null,
+};
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "project_settings",
+        .display_name = "Project Settings",
+        .is_open = &app.show_project_settings,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    if (!zgui.begin("Project Settings", .{
+        .popen = &app.show_project_settings,
+        .flags = .{ .always_auto_resize = true },
+    })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    const proj = app.project_manager.current_project orelse {
+        zgui.textDisabled("No project open", .{});
+        return;
+    };
+
+    syncIfNeeded(&app.project_settings, proj);
+    const s = &app.project_settings;
+
+    _ = zgui.inputText("Name", .{ .buf = &s.name });
+    _ = zgui.inputText("Description", .{ .buf = &s.description });
+    _ = zgui.inputText("Title", .{ .buf = &s.title });
+    _ = zgui.inputText("Initial scene", .{ .buf = &s.initial_scene });
+
+    zgui.separator();
+    _ = zgui.inputInt("Width", .{ .v = &s.width });
+    _ = zgui.inputInt("Height", .{ .v = &s.height });
+    _ = zgui.inputInt("Target FPS", .{ .v = &s.target_fps });
+
+    zgui.separator();
+    _ = zgui.comboFromEnum("Backend", &s.backend);
+    _ = zgui.comboFromEnum("ECS", &s.ecs);
+
+    zgui.separator();
+    _ = zgui.inputText("core_version", .{ .buf = &s.core_version });
+    _ = zgui.inputText("engine_version", .{ .buf = &s.engine_version });
+    _ = zgui.inputText("gfx_version", .{ .buf = &s.gfx_version });
+    _ = zgui.inputText("assembler_version", .{ .buf = &s.assembler_version });
+
+    zgui.separator();
+    if (zgui.button("Save", .{ .w = 120 })) saveAndPersist(app, proj);
+    zgui.sameLine(.{});
+    if (zgui.button("Revert", .{ .w = 120 })) {
+        s.last_synced = null; // force resync next frame
+    }
+}
+
+fn syncIfNeeded(s: *ProjectSettings, proj: *project.Project) void {
+    if (s.last_synced == proj) return;
+    syncFromConfig(s, proj);
+    s.last_synced = proj;
+}
+
+fn syncFromConfig(s: *ProjectSettings, proj: *const project.Project) void {
+    const c = proj.config;
+    copyToBuf(&s.name, c.name);
+    copyToBuf(&s.description, c.description);
+    copyToBuf(&s.title, c.title);
+    copyToBuf(&s.initial_scene, c.initial_scene);
+    copyToBuf(&s.core_version, c.core_version);
+    copyToBuf(&s.engine_version, c.engine_version);
+    copyToBuf(&s.gfx_version, c.gfx_version);
+    copyToBuf(&s.assembler_version, c.assembler_version);
+    s.width = @intCast(c.width);
+    s.height = @intCast(c.height);
+    s.target_fps = @intCast(c.target_fps);
+    s.backend = c.backend;
+    s.ecs = c.ecs;
+}
+
+fn saveAndPersist(app: *App, proj: *project.Project) void {
+    applyBuffers(app, proj) catch |err| {
+        std.log.err("Project Settings: apply failed: {s}", .{@errorName(err)});
+        app.setStatus("Error applying settings!");
+        return;
+    };
+    const dir = proj.dir orelse {
+        app.setStatus("Project has no path — use Save As first");
+        return;
+    };
+    app.project_manager.saveProject(dir) catch |err| {
+        std.log.err("Project Settings: save failed: {s}", .{@errorName(err)});
+        app.setStatus("Error saving project!");
+        return;
+    };
+    app.setStatus("Project settings saved!");
+}
+
+/// Write buffer values back into `proj.config`. Strings are duped into
+/// the project's arena, so the original arena-allocated slices are not
+/// freed — they're abandoned. That's intentional: ArenaAllocator
+/// doesn't reclaim individual frees and the project's arena lives only
+/// as long as the project itself, so the leak is bounded.
+fn applyBuffers(app: *App, proj: *project.Project) !void {
+    const a = proj.arena.allocator();
+    const s = &app.project_settings;
+
+    proj.config.name = try a.dupe(u8, bufStr(&s.name));
+    proj.config.description = try a.dupe(u8, bufStr(&s.description));
+    proj.config.title = try a.dupe(u8, bufStr(&s.title));
+    proj.config.initial_scene = try a.dupe(u8, bufStr(&s.initial_scene));
+    proj.config.core_version = try a.dupe(u8, bufStr(&s.core_version));
+    proj.config.engine_version = try a.dupe(u8, bufStr(&s.engine_version));
+    proj.config.gfx_version = try a.dupe(u8, bufStr(&s.gfx_version));
+    proj.config.assembler_version = try a.dupe(u8, bufStr(&s.assembler_version));
+    proj.config.width = @intCast(@max(s.width, 0));
+    proj.config.height = @intCast(@max(s.height, 0));
+    proj.config.target_fps = @intCast(@max(s.target_fps, 0));
+    proj.config.backend = s.backend;
+    proj.config.ecs = s.ecs;
+    proj.markDirty();
+}
+
+fn copyToBuf(buf: []u8, src: []const u8) void {
+    @memset(buf, 0);
+    const n = @min(buf.len, src.len);
+    @memcpy(buf[0..n], src[0..n]);
+}
+
+fn bufStr(buf: []const u8) []const u8 {
+    return std.mem.sliceTo(buf, 0);
+}

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -1,0 +1,44 @@
+//! Project Tree sidebar — togglable panel showing the project's file tree.
+//!
+//! Always rendered at x=0 with a fixed `sidebar_width`. When toggled off
+//! via the View menu, the space is left empty — Main Content keeps its
+//! hardcoded position. Re-enable to bring the tree back.
+
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const config = @import("../config.zig");
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "project_tree",
+        .display_name = "Project Tree",
+        .is_open = &app.show_project_tree,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    const viewport = zgui.getMainViewport();
+    const work_pos = viewport.getWorkPos();
+    const work_size = viewport.getWorkSize();
+    zgui.setNextWindowPos(.{ .x = work_pos[0], .y = work_pos[1] });
+    zgui.setNextWindowSize(.{
+        .w = config.ui.sidebar_width,
+        .h = work_size[1] - config.ui.status_bar_height,
+    });
+
+    if (zgui.begin("Project", .{ .flags = .{
+        .no_resize = true,
+        .no_move = true,
+        .no_collapse = true,
+    } })) {
+        if (app.project_manager.current_project) |proj| {
+            _ = app.tree_view.render(proj.getProjectDir());
+        } else {
+            zgui.textDisabled("No project open", .{});
+        }
+    }
+    zgui.end();
+}

--- a/src/modules/resources.zig
+++ b/src/modules/resources.zig
@@ -1,0 +1,170 @@
+//! Resources panel — edits `ProjectConfig.resources` (the sprite-atlas
+//! manifest the engine consumes through generated `main.zig`).
+//!
+//! Each row carries its own sentinel-terminated edit buffers because
+//! `zgui.inputText` writes in place. Buffers re-sync from the live
+//! config whenever the active project pointer changes. Save dupes
+//! buffers back into `Project.arena` and replaces `proj.config.resources`
+//! with a fresh slice; old slices stay in the arena until project
+//! close (arena leak is bounded — same model as Project Settings).
+//!
+//! Row count is capped at `max_slots` — the editor is for hand-curated
+//! atlases, not a thousand-entry dataset. Bump the constant when a real
+//! user runs into the cap.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const project = @import("../project.zig");
+
+const max_slots = 32;
+const name_cap = 64;
+const path_cap = 256;
+
+const Slot = struct {
+    name: [name_cap:0]u8 = [_:0]u8{0} ** name_cap,
+    json: [path_cap:0]u8 = [_:0]u8{0} ** path_cap,
+    texture: [path_cap:0]u8 = [_:0]u8{0} ** path_cap,
+};
+
+pub const ResourcesEditor = struct {
+    slots: [max_slots]Slot = [_]Slot{.{}} ** max_slots,
+    count: usize = 0,
+    last_synced: ?*const project.Project = null,
+};
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "resources",
+        .display_name = "Resources",
+        .is_open = &app.show_resources,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    if (!zgui.begin("Resources", .{
+        .popen = &app.show_resources,
+        .flags = .{ .always_auto_resize = true },
+    })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    const proj = app.project_manager.current_project orelse {
+        zgui.textDisabled("No project open", .{});
+        return;
+    };
+
+    syncIfNeeded(&app.resources_editor, proj);
+    const ed = &app.resources_editor;
+
+    if (ed.count == 0) {
+        zgui.textDisabled("No resources. Click Add to create one.", .{});
+    }
+
+    var i: usize = 0;
+    var remove_idx: ?usize = null;
+    while (i < ed.count) : (i += 1) {
+        // String IDs (rather than pushIntId) so ImGui Test Engine refs
+        // like "Resources/row0/name" resolve cleanly to a row's inputs.
+        var id_buf: [16:0]u8 = undefined;
+        const row_id = std.fmt.bufPrintZ(&id_buf, "row{d}", .{i}) catch "row?";
+        zgui.pushStrIdZ(row_id);
+        defer zgui.popId();
+
+        zgui.separator();
+        _ = zgui.inputText("name", .{ .buf = &ed.slots[i].name });
+        _ = zgui.inputText("json", .{ .buf = &ed.slots[i].json });
+        _ = zgui.inputText("texture", .{ .buf = &ed.slots[i].texture });
+        if (zgui.button("Remove", .{ .w = 80 })) remove_idx = i;
+    }
+    if (remove_idx) |idx| removeAt(ed, idx);
+
+    zgui.separator();
+    if (zgui.button("Add", .{ .w = 80 })) addSlot(ed);
+    zgui.sameLine(.{});
+    if (zgui.button("Save", .{ .w = 80 })) saveAndPersist(app, proj);
+    zgui.sameLine(.{});
+    if (zgui.button("Revert", .{ .w = 80 })) {
+        ed.last_synced = null; // resync next frame
+    }
+}
+
+fn syncIfNeeded(ed: *ResourcesEditor, proj: *project.Project) void {
+    if (ed.last_synced == proj) return;
+    ed.count = @min(proj.config.resources.len, max_slots);
+    for (proj.config.resources[0..ed.count], 0..) |r, i| {
+        copyToBuf(&ed.slots[i].name, r.name);
+        copyToBuf(&ed.slots[i].json, r.json);
+        copyToBuf(&ed.slots[i].texture, r.texture);
+    }
+    // Clear any leftover rows from a previous project so stale buffers
+    // don't show up if the new project has fewer resources.
+    var k = ed.count;
+    while (k < max_slots) : (k += 1) ed.slots[k] = .{};
+    ed.last_synced = proj;
+}
+
+fn addSlot(ed: *ResourcesEditor) void {
+    if (ed.count >= max_slots) return;
+    ed.slots[ed.count] = .{};
+    ed.count += 1;
+}
+
+fn removeAt(ed: *ResourcesEditor, idx: usize) void {
+    if (idx >= ed.count) return;
+    // Shift later slots down; explicit copy keeps buffer contents
+    // (each Slot is a value).
+    var i = idx;
+    while (i + 1 < ed.count) : (i += 1) ed.slots[i] = ed.slots[i + 1];
+    ed.slots[ed.count - 1] = .{};
+    ed.count -= 1;
+}
+
+fn saveAndPersist(app: *App, proj: *project.Project) void {
+    applyBuffers(app, proj) catch |err| {
+        std.log.err("Resources: apply failed: {s}", .{@errorName(err)});
+        app.setStatus("Error applying resources!");
+        return;
+    };
+    const dir = proj.dir orelse {
+        app.setStatus("Project has no path — use Save As first");
+        return;
+    };
+    app.project_manager.saveProject(dir) catch |err| {
+        std.log.err("Resources: save failed: {s}", .{@errorName(err)});
+        app.setStatus("Error saving project!");
+        return;
+    };
+    app.setStatus("Resources saved!");
+}
+
+fn applyBuffers(app: *App, proj: *project.Project) !void {
+    const a = proj.arena.allocator();
+    const ed = &app.resources_editor;
+
+    const resources = try a.alloc(project.ResourceDef, ed.count);
+    for (resources, 0..) |*dst, i| {
+        dst.* = .{
+            .name = try a.dupe(u8, bufStr(&ed.slots[i].name)),
+            .json = try a.dupe(u8, bufStr(&ed.slots[i].json)),
+            .texture = try a.dupe(u8, bufStr(&ed.slots[i].texture)),
+        };
+    }
+    proj.config.resources = resources;
+    proj.markDirty();
+}
+
+fn copyToBuf(buf: []u8, src: []const u8) void {
+    @memset(buf, 0);
+    const n = @min(buf.len, src.len);
+    @memcpy(buf[0..n], src[0..n]);
+}
+
+fn bufStr(buf: []const u8) []const u8 {
+    return std.mem.sliceTo(buf, 0);
+}

--- a/src/project.zig
+++ b/src/project.zig
@@ -30,6 +30,14 @@ pub const Backend = enum { raylib, sokol, sdl, bgfx, wgpu, null };
 /// Mirrors `labelle-assembler`'s `config.EcsChoice`.
 pub const EcsChoice = enum { mock, zig_ecs, zflecs, mr_ecs };
 
+/// Mirrors `labelle-assembler`'s `config.ResourceDef`. The `lazy` flag is
+/// omitted for now — the assembler infers it from scene asset blocks.
+pub const ResourceDef = struct {
+    name: []const u8,
+    json: []const u8 = "",
+    texture: []const u8 = "",
+};
+
 /// Project configuration written to `<project_dir>/project.labelle` in ZON
 /// format. Schema-compatible with the subset of `labelle-assembler`'s
 /// `ProjectConfig` that gui edits today; the assembler fills in defaults
@@ -55,6 +63,10 @@ pub const ProjectConfig = struct {
     engine_version: []const u8 = "1.21.0",
     gfx_version: []const u8 = "1.7.0",
     assembler_version: []const u8 = "0.8.0",
+    /// Sprite atlas resources — name + JSON manifest + texture file. The
+    /// engine consumes these via the generated `main.zig` (see assembler
+    /// codegen). Defaults to empty; the editor adds entries.
+    resources: []const ResourceDef = &.{},
 };
 
 pub const Project = struct {
@@ -229,36 +241,36 @@ pub const ProjectManager = struct {
 /// stays minimal and hand-editable.
 fn renderProjectLabelle(allocator: std.mem.Allocator, cfg: ProjectConfig) ![]u8 {
     const title = if (cfg.title.len > 0) cfg.title else cfg.name;
-    return std.fmt.allocPrint(allocator,
-        \\.{{
-        \\    .name = "{s}",
-        \\    .description = "{s}",
-        \\    .title = "{s}",
-        \\    .width = {d},
-        \\    .height = {d},
-        \\    .target_fps = {d},
-        \\    .backend = .{s},
-        \\    .ecs = .{s},
-        \\    .initial_scene = "{s}",
-        \\    .core_version = "{s}",
-        \\    .engine_version = "{s}",
-        \\    .gfx_version = "{s}",
-        \\    .assembler_version = "{s}",
-        \\}}
-        \\
-    , .{
-        cfg.name,
-        cfg.description,
-        title,
-        cfg.width,
-        cfg.height,
-        cfg.target_fps,
-        @tagName(cfg.backend),
-        @tagName(cfg.ecs),
-        cfg.initial_scene,
-        cfg.core_version,
-        cfg.engine_version,
-        cfg.gfx_version,
-        cfg.assembler_version,
-    });
+    var buf: std.ArrayList(u8) = .{};
+    errdefer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+
+    try w.writeAll(".{\n");
+    try w.print("    .name = \"{s}\",\n", .{cfg.name});
+    try w.print("    .description = \"{s}\",\n", .{cfg.description});
+    try w.print("    .title = \"{s}\",\n", .{title});
+    try w.print("    .width = {d},\n", .{cfg.width});
+    try w.print("    .height = {d},\n", .{cfg.height});
+    try w.print("    .target_fps = {d},\n", .{cfg.target_fps});
+    try w.print("    .backend = .{s},\n", .{@tagName(cfg.backend)});
+    try w.print("    .ecs = .{s},\n", .{@tagName(cfg.ecs)});
+    try w.print("    .initial_scene = \"{s}\",\n", .{cfg.initial_scene});
+    try w.print("    .core_version = \"{s}\",\n", .{cfg.core_version});
+    try w.print("    .engine_version = \"{s}\",\n", .{cfg.engine_version});
+    try w.print("    .gfx_version = \"{s}\",\n", .{cfg.gfx_version});
+    try w.print("    .assembler_version = \"{s}\",\n", .{cfg.assembler_version});
+
+    if (cfg.resources.len > 0) {
+        try w.writeAll("    .resources = .{\n");
+        for (cfg.resources) |r| {
+            try w.print(
+                "        .{{ .name = \"{s}\", .json = \"{s}\", .texture = \"{s}\" }},\n",
+                .{ r.name, r.json, r.texture },
+            );
+        }
+        try w.writeAll("    },\n");
+    }
+
+    try w.writeAll("}\n");
+    return buf.toOwnedSlice(allocator);
 }

--- a/src/project.zig
+++ b/src/project.zig
@@ -71,11 +71,20 @@ pub const ProjectConfig = struct {
 
 pub const Project = struct {
     allocator: std.mem.Allocator,
-    /// Owns every string in `config` and the `dir` field. Freed in `deinit`.
+    /// Owns every string in `config`, `extras`, and the `dir` field.
+    /// Freed in `deinit`.
     arena: *std.heap.ArenaAllocator,
     /// Project directory (absolute path). null until the project is saved.
     dir: ?[]const u8,
     config: ProjectConfig,
+    /// Verbatim text for top-level `project.labelle` fields the gui's
+    /// `ProjectConfig` doesn't model (e.g. `states`, `plugins`, `layers`,
+    /// `gui`, `ios`, `android`, `labelle_version`, `hidden`). Captured on
+    /// `loadProject` and re-emitted on `saveProject` so external projects
+    /// round-trip without data loss. Each element is one field's source
+    /// text, starting at `.name` and ending right before the trailing
+    /// comma. Empty for projects authored by the gui.
+    extras: []const []const u8,
     is_dirty: bool,
 
     const Self = @This();
@@ -96,6 +105,7 @@ pub const Project = struct {
             .arena = arena,
             .dir = null,
             .config = .{ .name = name_copy },
+            .extras = &.{},
             .is_dirty = true,
         };
         return project;
@@ -163,7 +173,7 @@ pub const ProjectManager = struct {
         const file_path = try std.fs.path.join(self.allocator, &.{ dir_path, PROJECT_FILENAME });
         defer self.allocator.free(file_path);
 
-        const content = try renderProjectLabelle(self.allocator, proj.config);
+        const content = try renderProjectLabelle(self.allocator, proj.config, proj.extras);
         defer self.allocator.free(content);
 
         const file = try std.fs.cwd().createFile(file_path, .{});
@@ -220,11 +230,19 @@ pub const ProjectManager = struct {
             return err;
         };
 
+        // Capture text for any top-level field our ProjectConfig doesn't
+        // model, so we can re-emit them on save without dropping data.
+        const extras = extractUnmodeledFields(arena_alloc, source) catch |err| blk: {
+            std.log.warn("project.labelle extras scan failed at {s}: {s} (saving will drop unknown fields)", .{ file_path, @errorName(err) });
+            break :blk &.{};
+        };
+
         project.* = .{
             .allocator = self.allocator,
             .arena = arena,
             .dir = try arena_alloc.dupe(u8, dir_path),
             .config = parsed,
+            .extras = extras,
             .is_dirty = false,
         };
 
@@ -250,10 +268,144 @@ pub const ProjectManager = struct {
     }
 };
 
+/// Field names we render explicitly via `renderProjectLabelle`. Any
+/// top-level key in the loaded file that isn't in this set is captured
+/// verbatim into `Project.extras` for round-trip preservation. Keep in
+/// sync with the field list in `renderProjectLabelle` above — these are
+/// the names of the fields we emit ourselves and must not duplicate.
+const managed_field_names = [_][]const u8{
+    "name",         "description",       "title",
+    "width",        "height",            "target_fps",
+    "backend",      "ecs",               "initial_scene",
+    "core_version", "engine_version",    "gfx_version",
+    "assembler_version",                 "resources",
+};
+
+fn isManaged(name: []const u8) bool {
+    for (managed_field_names) |m| {
+        if (std.mem.eql(u8, m, name)) return true;
+    }
+    return false;
+}
+
+/// Extract verbatim source text for every top-level field in a ZON
+/// document that the gui's `ProjectConfig` doesn't model. The returned
+/// slices live in `arena` and each is the field's text starting at the
+/// leading `.` and ending right before the trailing comma (or the
+/// closing `}` for a final field).
+///
+/// Scope: handles the ZON dialect actually used in `project.labelle` —
+/// `// ... \n` comments, `"..."` strings with `\"` escapes, and brace /
+/// bracket / paren nesting in values. Multi-line strings (`\\...`) and
+/// `'...'` character literals are not handled because the assembler's
+/// project schema doesn't use them; if either appears in a future
+/// schema, this scanner will need to grow.
+fn extractUnmodeledFields(arena: std.mem.Allocator, raw: []const u8) ![]const []const u8 {
+    var i: usize = 0;
+    skipWsAndComments(raw, &i);
+    // Top-level shape is `.{ ... }`. Bail quietly on anything else; the
+    // caller treats a missing extras list as "no preservation possible".
+    if (i + 1 >= raw.len or raw[i] != '.' or raw[i + 1] != '{') return &.{};
+    i += 2;
+
+    var out: std.ArrayList([]const u8) = .{};
+    errdefer out.deinit(arena);
+
+    while (i < raw.len) {
+        skipWsAndComments(raw, &i);
+        if (i >= raw.len) break;
+        if (raw[i] == '}') break;
+        if (raw[i] != '.') break; // unexpected; stop rather than mis-parse
+
+        const field_start = i;
+        i += 1; // past '.'
+        const name_start = i;
+        while (i < raw.len) : (i += 1) {
+            const c = raw[i];
+            if (!std.ascii.isAlphanumeric(c) and c != '_') break;
+        }
+        const name = raw[name_start..i];
+        if (name.len == 0) break;
+
+        skipWsAndComments(raw, &i);
+        if (i >= raw.len or raw[i] != '=') break;
+        i += 1; // past '='
+
+        // Scan the value up to (but not including) the next top-level
+        // `,` or the outer `}`. Brace/string/comment aware.
+        scanValue(raw, &i);
+        const field_end = i;
+
+        // Consume optional trailing comma.
+        const save = i;
+        skipWsAndComments(raw, &i);
+        if (i < raw.len and raw[i] == ',') {
+            i += 1;
+        } else {
+            i = save;
+        }
+
+        if (!isManaged(name)) {
+            const trimmed = std.mem.trimRight(u8, raw[field_start..field_end], " \t\r\n");
+            const text = try arena.dupe(u8, trimmed);
+            try out.append(arena, text);
+        }
+    }
+    return out.toOwnedSlice(arena);
+}
+
+fn skipWsAndComments(raw: []const u8, i: *usize) void {
+    while (i.* < raw.len) {
+        const c = raw[i.*];
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r') {
+            i.* += 1;
+        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
+            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
+        } else break;
+    }
+}
+
+fn scanValue(raw: []const u8, i: *usize) void {
+    var depth: usize = 0;
+    while (i.* < raw.len) {
+        const c = raw[i.*];
+        if (c == '"') {
+            i.* += 1;
+            while (i.* < raw.len) {
+                if (raw[i.*] == '\\' and i.* + 1 < raw.len) {
+                    i.* += 2;
+                } else if (raw[i.*] == '"') {
+                    i.* += 1;
+                    break;
+                } else {
+                    i.* += 1;
+                }
+            }
+        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
+            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
+        } else if (c == '{' or c == '[' or c == '(') {
+            depth += 1;
+            i.* += 1;
+        } else if (c == '}' or c == ']' or c == ')') {
+            if (depth == 0) return; // outer `}` — stop without consuming
+            depth -= 1;
+            i.* += 1;
+        } else if (c == ',' and depth == 0) {
+            return;
+        } else {
+            i.* += 1;
+        }
+    }
+}
+
 /// Format a `ProjectConfig` as ZON source matching `labelle-assembler`'s
 /// expected schema. Omits fields the assembler can default so the file
 /// stays minimal and hand-editable.
-fn renderProjectLabelle(allocator: std.mem.Allocator, cfg: ProjectConfig) ![]u8 {
+fn renderProjectLabelle(
+    allocator: std.mem.Allocator,
+    cfg: ProjectConfig,
+    extras: []const []const u8,
+) ![]u8 {
     const title = if (cfg.title.len > 0) cfg.title else cfg.name;
     var buf: std.ArrayList(u8) = .{};
     errdefer buf.deinit(allocator);
@@ -283,6 +435,18 @@ fn renderProjectLabelle(allocator: std.mem.Allocator, cfg: ProjectConfig) ![]u8 
             );
         }
         try w.writeAll("    },\n");
+    }
+
+    // Re-emit fields the gui doesn't model, verbatim from the source we
+    // loaded. Captured text already starts at `.name` and excludes the
+    // trailing comma; we just indent and add `,\n`. Multi-line values
+    // (e.g. nested struct literals) keep their original line breaks but
+    // not their original indentation level — good enough; the file is
+    // still ZON-parseable and human-editable.
+    for (extras) |field_text| {
+        try w.writeAll("    ");
+        try w.writeAll(field_text);
+        try w.writeAll(",\n");
     }
 
     try w.writeAll("}\n");

--- a/src/project.zig
+++ b/src/project.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 
-pub const PROJECT_EXTENSION = ".labelle";
-pub const PROJECT_VERSION = 1;
+pub const PROJECT_FILENAME = "project.labelle";
 
 pub const ProjectFolders = struct {
     pub const assets = "assets";
@@ -23,63 +22,85 @@ pub const ProjectFolders = struct {
     };
 };
 
-pub const ProjectMetadata = struct {
-    version: u32 = PROJECT_VERSION,
+/// Mirrors a subset of `labelle-assembler`'s `config.Backend` enum.
+/// Order/spelling must match so the ZON `.backend = .raylib` literal parses
+/// identically in both binaries.
+pub const Backend = enum { raylib, sokol, sdl, bgfx, wgpu, null };
+
+/// Mirrors `labelle-assembler`'s `config.EcsChoice`.
+pub const EcsChoice = enum { mock, zig_ecs, zflecs, mr_ecs };
+
+/// Project configuration written to `<project_dir>/project.labelle` in ZON
+/// format. Schema-compatible with the subset of `labelle-assembler`'s
+/// `ProjectConfig` that gui edits today; the assembler fills in defaults
+/// for fields we omit (layers, resources, plugins, etc.).
+///
+/// The version pins MUST be emitted: without `assembler_version`, the
+/// `labelle` launcher falls back to its own version when fetching the
+/// assembler binary (see `labelle-cli/src/cli/cache.zig:29`), which fails
+/// on any machine where CLI and assembler aren't lockstep. The defaults
+/// below are the tested-coherent set from `labelle-cli/versions.zon` plus
+/// the assembler pin from its `build.zig.zon`.
+pub const ProjectConfig = struct {
     name: []const u8,
-    created_at: i64,
-    modified_at: i64,
     description: []const u8 = "",
+    title: []const u8 = "",
+    width: u32 = 800,
+    height: u32 = 600,
+    target_fps: u32 = 60,
+    backend: Backend = .raylib,
+    ecs: EcsChoice = .zig_ecs,
+    initial_scene: []const u8 = "main",
+    core_version: []const u8 = "1.10.0",
+    engine_version: []const u8 = "1.21.0",
+    gfx_version: []const u8 = "1.7.0",
+    assembler_version: []const u8 = "0.8.0",
 };
 
 pub const Project = struct {
     allocator: std.mem.Allocator,
-    path: ?[]const u8,
-    metadata: ProjectMetadata,
+    /// Owns every string in `config` and the `dir` field. Freed in `deinit`.
+    arena: *std.heap.ArenaAllocator,
+    /// Project directory (absolute path). null until the project is saved.
+    dir: ?[]const u8,
+    config: ProjectConfig,
     is_dirty: bool,
 
     const Self = @This();
 
     pub fn create(allocator: std.mem.Allocator, name: []const u8) !*Self {
         const project = try allocator.create(Self);
-        const timestamp = std.time.timestamp();
+        errdefer allocator.destroy(project);
 
-        const name_copy = try allocator.dupe(u8, name);
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const name_copy = try arena.allocator().dupe(u8, name);
 
         project.* = .{
             .allocator = allocator,
-            .path = null,
-            .metadata = .{
-                .name = name_copy,
-                .created_at = timestamp,
-                .modified_at = timestamp,
-            },
+            .arena = arena,
+            .dir = null,
+            .config = .{ .name = name_copy },
             .is_dirty = true,
         };
-
         return project;
     }
 
     pub fn deinit(self: *Self) void {
-        if (self.path) |p| {
-            self.allocator.free(p);
-        }
-        self.allocator.free(self.metadata.name);
-        if (self.metadata.description.len > 0) {
-            self.allocator.free(self.metadata.description);
-        }
+        self.arena.deinit();
+        self.allocator.destroy(self.arena);
         self.allocator.destroy(self);
     }
 
     pub fn markDirty(self: *Self) void {
         self.is_dirty = true;
-        self.metadata.modified_at = std.time.timestamp();
     }
 
     pub fn getProjectDir(self: *const Self) ?[]const u8 {
-        if (self.path) |p| {
-            return std.fs.path.dirname(p);
-        }
-        return null;
+        return self.dir;
     }
 };
 
@@ -97,16 +118,11 @@ pub const ProjectManager = struct {
     }
 
     pub fn deinit(self: *Self) void {
-        if (self.current_project) |project| {
-            project.deinit();
-        }
+        if (self.current_project) |project| project.deinit();
     }
 
     pub fn newProject(self: *Self, name: []const u8) !void {
-        if (self.current_project) |project| {
-            project.deinit();
-        }
-
+        if (self.current_project) |project| project.deinit();
         self.current_project = try Project.create(self.allocator, name);
     }
 
@@ -116,120 +132,78 @@ pub const ProjectManager = struct {
 
         for (ProjectFolders.all) |folder| {
             dir.makeDir(folder) catch |err| {
-                if (err != error.PathAlreadyExists) {
-                    return err;
-                }
+                if (err != error.PathAlreadyExists) return err;
             };
         }
     }
 
-    pub fn saveProject(self: *Self, path: []const u8) !void {
+    /// Save the current project to `<dir>/project.labelle` (ZON, assembler-compatible).
+    /// Creates the directory's scaffold folders if they don't exist.
+    pub fn saveProject(self: *Self, dir_path: []const u8) !void {
         const proj = self.current_project orelse return error.NoProjectOpen;
 
-        // Ensure path ends with .labelle
-        var save_path: []const u8 = undefined;
-        var allocated_path = false;
-
-        if (std.mem.endsWith(u8, path, PROJECT_EXTENSION)) {
-            save_path = path;
-        } else {
-            save_path = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ path, PROJECT_EXTENSION });
-            allocated_path = true;
-        }
-        defer if (allocated_path) self.allocator.free(save_path);
-
-        // Get directory for project folders
-        const dir_path = std.fs.path.dirname(save_path) orelse ".";
-
-        // Create project folders
+        std.fs.cwd().makePath(dir_path) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return err,
+        };
         try self.createProjectFolders(dir_path);
 
-        // Write project file as simple text format
-        const file = try std.fs.cwd().createFile(save_path, .{});
-        defer file.close();
+        const file_path = try std.fs.path.join(self.allocator, &.{ dir_path, PROJECT_FILENAME });
+        defer self.allocator.free(file_path);
 
-        // Format content
-        const content = try std.fmt.allocPrint(self.allocator, "version={d}\nname={s}\ncreated_at={d}\nmodified_at={d}\ndescription={s}\n", .{
-            proj.metadata.version,
-            proj.metadata.name,
-            proj.metadata.created_at,
-            proj.metadata.modified_at,
-            proj.metadata.description,
-        });
+        const content = try renderProjectLabelle(self.allocator, proj.config);
         defer self.allocator.free(content);
 
+        const file = try std.fs.cwd().createFile(file_path, .{});
+        defer file.close();
         try file.writeAll(content);
 
-        // Update project path
-        if (proj.path) |old_path| {
-            self.allocator.free(old_path);
-        }
-        proj.path = try self.allocator.dupe(u8, save_path);
+        proj.dir = try proj.arena.allocator().dupe(u8, dir_path);
         proj.is_dirty = false;
-
-        std.debug.print("Project saved to: {s}\n", .{save_path});
     }
 
+    /// Load a project from `<dir>/project.labelle`. The argument may be the
+    /// directory itself or the `project.labelle` file inside it — both are
+    /// resolved to the containing directory.
     pub fn loadProject(self: *Self, path: []const u8) !void {
-        const file = try std.fs.cwd().openFile(path, .{});
-        defer file.close();
+        const dir_path = if (std.mem.endsWith(u8, path, PROJECT_FILENAME))
+            std.fs.path.dirname(path) orelse "."
+        else
+            path;
 
-        const content = try file.readToEndAlloc(self.allocator, 1024 * 1024);
-        defer self.allocator.free(content);
+        const file_path = try std.fs.path.join(self.allocator, &.{ dir_path, PROJECT_FILENAME });
+        defer self.allocator.free(file_path);
 
-        // Parse simple text format
-        var version: u32 = PROJECT_VERSION;
-        var name: []const u8 = "";
-        var created_at: i64 = 0;
-        var modified_at: i64 = 0;
-        var description: []const u8 = "";
+        const raw = try std.fs.cwd().readFileAlloc(self.allocator, file_path, 1024 * 1024);
+        defer self.allocator.free(raw);
 
-        var lines = std.mem.splitScalar(u8, content, '\n');
-        while (lines.next()) |line| {
-            if (std.mem.indexOf(u8, line, "=")) |eq_pos| {
-                const key = line[0..eq_pos];
-                const value = line[eq_pos + 1 ..];
-
-                if (std.mem.eql(u8, key, "version")) {
-                    version = std.fmt.parseInt(u32, value, 10) catch PROJECT_VERSION;
-                } else if (std.mem.eql(u8, key, "name")) {
-                    name = value;
-                } else if (std.mem.eql(u8, key, "created_at")) {
-                    created_at = std.fmt.parseInt(i64, value, 10) catch 0;
-                } else if (std.mem.eql(u8, key, "modified_at")) {
-                    modified_at = std.fmt.parseInt(i64, value, 10) catch 0;
-                } else if (std.mem.eql(u8, key, "description")) {
-                    description = value;
-                }
-            }
-        }
-
-        // Close existing project
-        if (self.current_project) |project| {
-            project.deinit();
-        }
-
-        // Create new project with loaded data
+        // Build the project up front so its arena owns every string we parse
+        // into. Bail and tear it down on error so we don't leak.
         const project = try self.allocator.create(Project);
+        errdefer self.allocator.destroy(project);
+
+        const arena = try self.allocator.create(std.heap.ArenaAllocator);
+        errdefer self.allocator.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(self.allocator);
+        errdefer arena.deinit();
+
+        const arena_alloc = arena.allocator();
+        const source = try arena_alloc.dupeZ(u8, raw);
+
+        var diag: std.zon.parse.Diagnostics = .{};
+        defer diag.deinit(arena_alloc);
+        const parsed = try std.zon.parse.fromSlice(ProjectConfig, arena_alloc, source, &diag, .{});
+
         project.* = .{
             .allocator = self.allocator,
-            .path = try self.allocator.dupe(u8, path),
-            .metadata = .{
-                .version = version,
-                .name = try self.allocator.dupe(u8, name),
-                .created_at = created_at,
-                .modified_at = modified_at,
-                .description = if (description.len > 0)
-                    try self.allocator.dupe(u8, description)
-                else
-                    "",
-            },
+            .arena = arena,
+            .dir = try arena_alloc.dupe(u8, dir_path),
+            .config = parsed,
             .is_dirty = false,
         };
 
+        if (self.current_project) |old| old.deinit();
         self.current_project = project;
-
-        std.debug.print("Project loaded: {s}\n", .{project.metadata.name});
     }
 
     pub fn closeProject(self: *Self) void {
@@ -240,16 +214,51 @@ pub const ProjectManager = struct {
     }
 
     pub fn hasUnsavedChanges(self: *const Self) bool {
-        if (self.current_project) |project| {
-            return project.is_dirty;
-        }
+        if (self.current_project) |project| return project.is_dirty;
         return false;
     }
 
     pub fn getProjectName(self: *const Self) ?[]const u8 {
-        if (self.current_project) |project| {
-            return project.metadata.name;
-        }
+        if (self.current_project) |project| return project.config.name;
         return null;
     }
 };
+
+/// Format a `ProjectConfig` as ZON source matching `labelle-assembler`'s
+/// expected schema. Omits fields the assembler can default so the file
+/// stays minimal and hand-editable.
+fn renderProjectLabelle(allocator: std.mem.Allocator, cfg: ProjectConfig) ![]u8 {
+    const title = if (cfg.title.len > 0) cfg.title else cfg.name;
+    return std.fmt.allocPrint(allocator,
+        \\.{{
+        \\    .name = "{s}",
+        \\    .description = "{s}",
+        \\    .title = "{s}",
+        \\    .width = {d},
+        \\    .height = {d},
+        \\    .target_fps = {d},
+        \\    .backend = .{s},
+        \\    .ecs = .{s},
+        \\    .initial_scene = "{s}",
+        \\    .core_version = "{s}",
+        \\    .engine_version = "{s}",
+        \\    .gfx_version = "{s}",
+        \\    .assembler_version = "{s}",
+        \\}}
+        \\
+    , .{
+        cfg.name,
+        cfg.description,
+        title,
+        cfg.width,
+        cfg.height,
+        cfg.target_fps,
+        @tagName(cfg.backend),
+        @tagName(cfg.ecs),
+        cfg.initial_scene,
+        cfg.core_version,
+        cfg.engine_version,
+        cfg.gfx_version,
+        cfg.assembler_version,
+    });
+}

--- a/src/project.zig
+++ b/src/project.zig
@@ -312,12 +312,23 @@ fn extractUnmodeledFields(arena: std.mem.Allocator, raw: []const u8) ![]const []
     errdefer out.deinit(arena);
 
     while (i < raw.len) {
-        skipWsAndComments(raw, &i);
+        // Mark the start of this field's "block" *before* skipping
+        // leading whitespace + comments. We then skip past whitespace
+        // (so blank lines between fields don't accumulate) and any
+        // `//` comment lines, landing on the field's `.`. The captured
+        // block runs from this marker through the field value — so any
+        // comments directly above an unmodeled field travel with it,
+        // not lost between save / load cycles.
+        const block_start = i;
+        skipWhitespace(raw, &i);
+        while (i + 1 < raw.len and raw[i] == '/' and raw[i + 1] == '/') {
+            while (i < raw.len and raw[i] != '\n') i += 1;
+            skipWhitespace(raw, &i);
+        }
         if (i >= raw.len) break;
         if (raw[i] == '}') break;
         if (raw[i] != '.') break; // unexpected; stop rather than mis-parse
 
-        const field_start = i;
         i += 1; // past '.'
         const name_start = i;
         while (i < raw.len) : (i += 1) {
@@ -346,12 +357,27 @@ fn extractUnmodeledFields(arena: std.mem.Allocator, raw: []const u8) ![]const []
         }
 
         if (!isManaged(name)) {
-            const trimmed = std.mem.trimRight(u8, raw[field_start..field_end], " \t\r\n");
-            const text = try arena.dupe(u8, trimmed);
-            try out.append(arena, text);
+            // Trim outer whitespace but keep internal newlines so a
+            // multi-line `// comment\n.field = .{ ... }` block stays
+            // visually intact. The renderer prepends `"    "` to the
+            // first line; subsequent lines retain their original
+            // indentation from the source.
+            const trimmed = std.mem.trim(u8, raw[block_start..field_end], " \t\r\n");
+            if (trimmed.len > 0) {
+                const text = try arena.dupe(u8, trimmed);
+                try out.append(arena, text);
+            }
         }
     }
     return out.toOwnedSlice(arena);
+}
+
+fn skipWhitespace(raw: []const u8, i: *usize) void {
+    while (i.* < raw.len) {
+        const c = raw[i.*];
+        if (c != ' ' and c != '\t' and c != '\n' and c != '\r') break;
+        i.* += 1;
+    }
 }
 
 fn skipWsAndComments(raw: []const u8, i: *usize) void {

--- a/src/project.zig
+++ b/src/project.zig
@@ -196,7 +196,10 @@ pub const ProjectManager = struct {
         const file_path = try std.fs.path.join(self.allocator, &.{ dir_path, PROJECT_FILENAME });
         defer self.allocator.free(file_path);
 
-        const raw = try std.fs.cwd().readFileAlloc(self.allocator, file_path, 1024 * 1024);
+        // 16 MB cap is overkill for project.labelle (real ones are <10 KB)
+        // but the bot reviewer flagged 1 MB as too tight for "robustness";
+        // bumping it costs nothing and removes the question.
+        const raw = try std.fs.cwd().readFileAlloc(self.allocator, file_path, 16 * 1024 * 1024);
         defer self.allocator.free(raw);
 
         // Build the project up front so its arena owns every string we parse

--- a/src/project.zig
+++ b/src/project.zig
@@ -202,9 +202,23 @@ pub const ProjectManager = struct {
         const arena_alloc = arena.allocator();
         const source = try arena_alloc.dupeZ(u8, raw);
 
+        // Real-world project.labelle files (e.g. ../flying-platform-labelle/)
+        // carry fields the assembler models that we don't yet — states,
+        // layers, plugins, gui, ios, android, labelle_version, hidden.
+        // Default ZON parsing rejects unknown fields, so we'd refuse to
+        // open any project that wasn't created by this gui. Tolerant
+        // parse lets the user open them and edit the fields we *do*
+        // know — at the cost of dropping the unknown ones on Save.
+        // Saving an externally-authored project is therefore unsafe;
+        // the editor needs full pass-through before we lift that caveat.
         var diag: std.zon.parse.Diagnostics = .{};
         defer diag.deinit(arena_alloc);
-        const parsed = try std.zon.parse.fromSlice(ProjectConfig, arena_alloc, source, &diag, .{});
+        const parsed = std.zon.parse.fromSlice(ProjectConfig, arena_alloc, source, &diag, .{
+            .ignore_unknown_fields = true,
+        }) catch |err| {
+            std.log.err("project.labelle parse failed at {s}: {s}", .{ file_path, @errorName(err) });
+            return err;
+        };
 
         project.* = .{
             .allocator = self.allocator,

--- a/src/smoke.zig
+++ b/src/smoke.zig
@@ -11,9 +11,19 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
+    // Honor $TMPDIR (set on macOS by default, and respected on most Unix
+    // shells); fall back to /tmp. Windows isn't a target for this smoke
+    // runner but anyone can `set TMPDIR=...` before invoking if needed.
+    const tmp_base = std.process.getEnvVarOwned(allocator, "TMPDIR") catch try allocator.dupe(u8, "/tmp");
+    defer allocator.free(tmp_base);
     var prng = std.Random.DefaultPrng.init(@intCast(std.time.nanoTimestamp()));
-    var tmp_buf: [64]u8 = undefined;
-    const tmp = try std.fmt.bufPrint(&tmp_buf, "/tmp/labelle_gui_smoke_{x}", .{prng.random().int(u64)});
+    const dir_name = try std.fmt.allocPrint(allocator, "labelle_gui_smoke_{x}", .{prng.random().int(u64)});
+    defer allocator.free(dir_name);
+    const tmp = try std.fs.path.join(allocator, &.{
+        std.mem.trimRight(u8, tmp_base, "/\\"),
+        dir_name,
+    });
+    defer allocator.free(tmp);
     try std.fs.cwd().makePath(tmp);
     defer std.fs.cwd().deleteTree(tmp) catch {};
 

--- a/src/smoke.zig
+++ b/src/smoke.zig
@@ -1,0 +1,75 @@
+//! End-to-end smoke check for the project.labelle writer + Compiler launcher
+//! invocation. Creates a temp project via ProjectManager, then runs
+//! Compiler.launcherGenerate against it and reports pass/fail.
+
+const std = @import("std");
+const project = @import("project.zig");
+const compiler = @import("compiler.zig");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var prng = std.Random.DefaultPrng.init(@intCast(std.time.nanoTimestamp()));
+    var tmp_buf: [64]u8 = undefined;
+    const tmp = try std.fmt.bufPrint(&tmp_buf, "/tmp/labelle_gui_smoke_{x}", .{prng.random().int(u64)});
+    try std.fs.cwd().makePath(tmp);
+    defer std.fs.cwd().deleteTree(tmp) catch {};
+
+    var pm = project.ProjectManager.init(allocator);
+    defer pm.deinit();
+    try pm.newProject("smoke_via_gui");
+    try pm.saveProject(tmp);
+
+    std.log.info("wrote project at {s}", .{tmp});
+
+    var comp = compiler.Compiler.init(allocator);
+    defer comp.deinit();
+
+    var result = comp.launcherGenerate(pm.current_project.?) catch |err| {
+        std.log.err("launcherGenerate raised: {s}", .{@errorName(err)});
+        if (err == error.LauncherNotFound) {
+            std.log.err("  `labelle` not on PATH. Install via https://labelle.games or add ~/.labelle/bin to PATH.", .{});
+        }
+        std.process.exit(1);
+    };
+    defer result.deinit(allocator);
+
+    if (result.errors.len > 0) std.log.info("stderr:\n{s}", .{result.errors});
+    if (result.output.len > 0) std.log.info("stdout:\n{s}", .{result.output});
+
+    if (!result.success) {
+        std.log.err("launcher exited with non-zero status", .{});
+        std.process.exit(1);
+    }
+
+    // Verify the .labelle/<target>/ tree exists.
+    const expected = try std.fs.path.join(allocator, &.{ tmp, ".labelle", "raylib_desktop" });
+    defer allocator.free(expected);
+    var dir = std.fs.cwd().openDir(expected, .{}) catch |err| {
+        std.log.err("expected target dir not found: {s} ({s})", .{ expected, @errorName(err) });
+        std.process.exit(1);
+    };
+    dir.close();
+
+    std.log.info("generate OK — verifying full build...", .{});
+
+    // Now exercise the spawn-and-poll path that main.zig uses.
+    try comp.build(pm.current_project.?);
+    var build_result = while (true) {
+        if (comp.pollBuild()) |r| break r;
+        std.Thread.sleep(50 * std.time.ns_per_ms);
+    };
+    defer build_result.deinit(allocator);
+
+    if (build_result.errors.len > 0) std.log.info("build stderr:\n{s}", .{build_result.errors});
+    if (build_result.output.len > 0) std.log.info("build stdout:\n{s}", .{build_result.output});
+
+    if (!build_result.success) {
+        std.log.err("`labelle build` failed", .{});
+        std.process.exit(1);
+    }
+
+    std.log.info("SMOKE OK — generate + build via launcher succeeded", .{});
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5,6 +5,7 @@ const expect = zspec.expect;
 const project = @import("project.zig");
 const tree_view = @import("tree_view.zig");
 const compiler = @import("compiler.zig");
+const new_scene = @import("dialogs/new_scene.zig");
 
 test {
     zspec.runAll(@This());
@@ -272,6 +273,45 @@ pub const CompilerStateTests = struct {
 
 /// End-to-end tests for save → load → folder scaffold of the assembler-compatible
 /// `project.labelle` file. These do real filesystem work in /tmp.
+pub const SceneTemplateTests = struct {
+    test "renders scene name into .name field" {
+        const allocator = std.testing.allocator;
+        const out = try new_scene.renderSceneZon(allocator, "my_scene");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, ".name = \"my_scene\"") != null);
+    }
+
+    test "includes an entities block" {
+        const allocator = std.testing.allocator;
+        const out = try new_scene.renderSceneZon(allocator, "anything");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, ".entities = ") != null);
+    }
+
+    test "rendered template parses as ZON with name + entities" {
+        const allocator = std.testing.allocator;
+        const out = try new_scene.renderSceneZon(allocator, "parse_check");
+        defer allocator.free(out);
+
+        const source = try allocator.dupeZ(u8, out);
+        defer allocator.free(source);
+
+        const SceneSchema = struct {
+            name: []const u8,
+            scripts: []const []const u8 = &.{},
+            entities: []const struct {} = &.{},
+        };
+
+        var diag: std.zon.parse.Diagnostics = .{};
+        defer diag.deinit(allocator);
+        const parsed = try std.zon.parse.fromSlice(SceneSchema, allocator, source, &diag, .{});
+        defer std.zon.parse.free(allocator, parsed);
+
+        try expect.toBeTrue(std.mem.eql(u8, parsed.name, "parse_check"));
+        try expect.equal(parsed.entities.len, 0);
+    }
+};
+
 pub const ProjectFileTests = struct {
     fn createTempDir(allocator: std.mem.Allocator) ![]const u8 {
         const tmp_base = "/tmp";

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -617,6 +617,44 @@ pub const ProjectFileTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, pm2.current_project.?.config.name, "x"));
     }
 
+    test "saveProject preserves comments attached to unmodeled fields" {
+        // The flying-platform regression: comments directly above an
+        // unmodeled field must travel with it through save/load.
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        const labelle_path = try std.fs.path.join(allocator, &.{ temp_dir, "project.labelle" });
+        defer allocator.free(labelle_path);
+
+        const original =
+            \\.{
+            \\    .name = "x",
+            \\    .initial_scene = "loading",
+            \\    // Loading scene runs first; controller swaps to main
+            \\    // once the manifest is ready.
+            \\    .states = .{ "loading", "playing" },
+            \\}
+            \\
+        ;
+        const file = try std.fs.cwd().createFile(labelle_path, .{});
+        file.writeAll(original) catch unreachable;
+        file.close();
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.loadProject(temp_dir);
+        try pm.saveProject(temp_dir);
+
+        const reread = try std.fs.cwd().openFile(labelle_path, .{});
+        defer reread.close();
+        const saved = try reread.readToEndAlloc(allocator, 1024 * 1024);
+        defer allocator.free(saved);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, "// Loading scene runs first; controller swaps to main") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, "// once the manifest is ready.") != null);
+    }
+
     test "saveProject keeps extras when a modeled field changes" {
         // Editing .title via the gui must not collateral-damage .states/.gui.
         const allocator = std.testing.allocator;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -401,6 +401,61 @@ pub const ProjectFileTests = struct {
         try expect.toBeFalse(pm.current_project.?.is_dirty);
     }
 
+    test "saveProject omits empty resources block" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.newProject("no_resources");
+        try pm.saveProject(temp_dir);
+
+        const labelle_path = try std.fs.path.join(allocator, &.{ temp_dir, "project.labelle" });
+        defer allocator.free(labelle_path);
+        const file = try std.fs.cwd().openFile(labelle_path, .{});
+        defer file.close();
+        const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+        defer allocator.free(content);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, content, ".resources") == null);
+    }
+
+    test "resources round-trip through save + load" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        // Build a project with one resource directly via the arena so
+        // the slice is owned correctly. Save then reload via a fresh
+        // ProjectManager and assert the resource came back intact.
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.newProject("with_resources");
+
+        const proj = pm.current_project.?;
+        const a = proj.arena.allocator();
+        const resources = try a.alloc(project.ResourceDef, 1);
+        resources[0] = .{
+            .name = try a.dupe(u8, "sprites"),
+            .json = try a.dupe(u8, "assets/sprites.json"),
+            .texture = try a.dupe(u8, "assets/sprites.png"),
+        };
+        proj.config.resources = resources;
+
+        try pm.saveProject(temp_dir);
+
+        var pm2 = project.ProjectManager.init(allocator);
+        defer pm2.deinit();
+        try pm2.loadProject(temp_dir);
+
+        const loaded = pm2.current_project.?.config.resources;
+        try expect.equal(loaded.len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, loaded[0].name, "sprites"));
+        try expect.toBeTrue(std.mem.eql(u8, loaded[0].json, "assets/sprites.json"));
+        try expect.toBeTrue(std.mem.eql(u8, loaded[0].texture, "assets/sprites.png"));
+    }
+
     test "loadProject round-trips a saved project" {
         const allocator = std.testing.allocator;
         const temp_dir = try createTempDir(allocator);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -274,41 +274,55 @@ pub const CompilerStateTests = struct {
 /// End-to-end tests for save → load → folder scaffold of the assembler-compatible
 /// `project.labelle` file. These do real filesystem work in /tmp.
 pub const SceneTemplateTests = struct {
-    test "renders scene name into .name field" {
-        const allocator = std.testing.allocator;
-        const out = try new_scene.renderSceneZon(allocator, "my_scene");
-        defer allocator.free(out);
-        try expect.toBeTrue(std.mem.indexOf(u8, out, ".name = \"my_scene\"") != null);
+    /// Strip `//`-to-end-of-line comments so the JSONC template can be
+    /// fed to std.json (which doesn't accept comments). Replaces the
+    /// comment bytes with spaces so column/line offsets — and therefore
+    /// any later parser diagnostics — match the original.
+    fn stripLineComments(allocator: std.mem.Allocator, src: []const u8) ![]u8 {
+        const out = try allocator.dupe(u8, src);
+        var i: usize = 0;
+        while (i + 1 < out.len) : (i += 1) {
+            if (out[i] == '/' and out[i + 1] == '/') {
+                var j = i;
+                while (j < out.len and out[j] != '\n') : (j += 1) out[j] = ' ';
+                i = j;
+            }
+        }
+        return out;
     }
 
-    test "includes an entities block" {
+    test "renders scene name into name field" {
         const allocator = std.testing.allocator;
-        const out = try new_scene.renderSceneZon(allocator, "anything");
+        const out = try new_scene.renderSceneJsonc(allocator, "my_scene");
         defer allocator.free(out);
-        try expect.toBeTrue(std.mem.indexOf(u8, out, ".entities = ") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "\"name\": \"my_scene\"") != null);
     }
 
-    test "rendered template parses as ZON with name + entities" {
+    test "includes an entities array" {
         const allocator = std.testing.allocator;
-        const out = try new_scene.renderSceneZon(allocator, "parse_check");
+        const out = try new_scene.renderSceneJsonc(allocator, "anything");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "\"entities\":") != null);
+    }
+
+    test "uses .jsonc-compatible content (parses as JSON after stripping comments)" {
+        const allocator = std.testing.allocator;
+        const out = try new_scene.renderSceneJsonc(allocator, "parse_check");
         defer allocator.free(out);
 
-        const source = try allocator.dupeZ(u8, out);
-        defer allocator.free(source);
+        const stripped = try stripLineComments(allocator, out);
+        defer allocator.free(stripped);
 
         const SceneSchema = struct {
             name: []const u8,
-            scripts: []const []const u8 = &.{},
             entities: []const struct {} = &.{},
         };
 
-        var diag: std.zon.parse.Diagnostics = .{};
-        defer diag.deinit(allocator);
-        const parsed = try std.zon.parse.fromSlice(SceneSchema, allocator, source, &diag, .{});
-        defer std.zon.parse.free(allocator, parsed);
+        const parsed = try std.json.parseFromSlice(SceneSchema, allocator, stripped, .{ .ignore_unknown_fields = true });
+        defer parsed.deinit();
 
-        try expect.toBeTrue(std.mem.eql(u8, parsed.name, "parse_check"));
-        try expect.equal(parsed.entities.len, 0);
+        try expect.toBeTrue(std.mem.eql(u8, parsed.value.name, "parse_check"));
+        try expect.equal(parsed.value.entities.len, 0);
     }
 };
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -456,6 +456,93 @@ pub const ProjectFileTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, loaded[0].texture, "assets/sprites.png"));
     }
 
+    // Regression: ../flying-platform-labelle/project.labelle (and any
+    // project authored by the assembler / CLI) carries fields like
+    // `states`, `layers`, `plugins`, `gui`, `labelle_version`, etc. that
+    // our minimal ProjectConfig doesn't model. Default ZON parsing
+    // rejects unknown fields, which made every real project fail to
+    // open. Load must tolerate those fields and recover the ones we do
+    // model.
+    test "loadProject ignores unknown ZON fields" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        const labelle_path = try std.fs.path.join(allocator, &.{ temp_dir, "project.labelle" });
+        defer allocator.free(labelle_path);
+
+        // Hand-written project.labelle mimicking what flying-platform
+        // and the assembler examples ship: every modeled field plus a
+        // representative set of unmodeled ones.
+        const synthetic =
+            \\.{
+            \\    .name = "external_project",
+            \\    .title = "External",
+            \\    .width = 1024,
+            \\    .height = 768,
+            \\    .target_fps = 60,
+            \\    .backend = .sokol,
+            \\    .ecs = .zig_ecs,
+            \\    .initial_scene = "loading",
+            \\    .states = .{ "loading", "playing" },
+            \\    .gui = .{ .plugin = "imgui" },
+            \\    .resources = .{
+            \\        .{ .name = "sprites", .json = "assets/sprites.json", .texture = "assets/sprites.png" },
+            \\    },
+            \\    .plugins = .{
+            \\        .{ .name = "imgui", .repo = "local:../labelle-imgui" },
+            \\    },
+            \\    .layers = .{
+            \\        .{ .name = "world", .order = 0, .space = .world },
+            \\    },
+            \\    .core_version = "1.10.0",
+            \\    .engine_version = "1.21.0",
+            \\    .gfx_version = "1.7.0",
+            \\    .labelle_version = "1.36.0",
+            \\    .assembler_version = "0.8.0",
+            \\    .hidden = false,
+            \\}
+            \\
+        ;
+        const file = try std.fs.cwd().createFile(labelle_path, .{});
+        file.writeAll(synthetic) catch unreachable;
+        file.close();
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.loadProject(temp_dir);
+
+        const cfg = pm.current_project.?.config;
+        try expect.toBeTrue(std.mem.eql(u8, cfg.name, "external_project"));
+        try expect.equal(cfg.backend, .sokol);
+        try expect.equal(cfg.ecs, .zig_ecs);
+        try expect.toBeTrue(std.mem.eql(u8, cfg.initial_scene, "loading"));
+        try expect.equal(cfg.resources.len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, cfg.resources[0].name, "sprites"));
+    }
+
+    test "loadProject still errors on malformed ZON" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        const labelle_path = try std.fs.path.join(allocator, &.{ temp_dir, "project.labelle" });
+        defer allocator.free(labelle_path);
+
+        // Unbalanced braces — syntactically invalid ZON, not just an
+        // unknown field. ignore_unknown_fields must not mask this.
+        const broken = ".{ .name = \"oops\",";
+        const file = try std.fs.cwd().createFile(labelle_path, .{});
+        file.writeAll(broken) catch unreachable;
+        file.close();
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+
+        const got = pm.loadProject(temp_dir);
+        try expect.toBeTrue(std.meta.isError(got));
+    }
+
     test "loadProject round-trips a saved project" {
         const allocator = std.testing.allocator;
         const temp_dir = try createTempDir(allocator);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10,23 +10,27 @@ test {
     zspec.runAll(@This());
 }
 
-pub const ProjectMetadataTests = struct {
-    test "has correct default version" {
-        const metadata = project.ProjectMetadata{
-            .name = "test",
-            .created_at = 0,
-            .modified_at = 0,
-        };
-        try expect.equal(metadata.version, project.PROJECT_VERSION);
+pub const ProjectConfigTests = struct {
+    test "defaults to raylib backend" {
+        const cfg = project.ProjectConfig{ .name = "test" };
+        try expect.equal(cfg.backend, .raylib);
     }
 
-    test "has empty description by default" {
-        const metadata = project.ProjectMetadata{
-            .name = "test",
-            .created_at = 0,
-            .modified_at = 0,
-        };
-        try expect.equal(metadata.description.len, 0);
+    test "defaults to zig_ecs" {
+        const cfg = project.ProjectConfig{ .name = "test" };
+        try expect.equal(cfg.ecs, .zig_ecs);
+    }
+
+    test "defaults to 800x600 at 60fps" {
+        const cfg = project.ProjectConfig{ .name = "test" };
+        try expect.equal(cfg.width, 800);
+        try expect.equal(cfg.height, 600);
+        try expect.equal(cfg.target_fps, 60);
+    }
+
+    test "defaults initial_scene to main" {
+        const cfg = project.ProjectConfig{ .name = "test" };
+        try expect.toBeTrue(std.mem.eql(u8, cfg.initial_scene, "main"));
     }
 };
 
@@ -77,7 +81,7 @@ pub const ProjectTests = struct {
         const proj = try project.Project.create(allocator, "TestProject");
         defer proj.deinit();
 
-        try expect.toBeTrue(std.mem.eql(u8, proj.metadata.name, "TestProject"));
+        try expect.toBeTrue(std.mem.eql(u8, proj.config.name, "TestProject"));
     }
 
     test "is marked dirty on creation" {
@@ -88,12 +92,12 @@ pub const ProjectTests = struct {
         try expect.toBeTrue(proj.is_dirty);
     }
 
-    test "has no path on creation" {
+    test "has no dir on creation" {
         const allocator = std.testing.allocator;
         const proj = try project.Project.create(allocator, "TestProject");
         defer proj.deinit();
 
-        try expect.toBeTrue(proj.path == null);
+        try expect.toBeTrue(proj.dir == null);
     }
 };
 
@@ -147,12 +151,8 @@ pub const ProjectManagerTests = struct {
 };
 
 pub const ConstantsTests = struct {
-    test "PROJECT_EXTENSION is .labelle" {
-        try expect.toBeTrue(std.mem.eql(u8, project.PROJECT_EXTENSION, ".labelle"));
-    }
-
-    test "PROJECT_VERSION is 1" {
-        try expect.equal(project.PROJECT_VERSION, 1);
+    test "PROJECT_FILENAME is project.labelle" {
+        try expect.toBeTrue(std.mem.eql(u8, project.PROJECT_FILENAME, "project.labelle"));
     }
 };
 
@@ -270,13 +270,13 @@ pub const CompilerStateTests = struct {
     }
 };
 
-/// System tests for end-to-end project compilation
-pub const ProjectCompilationTests = struct {
+/// End-to-end tests for save → load → folder scaffold of the assembler-compatible
+/// `project.labelle` file. These do real filesystem work in /tmp.
+pub const ProjectFileTests = struct {
     fn createTempDir(allocator: std.mem.Allocator) ![]const u8 {
         const tmp_base = "/tmp";
-        const timestamp = std.time.timestamp();
-        const dir_name = try std.fmt.allocPrint(allocator, "{s}/labelle_test_{d}", .{ tmp_base, timestamp });
-
+        const ts = std.time.nanoTimestamp();
+        const dir_name = try std.fmt.allocPrint(allocator, "{s}/labelle_test_{d}", .{ tmp_base, ts });
         try std.fs.cwd().makeDir(dir_name);
         return dir_name;
     }
@@ -286,204 +286,42 @@ pub const ProjectCompilationTests = struct {
         allocator.free(dir_path);
     }
 
-    test "generates valid build.zig" {
+    test "saveProject writes project.labelle in the directory" {
         const allocator = std.testing.allocator;
-
-        // Create temp directory
         const temp_dir = try createTempDir(allocator);
         defer deleteTempDir(allocator, temp_dir);
 
-        // Create project
         var pm = project.ProjectManager.init(allocator);
         defer pm.deinit();
-
         try pm.newProject("test_project");
+        try pm.saveProject(temp_dir);
 
-        // Save project to temp directory
-        const project_path = try std.fmt.allocPrint(allocator, "{s}/project", .{temp_dir});
-        defer allocator.free(project_path);
+        const labelle_path = try std.fs.path.join(allocator, &.{ temp_dir, "project.labelle" });
+        defer allocator.free(labelle_path);
 
-        try pm.saveProject(project_path);
-
-        // Generate build files
-        var comp = compiler.Compiler.init(allocator);
-        defer comp.deinit();
-
-        try comp.generateAllBuildFiles(pm.current_project.?);
-
-        // Verify build.zig exists
-        const build_zig_path = try std.fmt.allocPrint(allocator, "{s}/build.zig", .{temp_dir});
-        defer allocator.free(build_zig_path);
-
-        const build_zig = try std.fs.cwd().openFile(build_zig_path, .{});
-        defer build_zig.close();
-
-        const content = try build_zig.readToEndAlloc(allocator, 1024 * 1024);
+        const file = try std.fs.cwd().openFile(labelle_path, .{});
+        defer file.close();
+        const content = try file.readToEndAlloc(allocator, 1024 * 1024);
         defer allocator.free(content);
 
-        // Verify key parts of build.zig
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "labelle_engine") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "labelle-gfx") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "zig_ecs") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "main.zig") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, content, ".name = \"test_project\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, content, ".backend = .raylib") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, content, ".ecs = .zig_ecs") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, content, ".initial_scene = \"main\"") != null);
     }
 
-    test "generates valid build.zig.zon with fingerprint" {
+    test "saveProject creates scaffold folders" {
         const allocator = std.testing.allocator;
-
-        // Create temp directory
         const temp_dir = try createTempDir(allocator);
         defer deleteTempDir(allocator, temp_dir);
 
-        // Create project
         var pm = project.ProjectManager.init(allocator);
         defer pm.deinit();
-
         try pm.newProject("test_project");
+        try pm.saveProject(temp_dir);
 
-        // Save project
-        const project_path = try std.fmt.allocPrint(allocator, "{s}/project", .{temp_dir});
-        defer allocator.free(project_path);
-
-        try pm.saveProject(project_path);
-
-        // Generate build files
-        var comp = compiler.Compiler.init(allocator);
-        defer comp.deinit();
-
-        try comp.generateAllBuildFiles(pm.current_project.?);
-
-        // Verify build.zig.zon exists and has correct content
-        const zon_path = try std.fmt.allocPrint(allocator, "{s}/build.zig.zon", .{temp_dir});
-        defer allocator.free(zon_path);
-
-        const zon_file = try std.fs.cwd().openFile(zon_path, .{});
-        defer zon_file.close();
-
-        const content = try zon_file.readToEndAlloc(allocator, 1024 * 1024);
-        defer allocator.free(content);
-
-        // Verify key parts of build.zig.zon
-        try expect.toBeTrue(std.mem.indexOf(u8, content, ".fingerprint") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, ".name = .test_project") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "labelle_engine") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "labelle-gfx") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "zig_ecs") != null);
-        // Verify hashes are present
-        try expect.toBeTrue(std.mem.indexOf(u8, content, ".hash = ") != null);
-    }
-
-    test "generates main.zig with Game facade" {
-        const allocator = std.testing.allocator;
-
-        // Create temp directory
-        const temp_dir = try createTempDir(allocator);
-        defer deleteTempDir(allocator, temp_dir);
-
-        // Create project
-        var pm = project.ProjectManager.init(allocator);
-        defer pm.deinit();
-
-        try pm.newProject("test_project");
-
-        // Save project
-        const project_path = try std.fmt.allocPrint(allocator, "{s}/project", .{temp_dir});
-        defer allocator.free(project_path);
-
-        try pm.saveProject(project_path);
-
-        // Generate build files
-        var comp = compiler.Compiler.init(allocator);
-        defer comp.deinit();
-
-        try comp.generateAllBuildFiles(pm.current_project.?);
-
-        // Verify main.zig exists at root (not in src/)
-        const main_path = try std.fmt.allocPrint(allocator, "{s}/main.zig", .{temp_dir});
-        defer allocator.free(main_path);
-
-        const main_file = try std.fs.cwd().openFile(main_path, .{});
-        defer main_file.close();
-
-        const content = try main_file.readToEndAlloc(allocator, 1024 * 1024);
-        defer allocator.free(content);
-
-        // Verify main.zig uses Game facade
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "engine.Game.init") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "ComponentRegistry") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "SceneLoader") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, "scenes/main.zon") != null);
-    }
-
-    test "generates scene .zon file" {
-        const allocator = std.testing.allocator;
-
-        // Create temp directory
-        const temp_dir = try createTempDir(allocator);
-        defer deleteTempDir(allocator, temp_dir);
-
-        // Create project
-        var pm = project.ProjectManager.init(allocator);
-        defer pm.deinit();
-
-        try pm.newProject("test_project");
-
-        // Save project
-        const project_path = try std.fmt.allocPrint(allocator, "{s}/project", .{temp_dir});
-        defer allocator.free(project_path);
-
-        try pm.saveProject(project_path);
-
-        // Generate build files
-        var comp = compiler.Compiler.init(allocator);
-        defer comp.deinit();
-
-        try comp.generateAllBuildFiles(pm.current_project.?);
-
-        // Verify main.zon scene exists
-        const scene_path = try std.fmt.allocPrint(allocator, "{s}/scenes/main.zon", .{temp_dir});
-        defer allocator.free(scene_path);
-
-        const scene_file = try std.fs.cwd().openFile(scene_path, .{});
-        defer scene_file.close();
-
-        const content = try scene_file.readToEndAlloc(allocator, 1024 * 1024);
-        defer allocator.free(content);
-
-        // Verify scene has valid structure
-        try expect.toBeTrue(std.mem.indexOf(u8, content, ".name = ") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, ".entities = ") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, content, ".shape = ") != null);
-    }
-
-    test "creates project folder structure" {
-        const allocator = std.testing.allocator;
-
-        // Create temp directory
-        const temp_dir = try createTempDir(allocator);
-        defer deleteTempDir(allocator, temp_dir);
-
-        // Create project
-        var pm = project.ProjectManager.init(allocator);
-        defer pm.deinit();
-
-        try pm.newProject("test_project");
-
-        // Save project
-        const project_path = try std.fmt.allocPrint(allocator, "{s}/project", .{temp_dir});
-        defer allocator.free(project_path);
-
-        try pm.saveProject(project_path);
-
-        // Generate build files
-        var comp = compiler.Compiler.init(allocator);
-        defer comp.deinit();
-
-        try comp.generateAllBuildFiles(pm.current_project.?);
-
-        // Verify folder structure matches ProjectFolders.all
         for (project.ProjectFolders.all) |folder| {
-            const folder_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ temp_dir, folder });
+            const folder_path = try std.fs.path.join(allocator, &.{ temp_dir, folder });
             defer allocator.free(folder_path);
 
             var dir = std.fs.cwd().openDir(folder_path, .{}) catch {
@@ -492,5 +330,42 @@ pub const ProjectCompilationTests = struct {
             };
             dir.close();
         }
+    }
+
+    test "saveProject stores directory on the project" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.newProject("test_project");
+        try pm.saveProject(temp_dir);
+
+        try expect.toBeTrue(pm.current_project.?.dir != null);
+        try expect.toBeTrue(std.mem.eql(u8, pm.current_project.?.dir.?, temp_dir));
+        try expect.toBeFalse(pm.current_project.?.is_dirty);
+    }
+
+    test "loadProject round-trips a saved project" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        {
+            var pm = project.ProjectManager.init(allocator);
+            defer pm.deinit();
+            try pm.newProject("round_trip");
+            try pm.saveProject(temp_dir);
+        }
+
+        var pm2 = project.ProjectManager.init(allocator);
+        defer pm2.deinit();
+        try pm2.loadProject(temp_dir);
+
+        try expect.toBeTrue(pm2.current_project != null);
+        try expect.toBeTrue(std.mem.eql(u8, pm2.current_project.?.config.name, "round_trip"));
+        try expect.equal(pm2.current_project.?.config.backend, .raylib);
+        try expect.equal(pm2.current_project.?.config.ecs, .zig_ecs);
     }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -521,6 +521,141 @@ pub const ProjectFileTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, cfg.resources[0].name, "sprites"));
     }
 
+    test "saveProject preserves unmodeled fields verbatim (round-trip)" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        const labelle_path = try std.fs.path.join(allocator, &.{ temp_dir, "project.labelle" });
+        defer allocator.free(labelle_path);
+
+        const original =
+            \\.{
+            \\    .name = "external_project",
+            \\    .title = "External",
+            \\    .width = 1024,
+            \\    .height = 768,
+            \\    .target_fps = 60,
+            \\    .backend = .sokol,
+            \\    .ecs = .zig_ecs,
+            \\    .initial_scene = "loading",
+            \\    .states = .{ "loading", "playing" },
+            \\    .gui = .{ .plugin = "imgui" },
+            \\    .plugins = .{
+            \\        .{ .name = "imgui", .repo = "local:../labelle-imgui" },
+            \\    },
+            \\    .layers = .{
+            \\        .{ .name = "world", .order = 0, .space = .world },
+            \\    },
+            \\    .core_version = "1.10.0",
+            \\    .engine_version = "1.21.0",
+            \\    .gfx_version = "1.7.0",
+            \\    .labelle_version = "1.36.0",
+            \\    .assembler_version = "0.8.0",
+            \\    .hidden = false,
+            \\}
+            \\
+        ;
+        const file = try std.fs.cwd().createFile(labelle_path, .{});
+        file.writeAll(original) catch unreachable;
+        file.close();
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.loadProject(temp_dir);
+        try pm.saveProject(temp_dir);
+
+        const reread = try std.fs.cwd().openFile(labelle_path, .{});
+        defer reread.close();
+        const saved = try reread.readToEndAlloc(allocator, 1024 * 1024);
+        defer allocator.free(saved);
+
+        // The five unmodeled fields must survive a save+load cycle.
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, ".states") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, ".gui") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, ".plugins") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, ".layers") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, ".labelle_version") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, ".hidden") != null);
+        // And the unmodeled struct literals must still be there.
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, "\"loading\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, "imgui") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, "local:../labelle-imgui") != null);
+    }
+
+    test "saveProject re-parses cleanly after extras round-trip" {
+        // Belt-and-suspenders: after save, loading the saved file again
+        // must succeed. Catches accidental syntax breakage in the
+        // verbatim-extras emission (missing commas, wrong braces, etc.).
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        const labelle_path = try std.fs.path.join(allocator, &.{ temp_dir, "project.labelle" });
+        defer allocator.free(labelle_path);
+
+        const original =
+            \\.{
+            \\    .name = "x",
+            \\    .states = .{ "menu", "playing" },
+            \\    .gui = .{ .plugin = "imgui" },
+            \\}
+            \\
+        ;
+        const file = try std.fs.cwd().createFile(labelle_path, .{});
+        file.writeAll(original) catch unreachable;
+        file.close();
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.loadProject(temp_dir);
+        try pm.saveProject(temp_dir);
+
+        var pm2 = project.ProjectManager.init(allocator);
+        defer pm2.deinit();
+        try pm2.loadProject(temp_dir);
+        try expect.toBeTrue(std.mem.eql(u8, pm2.current_project.?.config.name, "x"));
+    }
+
+    test "saveProject keeps extras when a modeled field changes" {
+        // Editing .title via the gui must not collateral-damage .states/.gui.
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        const labelle_path = try std.fs.path.join(allocator, &.{ temp_dir, "project.labelle" });
+        defer allocator.free(labelle_path);
+
+        const original =
+            \\.{
+            \\    .name = "x",
+            \\    .title = "Old Title",
+            \\    .states = .{ "menu" },
+            \\}
+            \\
+        ;
+        const file = try std.fs.cwd().createFile(labelle_path, .{});
+        file.writeAll(original) catch unreachable;
+        file.close();
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.loadProject(temp_dir);
+
+        const proj = pm.current_project.?;
+        proj.config.title = try proj.arena.allocator().dupe(u8, "New Title");
+
+        try pm.saveProject(temp_dir);
+
+        const reread = try std.fs.cwd().openFile(labelle_path, .{});
+        defer reread.close();
+        const saved = try reread.readToEndAlloc(allocator, 1024 * 1024);
+        defer allocator.free(saved);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, "\"New Title\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, saved, ".states") != null);
+    }
+
     test "loadProject still errors on malformed ZON" {
         const allocator = std.testing.allocator;
         const temp_dir = try createTempDir(allocator);


### PR DESCRIPTION
## Summary

Modernizes labelle-gui to integrate with the rest of the toolkit (assembler + launcher), introduces a compile-time module/panel system, and adds two functioning editors backed by ImGui Test Engine coverage. Touches issues #17, #19, #20, #21, #22.

### What changed

- **Build is now delegated to `labelle build/run`.** `compiler.zig` no longer hand-rolls `build.zig` / `build.zig.zon` / `main.zig` templates — the launcher handles cache priming, version resolution and fingerprint patching. The gui only writes `project.labelle`.
- **`project.labelle` is the project file.** Old `key=value` text format is gone; saved file is ZON, schema-compatible with `labelle-assembler/src/config.zig:ProjectConfig`. Open / Save dialogs switched from file pickers to folder pickers.
- **Module + Registry system (#22).** `src/module.zig` defines togglable panels; `App` holds a comptime Registry, View menu auto-builds from it. Each panel module is one file under `src/modules/`.
- **Project Settings editor.** First-class panel for editing name/title/dimensions/fps/backend/ecs/initial_scene/version pins. Save dupes into the project's arena and writes through the existing `ProjectManager.saveProject` path.
- **Resources editor (#20).** Adds `ResourceDef` + `ProjectConfig.resources`, with a panel for adding/removing/editing sprite-atlas entries. `renderProjectLabelle` becomes a streaming writer to emit the variable-length block.
- **Engine-compatible scene format (#21).** New Scene dialog writes `<name>.jsonc` in the shape labelle-engine expects (`name` / `entities` / optional `include`) instead of the old `.scene` TOML stub.
- **Resilient project.labelle load.** Tolerates unknown fields with `ignore_unknown_fields = true` (so external projects like `flying-platform-labelle` open) and preserves them verbatim across save via a hand-rolled top-level ZON scanner. Comments attached to unmodeled fields ride along too.
- **App refactor.** `main.zig` shrank from ~650 lines to ~110 — App holds the per-frame state and `renderFrame()` is the single entry point both the main loop and the TE harness call.
- **Dep pinning.** zig-gamedev deps pinned to pre-Zig-0.16 commits so the project builds on the toolkit's pinned Zig 0.15.2.

### Test coverage

| Target | Result |
|---|---|
| `zig build` | exit 0 |
| `zig build test` | **53/53** zspec |
| `zig build gui-test` | **4/4** ImGui Test Engine |
| `zig build smoke` | end-to-end against the real `labelle` launcher |

New regression tests pin every behavior we relied on:
- Scene template parses as JSONC after comment stripping (catches engine-load-time syntax breakage).
- `loadProject` tolerates unknown ZON fields (closes the "Error loading project" against external files).
- Unmodeled fields round-trip verbatim through save + load.
- Saved file re-parses cleanly (belt-and-suspenders against extras emission breaking syntax).
- Editing a managed field doesn't collateral-damage extras.
- Comments above unmodeled fields survive round-trip.

The TE harness also drives real menu actions:
- View > Compiler Output toggles `app.show_compiler_output` both directions.
- Project Settings: type into Title via `itemInputStrValue`, click Save, read `project.labelle` off disk and verify the change persisted.
- Resources: open panel, click Add, fill three inputs, click Save, verify the resource line is in the file.

### Live-verified

Round-trip against `../flying-platform-labelle/project.labelle` (most complex real-world file in the toolkit): all 14 unmodeled fields and the `// Loading scene runs first...` comment block survive.

### Known limitations (documented in CLAUDE.md)

- Comments above *managed* fields are dropped — preserving them would need top-level-order capture.
- Field order shifts: managed fields render first, extras after. Semantically equivalent, not byte-identical.
- Multi-line strings (`\\...`) and `'...'` char literals aren't handled in `scanValue` because the schema doesn't use them; easy to extend if needed.

## Test plan

- [ ] `zig build` — main exe links
- [ ] `zig build test` — 53/53 zspec
- [ ] `zig build gui-test` — 4/4 TE
- [ ] `zig build smoke` — end-to-end via `labelle` launcher (requires `labelle` on PATH)
- [ ] Open `../flying-platform-labelle/` in the gui, verify no parse error, Save, diff `project.labelle` — fields and comments should still be there