### PR TITLE
Scene editor as tabs opened from the project tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@ zig build smoke     # end-to-end against the real `labelle` launcher — env-dep
 | `src/main.zig` | GLFW init, window + GL context, font + DPI setup, frame loop. Delegates per-frame UI to `App.renderFrame()`. Stays slim on purpose. |
 | `src/app.zig` | `App` struct: owns `ProjectManager`, `Compiler`, `TreeView`, status bar, dialog state, and the `Module.Registry`. `App.renderFrame()` is the single function the test runner can call to drive the real UI. |
 | `src/module.zig` | `Module` and `Registry` (issue #22). Modules expose a togglable panel; the Registry renders the View menu and dispatches `render_panel(*App)` for every open module. Each module's `is_open` points into App state so the menu toggle and the panel's `popen` flag are the same memory. |
-| `src/modules/` | One file per togglable panel. Each exports `makeModule(*App) module.Module` and gets appended to `App.modules` in `App.init`. Current: `compiler_output`, `project_settings`, `project_tree`. |
-| `src/dialogs/` | Modal popups — transient, not part of the Registry because they're not togglable panels. Each exports `pub fn render(*App) void` called once per frame from `App.renderFrame`. Current: `new_scene`, `dpi_warning`. |
+| `src/modules/` | One file per togglable panel. Each exports `makeModule(*App) module.Module` and gets appended to `App.modules` in `App.init`. Current: `compiler_output`, `project_settings`, `project_tree`, `resources`. The Scene editor lives here too but is *not* registered as a togglable panel — it opens as a tab via tree-click. |
+| `src/dialogs/` | Modal popups — transient, not part of the Registry because they're not togglable panels. Each exports `pub fn render(*App) void` called once per frame from `App.renderFrame`. Current: `new_scene`, `dpi_warning`, `close_scene` (unsaved-tab confirmation). |
 | `src/project.zig` | `ProjectConfig` (mirrors a subset of `labelle-assembler/src/config.zig:ProjectConfig`), `ProjectManager`, `project.labelle` read/write. Each `Project` owns an `ArenaAllocator` so the parsed config strings free uniformly in `deinit`. |
 | `src/compiler.zig` | Wraps `labelle generate/build/run` as a child process. `syncProjectFiles` calls `ProjectManager.saveProject`. `buildOrRun` spawns; `pollBuild` waits and captures stdout/stderr. |
 | `src/tree_view.zig` | Project tree widget. |
@@ -70,6 +70,25 @@ Known limitations of the pass-through:
 1. **`project.labelle` must pin all four versions** — `core_version`, `engine_version`, `gfx_version`, `assembler_version`. The launcher's resolver falls back to its own version for missing fields (`labelle-cli/src/cli/cache.zig:29`: `cfg.assembler_version orelse cfg.labelle_version`), which 404s when CLI and assembler aren't lockstep. Defaults in `ProjectConfig` track `labelle-cli/versions.zon` and the CLI's own assembler pin.
 2. **Project = directory.** `Project.dir` holds the project directory; `<dir>/project.labelle` is the editable file. Open / Save dialogs use `nfd.openFolderDialog`, not file dialogs.
 3. **Don't reintroduce `build.zig` template generation.** The assembler owns that. If you find yourself writing build files from the gui, you're going the wrong direction.
+
+## Scene editor: tabs, not a panel
+
+The Scene editor isn't a togglable panel through the View menu. Instead:
+
+- The user clicks a `.jsonc` file in the Project Tree → `project_tree`
+  routes it through `App.openScene(path)` → a new `SceneState` is
+  appended to `App.open_scenes`.
+- The main content area renders a `TabBar` when `open_scenes.len > 0`;
+  each tab's body is `scene_mod.render(state, app)`.
+- The × close button on a dirty tab opens `dialogs/close_scene.zig`
+  (Save and close / Discard / Cancel) via `App.pending_close_idx`.
+- Project transitions (`ProjectManager.generation` change) trigger
+  `App.closeAllScenes` so the next frame doesn't read freed memory
+  belonging to the old project.
+
+Each `SceneState` carries its own arena (path + display name) and
+owns a `LoadedScene` (parsed-scene arena from `scene_io.parseScene`).
+`SceneState.deinit(allocator)` frees both.
 
 ## Adding a new module
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ src/
     project_settings.zig         # Edit ProjectConfig fields and persist via ProjectManager
     project_tree.zig             # Project sidebar (file tree)
     resources.zig                # Edit `resources` block (sprite atlases)
-    scene.zig                    # Scene viewer: file list + entity list + 2D viewport
+    scene.zig                    # Scene editor (per-tab state; opens via tree click, not View menu)
   dialogs/
     new_scene.zig                # New Scene modal + scene-file writer
     dpi_warning.zig              # One-shot DPI-changed warning modal
+    close_scene.zig              # Unsaved-scene "Save and close / Discard / Cancel" modal
   project.zig                    # ProjectConfig, ProjectManager, project.labelle ZON I/O
   scene_io.zig                   # JSONC scene loader (used by modules/scene.zig)
   compiler.zig                   # Launches `labelle generate/build/run` and polls the child

--- a/src/app.zig
+++ b/src/app.zig
@@ -55,7 +55,14 @@ pub const App = struct {
     /// `closeAllScenes` runs on project transitions.
     open_scenes: std.ArrayList(scene_mod.SceneState) = .{},
     /// Which tab is foregrounded. null when no scenes are open.
+    /// Updated each frame from whichever tab ImGui reports active.
     active_scene_idx: ?usize = null,
+    /// One-shot: when set, the next `renderSceneTabs` forces this tab
+    /// to be active via ImGui's `set_selected` flag, then clears the
+    /// field. `set_selected` is one-shot in ImGui — applying it every
+    /// frame would re-force the same tab and prevent the user from
+    /// switching by clicking other tabs.
+    focus_tab_idx: ?usize = null,
     /// Set when the user clicks the × on a dirty tab. While non-null
     /// the close-confirmation dialog is shown and other tabs can't be
     /// closed.
@@ -115,14 +122,16 @@ pub const App = struct {
     pub fn openScene(self: *Self, path: []const u8) !void {
         for (self.open_scenes.items, 0..) |s, i| {
             if (std.mem.eql(u8, s.path, path)) {
-                self.active_scene_idx = i;
+                self.focus_tab_idx = i; // bring the existing tab forward once
                 return;
             }
         }
         var state = try scene_mod.SceneState.open(self.allocator, path);
         errdefer state.deinit(self.allocator);
         try self.open_scenes.append(self.allocator, state);
-        self.active_scene_idx = self.open_scenes.items.len - 1;
+        const new_idx = self.open_scenes.items.len - 1;
+        self.active_scene_idx = new_idx;
+        self.focus_tab_idx = new_idx;
     }
 
     /// Close the tab at `idx` unconditionally. Caller is responsible
@@ -169,6 +178,7 @@ pub const App = struct {
         for (self.open_scenes.items) |*s| s.deinit(self.allocator);
         self.open_scenes.clearRetainingCapacity();
         self.active_scene_idx = null;
+        self.focus_tab_idx = null;
         self.pending_close_idx = null;
     }
 
@@ -429,18 +439,32 @@ pub const App = struct {
         })) return;
         defer zgui.endTabBar();
 
+        // Consume the one-shot focus request *before* the loop so each
+        // tab sees the same value and we don't re-apply it next frame.
+        const focus = self.focus_tab_idx;
+        self.focus_tab_idx = null;
+
         var to_close: ?usize = null;
 
         for (self.open_scenes.items, 0..) |*s, i| {
             // Disambiguate tabs by full path so two scenes with the
             // same stem (across projects or fragments) get distinct
             // imgui IDs. `unsaved_document` puts ImGui's own marker
-            // on dirty tabs.
-            var label_buf: [512]u8 = undefined;
+            // on dirty tabs. Buffer is sized for the longest plausible
+            // absolute path (`std.fs.max_path_bytes`, which is 4096 on
+            // Linux + larger limits on macOS) plus slack for the label
+            // prefix; smaller buffers silently dropped the tab when
+            // pointed at deeply-nested project paths.
+            var label_buf: [std.fs.max_path_bytes + 256]u8 = undefined;
             const label = std.fmt.bufPrintZ(&label_buf, "{s}##{s}", .{ s.display_name, s.path }) catch continue;
 
             var open: bool = true;
-            const set_selected = self.active_scene_idx != null and self.active_scene_idx.? == i;
+            // `set_selected` is one-shot in ImGui — fire it only when
+            // we explicitly want to bring a tab forward (just-opened
+            // or re-focused via tree click on an already-open scene).
+            // Applying it every frame creates a feedback loop that
+            // prevents the user from switching tabs by clicking.
+            const set_selected = focus != null and focus.? == i;
             const flags: zgui.TabItemFlags = .{ .set_selected = set_selected, .unsaved_document = s.is_dirty };
             if (zgui.beginTabItem(label, .{ .p_open = &open, .flags = flags })) {
                 self.active_scene_idx = i;

--- a/src/app.zig
+++ b/src/app.zig
@@ -20,6 +20,7 @@ const project_settings_mod = @import("modules/project_settings.zig");
 const project_tree_mod = @import("modules/project_tree.zig");
 const resources_mod = @import("modules/resources.zig");
 const scene_mod = @import("modules/scene.zig");
+const close_scene_dialog = @import("dialogs/close_scene.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
 const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
 
@@ -48,8 +49,20 @@ pub const App = struct {
     show_resources: bool = false,
     resources_editor: resources_mod.ResourcesEditor = .{},
 
-    show_scene: bool = false,
-    scene_state: scene_mod.SceneState = .{},
+    /// Scene editor tabs. Each entry owns a loaded `.jsonc` plus
+    /// per-tab UI state (selection, pan/zoom, dirty flag). Populated
+    /// when the user clicks a `.jsonc` file in the project tree;
+    /// `closeAllScenes` runs on project transitions.
+    open_scenes: std.ArrayList(scene_mod.SceneState) = .{},
+    /// Which tab is foregrounded. null when no scenes are open.
+    active_scene_idx: ?usize = null,
+    /// Set when the user clicks the × on a dirty tab. While non-null
+    /// the close-confirmation dialog is shown and other tabs can't be
+    /// closed.
+    pending_close_idx: ?usize = null,
+    /// Last seen `ProjectManager.generation`. Compared each frame so
+    /// `closeAllScenes` runs the frame the active project changes.
+    last_project_generation: ?u64 = null,
 
     show_project_tree: bool = true,
 
@@ -59,7 +72,7 @@ pub const App = struct {
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [5]module.Module = undefined,
+    modules: [4]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -80,18 +93,83 @@ pub const App = struct {
         app.modules[1] = compiler_output.makeModule(app);
         app.modules[2] = project_settings_mod.makeModule(app);
         app.modules[3] = resources_mod.makeModule(app);
-        app.modules[4] = scene_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
 
         return app;
     }
 
     pub fn deinit(self: *Self) void {
-        self.scene_state.deinit();
+        self.closeAllScenes();
+        self.open_scenes.deinit(self.allocator);
         self.project_manager.deinit();
         self.tree_view.deinit();
         self.compiler.deinit();
         self.allocator.destroy(self);
+    }
+
+    // ─── Scene tabs ─────────────────────────────────────────────────────
+
+    /// Open `path` (typically a `.jsonc` under the project's `scenes/`
+    /// directory) as a tab in the main content area. If the path is
+    /// already open, focuses the existing tab instead of reloading.
+    pub fn openScene(self: *Self, path: []const u8) !void {
+        for (self.open_scenes.items, 0..) |s, i| {
+            if (std.mem.eql(u8, s.path, path)) {
+                self.active_scene_idx = i;
+                return;
+            }
+        }
+        var state = try scene_mod.SceneState.open(self.allocator, path);
+        errdefer state.deinit(self.allocator);
+        try self.open_scenes.append(self.allocator, state);
+        self.active_scene_idx = self.open_scenes.items.len - 1;
+    }
+
+    /// Close the tab at `idx` unconditionally. Caller is responsible
+    /// for asking the user about unsaved changes — `closeSceneSafe`
+    /// does that.
+    pub fn closeScene(self: *Self, idx: usize) void {
+        if (idx >= self.open_scenes.items.len) return;
+        var removed = self.open_scenes.orderedRemove(idx);
+        removed.deinit(self.allocator);
+
+        if (self.open_scenes.items.len == 0) {
+            self.active_scene_idx = null;
+        } else if (self.active_scene_idx) |a| {
+            if (a == idx) {
+                self.active_scene_idx = if (idx > 0) idx - 1 else 0;
+            } else if (a > idx) {
+                self.active_scene_idx = a - 1;
+            }
+        }
+        // If pending_close was pointing at this tab (or one shifted by
+        // the removal), clear / adjust it so the dialog doesn't end up
+        // tracking the wrong tab.
+        if (self.pending_close_idx) |p| {
+            if (p == idx) {
+                self.pending_close_idx = null;
+            } else if (p > idx) {
+                self.pending_close_idx = p - 1;
+            }
+        }
+    }
+
+    /// Close the tab at `idx`, prompting the user first if the tab has
+    /// unsaved changes.
+    pub fn requestCloseScene(self: *Self, idx: usize) void {
+        if (idx >= self.open_scenes.items.len) return;
+        if (self.open_scenes.items[idx].is_dirty) {
+            self.pending_close_idx = idx;
+        } else {
+            self.closeScene(idx);
+        }
+    }
+
+    pub fn closeAllScenes(self: *Self) void {
+        for (self.open_scenes.items) |*s| s.deinit(self.allocator);
+        self.open_scenes.clearRetainingCapacity();
+        self.active_scene_idx = null;
+        self.pending_close_idx = null;
     }
 
     pub fn setStatus(self: *Self, message: []const u8) void {
@@ -109,12 +187,23 @@ pub const App = struct {
     pub fn renderFrame(self: *Self, dt_seconds: f32) void {
         if (self.status_timer > 0) self.status_timer -= dt_seconds;
 
+        // Project transitions close all open scene tabs so the next
+        // frame doesn't read into freed memory belonging to the old
+        // project. Detected via ProjectManager.generation, which is
+        // bumped on new/load/close.
+        const gen = self.project_manager.generation;
+        if (self.last_project_generation) |prev| {
+            if (prev != gen) self.closeAllScenes();
+        }
+        self.last_project_generation = gen;
+
         self.renderMenuBar();
         self.pollCompiler();
         self.renderMainContent();
         self.registry.renderAllPanels(self);
         self.renderStatusBar();
         new_scene_dialog.render(self);
+        close_scene_dialog.render(self);
         dpi_warning_dialog.render(self);
     }
 
@@ -301,6 +390,15 @@ pub const App = struct {
         }
         defer zgui.end();
 
+        // When at least one scene tab is open, the main area becomes
+        // a TabBar; the welcome view is purely the empty-state. The
+        // first frame after `openScene` selects the new tab via
+        // `set_selected` so the user lands on what they just clicked.
+        if (self.open_scenes.items.len > 0) {
+            self.renderSceneTabs();
+            return;
+        }
+
         if (self.project_manager.current_project) |proj| {
             zgui.text("Project: {s}", .{proj.config.name});
             if (proj.is_dirty) {
@@ -308,11 +406,7 @@ pub const App = struct {
                 zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
             }
             zgui.separator();
-            if (self.tree_view.getSelectedPath()) |selected| {
-                zgui.text("Selected: {s}", .{std.fs.path.basename(selected)});
-                zgui.separator();
-            }
-            zgui.text("Ready to work!", .{});
+            zgui.text("Click a scene in the tree to open it.", .{});
         } else {
             zgui.text("Welcome to Labelle!", .{});
             zgui.spacing();
@@ -321,6 +415,42 @@ pub const App = struct {
             if (zgui.button("New Project...", .{ .w = 150 })) self.pickFolderAndCreateProject();
             if (zgui.button("Open Project...", .{ .w = 150 })) self.pickFolderAndOpenProject();
         }
+    }
+
+    /// Render the per-scene tab strip and the active tab's body. Tabs
+    /// use `popen` on the tab item so the × close button fires through
+    /// `requestCloseScene`, which routes a dirty tab to the
+    /// confirmation dialog.
+    fn renderSceneTabs(self: *Self) void {
+        if (!zgui.beginTabBar("##scene_tabs", .{
+            .reorderable = true,
+            .auto_select_new_tabs = true,
+            .tab_list_popup_button = true,
+        })) return;
+        defer zgui.endTabBar();
+
+        var to_close: ?usize = null;
+
+        for (self.open_scenes.items, 0..) |*s, i| {
+            // Disambiguate tabs by full path so two scenes with the
+            // same stem (across projects or fragments) get distinct
+            // imgui IDs. `unsaved_document` puts ImGui's own marker
+            // on dirty tabs.
+            var label_buf: [512]u8 = undefined;
+            const label = std.fmt.bufPrintZ(&label_buf, "{s}##{s}", .{ s.display_name, s.path }) catch continue;
+
+            var open: bool = true;
+            const set_selected = self.active_scene_idx != null and self.active_scene_idx.? == i;
+            const flags: zgui.TabItemFlags = .{ .set_selected = set_selected, .unsaved_document = s.is_dirty };
+            if (zgui.beginTabItem(label, .{ .p_open = &open, .flags = flags })) {
+                self.active_scene_idx = i;
+                scene_mod.render(s, self);
+                zgui.endTabItem();
+            }
+            if (!open and to_close == null) to_close = i;
+        }
+
+        if (to_close) |i| self.requestCloseScene(i);
     }
 
     fn renderStatusBar(self: *Self) void {

--- a/src/dialogs/close_scene.zig
+++ b/src/dialogs/close_scene.zig
@@ -1,0 +1,60 @@
+//! Confirmation modal shown when the user tries to close a tab that
+//! has unsaved edits. Driven by `App.pending_close_idx` — non-null
+//! means "the tab at this index has been ×'d and is dirty; ask the
+//! user what to do." Three resolutions:
+//!
+//! - **Save and close**: writes the scene back to disk via the Scene
+//!   module's `saveScene` and then drops the tab.
+//! - **Discard**: drops the tab without writing.
+//! - **Cancel**: keeps the tab open; `pending_close_idx` is cleared
+//!   so subsequent close attempts re-fire the dialog.
+
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const scene_mod = @import("../modules/scene.zig");
+
+pub fn render(app: *App) void {
+    const idx = app.pending_close_idx orelse return;
+    if (idx >= app.open_scenes.items.len) {
+        // Tab was already gone (e.g. closeAllScenes ran between
+        // request and dialog render). Drop the request silently.
+        app.pending_close_idx = null;
+        return;
+    }
+    const state = &app.open_scenes.items[idx];
+
+    zgui.openPopup("Unsaved scene", .{});
+    if (!zgui.beginPopupModal("Unsaved scene", .{ .flags = .{ .always_auto_resize = true } })) return;
+    defer zgui.endPopup();
+
+    zgui.text("Scene \"{s}\" has unsaved changes.", .{state.display_name});
+    zgui.text("Save before closing?", .{});
+    zgui.spacing();
+    zgui.separator();
+    zgui.spacing();
+
+    if (zgui.button("Save and close", .{ .w = 150 })) {
+        scene_mod.saveScene(state, app);
+        if (!state.is_dirty) {
+            // Save succeeded — close.
+            app.closeScene(idx);
+        }
+        // If save_scene failed, is_dirty stays true; status bar already
+        // surfaces the error. Keep the dialog dismissed so the user
+        // can investigate without it re-firing on the next frame.
+        app.pending_close_idx = null;
+        zgui.closeCurrentPopup();
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("Discard", .{ .w = 100 })) {
+        app.closeScene(idx);
+        app.pending_close_idx = null;
+        zgui.closeCurrentPopup();
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("Cancel", .{ .w = 100 })) {
+        app.pending_close_idx = null;
+        zgui.closeCurrentPopup();
+    }
+}

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -10,6 +10,7 @@ const zopengl = @import("zopengl");
 const zgui = @import("zgui");
 
 const App = @import("app.zig").App;
+const scene_mod = @import("modules/scene.zig");
 
 const gl_major = 4;
 const gl_minor = 1;
@@ -142,7 +143,7 @@ pub fn main() !void {
         sf.close();
     }
 
-    _ = engine.registerTest("phase3", "scene_save_preserves_extras", @src(), struct {
+    _ = engine.registerTest("phase3", "scene_open_save_preserves_extras", @src(), struct {
         fn gui(_: *zgui.te.TestContext) !void {
             if (g_app) |a| a.renderFrame(1.0 / 60.0);
         }
@@ -152,30 +153,33 @@ pub fn main() !void {
                 return;
             };
 
-            // Set selection directly — clicking entries in the file-list
-            // child window is fiddly to address via TE refs, and we're
-            // testing Save, not selection wiring.
-            const name = "scene_with_sprite";
-            @memset(&a.scene_state.selected_name, 0);
-            @memcpy(a.scene_state.selected_name[0..name.len], name);
-
-            ctx.menuAction(.click, "View/Scene");
-            ctx.yield(2); // give the panel time to load the scene from disk
-
-            const loaded_ok = a.scene_state.loaded != null and
-                a.scene_state.loaded.?.scene.entities.len == 1;
-            _ = zgui.te.check(@src(), .{}, loaded_ok, "scene loaded with one entity");
-
-            // Edit the in-memory position, then save.
-            a.scene_state.loaded.?.scene.entities[0].position.?.x = 999;
-            a.scene_state.is_dirty = true;
-            ctx.itemAction(.click, "Scene/Save", .{}, null);
-            _ = zgui.te.check(@src(), .{}, !a.scene_state.is_dirty, "is_dirty cleared after Save");
-
-            // Read the file back and confirm Sprite + edited Position landed.
             const dir = g_settings_project_dir.?;
             var path_buf: [512]u8 = undefined;
             const path = std.fmt.bufPrint(&path_buf, "{s}/scenes/scene_with_sprite.jsonc", .{dir}) catch return;
+
+            // Drive the public openScene API — same path the tree-click
+            // handler uses, just bypassed for test setup.
+            a.openScene(path) catch {
+                _ = zgui.te.check(@src(), .{}, false, "openScene must succeed");
+                return;
+            };
+            ctx.yield(1);
+
+            const opened_ok = a.open_scenes.items.len == 1 and
+                a.open_scenes.items[0].loaded.scene.entities.len == 1;
+            _ = zgui.te.check(@src(), .{}, opened_ok, "scene opened with one entity");
+
+            // Edit the in-memory position, then save via the module's
+            // public saveScene (the same function the tab's Save button
+            // calls). Driving the button via TE refs through the
+            // nested tab-bar ID stack is brittle; saveScene is what we
+            // actually care about here.
+            const tab = &a.open_scenes.items[0];
+            tab.loaded.scene.entities[0].position.?.x = 999;
+            tab.is_dirty = true;
+            scene_mod.saveScene(tab, a);
+            _ = zgui.te.check(@src(), .{}, !tab.is_dirty, "is_dirty cleared after Save");
+
             var file_buf: [4096]u8 = undefined;
             const file = std.fs.cwd().openFile(path, .{}) catch return;
             defer file.close();
@@ -184,25 +188,9 @@ pub fn main() !void {
 
             _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Sprite\"") != null, "Sprite preserved on disk");
             _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"x\": 999") != null, "edited Position written");
-        }
-    });
 
-    _ = engine.registerTest("phase3", "scene_panel_toggles", @src(), struct {
-        fn gui(_: *zgui.te.TestContext) !void {
-            // Synthetic dt; tests don't observe status_timer decay.
-            if (g_app) |a| a.renderFrame(1.0 / 60.0);
-        }
-        fn run(ctx: *zgui.te.TestContext) !void {
-            const a = g_app orelse {
-                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
-                return;
-            };
-
-            _ = zgui.te.check(@src(), .{}, !a.show_scene, "Scene panel starts closed");
-            ctx.menuAction(.click, "View/Scene");
-            _ = zgui.te.check(@src(), .{}, a.show_scene, "View/Scene opens panel");
-            ctx.menuAction(.click, "View/Scene");
-            _ = zgui.te.check(@src(), .{}, !a.show_scene, "View/Scene closes panel");
+            // Close the tab cleanly so subsequent tests see a fresh App.
+            a.closeScene(0);
         }
     });
 

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -10,6 +10,7 @@ const zgui = @import("zgui");
 const App = @import("../app.zig").App;
 const module = @import("../module.zig");
 const config = @import("../config.zig");
+const project = @import("../project.zig");
 
 pub fn makeModule(app: *App) module.Module {
     return .{
@@ -18,6 +19,22 @@ pub fn makeModule(app: *App) module.Module {
         .is_open = &app.show_project_tree,
         .render_panel = render,
     };
+}
+
+/// Return true when `path` is a `.jsonc` file under the project's
+/// `scenes/` directory (including subdirectories — engine scenes
+/// support nested fragments). Prefabs and other `.jsonc` files
+/// elsewhere in the project return false; the caller skips opening
+/// them as scenes.
+pub fn isScenePath(proj_dir: ?[]const u8, path: []const u8) bool {
+    const dir = proj_dir orelse return false;
+    if (!std.mem.endsWith(u8, path, ".jsonc")) return false;
+    var prefix_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = std.fmt.bufPrint(&prefix_buf, "{s}/{s}/", .{
+        dir,
+        project.ProjectFolders.scenes,
+    }) catch return false;
+    return std.mem.startsWith(u8, path, prefix);
 }
 
 fn render(app: *App) void {
@@ -37,11 +54,15 @@ fn render(app: *App) void {
     } })) {
         if (app.project_manager.current_project) |proj| {
             // Tree returns true on the frame a file is newly clicked.
-            // Route `.jsonc` selections through the App so they open
-            // as scene editor tabs in the main content area.
+            // Route `.jsonc` files under the project's `scenes/` dir
+            // to the scene editor. Prefabs (also `.jsonc`, but under
+            // `prefabs/`) intentionally fall through here — they
+            // need their own editor (not yet implemented) and must
+            // not open in the scene editor, since saving back would
+            // overwrite the prefab as an empty scene.
             if (app.tree_view.render(proj.getProjectDir())) {
                 if (app.tree_view.getSelectedPath()) |path| {
-                    if (std.mem.endsWith(u8, path, ".jsonc")) {
+                    if (isScenePath(proj.getProjectDir(), path)) {
                         app.openScene(path) catch |err| {
                             std.log.err("Failed to open scene {s}: {s}", .{ path, @errorName(err) });
                             app.setStatus("Error opening scene!");

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -4,6 +4,7 @@
 //! via the View menu, the space is left empty — Main Content keeps its
 //! hardcoded position. Re-enable to bring the tree back.
 
+const std = @import("std");
 const zgui = @import("zgui");
 
 const App = @import("../app.zig").App;
@@ -35,7 +36,19 @@ fn render(app: *App) void {
         .no_collapse = true,
     } })) {
         if (app.project_manager.current_project) |proj| {
-            _ = app.tree_view.render(proj.getProjectDir());
+            // Tree returns true on the frame a file is newly clicked.
+            // Route `.jsonc` selections through the App so they open
+            // as scene editor tabs in the main content area.
+            if (app.tree_view.render(proj.getProjectDir())) {
+                if (app.tree_view.getSelectedPath()) |path| {
+                    if (std.mem.endsWith(u8, path, ".jsonc")) {
+                        app.openScene(path) catch |err| {
+                            std.log.err("Failed to open scene {s}: {s}", .{ path, @errorName(err) });
+                            app.setStatus("Error opening scene!");
+                        };
+                    }
+                }
+            }
         } else {
             zgui.textDisabled("No project open", .{});
         }

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -83,8 +83,13 @@ fn deriveDisplayName(path: []const u8) []const u8 {
     return base;
 }
 
+const inspector_w: f32 = 300;
+const split_gap: f32 = 8;
+
 /// Render a single open scene as the content of a tab. Caller has
-/// already entered the tab item; we just paint the body.
+/// already entered the tab item; we just paint the body. Layout is
+/// scene-level header + controls across the top, then a viewport
+/// child on the left and an inspector child on the right.
 pub fn render(s: *SceneState, app: *App) void {
     zgui.text("Scene: {s}", .{s.loaded.scene.name});
     zgui.sameLine(.{});
@@ -109,9 +114,23 @@ pub fn render(s: *SceneState, app: *App) void {
     if (zgui.button("Save", .{})) saveScene(s, app);
     zgui.separator();
 
-    renderInspector(s);
-    zgui.separator();
-    renderViewport(s);
+    // Two-column body: viewport on the left, inspector on the right.
+    const total_w = zgui.getContentRegionAvail()[0];
+    const viewport_w = @max(120.0, total_w - inspector_w - split_gap);
+
+    if (zgui.beginChild("##viewport_col", .{ .w = viewport_w, .h = 0 })) {
+        renderViewport(s);
+    }
+    zgui.endChild();
+    zgui.sameLine(.{});
+    if (zgui.beginChild("##inspector_col", .{
+        .w = 0,
+        .h = 0,
+        .child_flags = .{ .border = true },
+    })) {
+        renderInspector(s);
+    }
+    zgui.endChild();
 }
 
 /// Write the current scene back to its source path. Clears the dirty
@@ -127,32 +146,65 @@ pub fn saveScene(s: *SceneState, app: *App) void {
 }
 
 fn renderInspector(s: *SceneState) void {
-    if (s.selected_index) |idx| {
-        if (idx >= s.loaded.scene.entities.len) {
-            s.selected_index = null;
-            zgui.textDisabled("(selection out of range)", .{});
-            return;
-        }
-        const e = &s.loaded.scene.entities[idx];
-        const prefab = e.prefab orelse "(no prefab)";
-        zgui.text("Selected: #{d} {s}", .{ idx, prefab });
+    zgui.text("Inspector", .{});
+    zgui.separator();
 
+    const idx = s.selected_index orelse {
+        zgui.textDisabled("Click an entity in the viewport to select.", .{});
+        return;
+    };
+    if (idx >= s.loaded.scene.entities.len) {
+        s.selected_index = null;
+        zgui.textDisabled("(selection out of range)", .{});
+        return;
+    }
+    const e = &s.loaded.scene.entities[idx];
+    const prefab = e.prefab orelse "(no prefab)";
+    zgui.text("Entity #{d}", .{idx});
+    if (e.prefab) |p| zgui.text("prefab: {s}", .{p}) else {
+        _ = prefab;
+        zgui.textDisabled("(no prefab)", .{});
+    }
+    zgui.spacing();
+
+    // Position is the only component the gui models structurally.
+    // Other components are read from the captured extras list and
+    // rendered as collapsible value previews.
+    if (zgui.collapsingHeader("Position", .{ .default_open = true })) {
         if (e.position) |*pos| {
             if (zgui.inputFloat("x", .{ .v = &pos.x })) s.is_dirty = true;
             if (zgui.inputFloat("y", .{ .v = &pos.y })) s.is_dirty = true;
         } else {
             zgui.textDisabled("(no Position component)", .{});
         }
+    }
 
+    if (zgui.collapsingHeader("Comment", .{})) {
         if (zgui.inputTextMultiline("##comment", .{
             .buf = &e.comment,
             .w = 0,
             .h = 80,
         })) s.is_dirty = true;
-        zgui.sameLine(.{});
-        zgui.textDisabled("(comment)", .{});
-    } else {
-        zgui.textDisabled("Click an entity in the viewport to select.", .{});
+    }
+
+    // Per-entity unmodeled components captured verbatim at load time
+    // (Sprite, Shape, user-defined). Read-only display for now —
+    // structured editing of these is a follow-up; users can still
+    // hand-edit the .jsonc directly and reopen the scene.
+    if (idx < s.loaded.extras.entity_components.len) {
+        const extras = s.loaded.extras.entity_components[idx];
+        if (extras.len > 0) {
+            zgui.spacing();
+            zgui.separator();
+            zgui.textDisabled("Other components ({d})", .{extras.len});
+            for (extras) |extra| {
+                var label_buf: [128:0]u8 = undefined;
+                const label = std.fmt.bufPrintZ(&label_buf, "{s}", .{extra.name}) catch continue;
+                if (zgui.collapsingHeader(label, .{})) {
+                    zgui.textUnformatted(extra.value_text);
+                }
+            }
+        }
     }
 }
 

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -1,261 +1,100 @@
-//! Scene module — togglable panel that lists `<project>/scenes/*.jsonc`,
-//! parses a selected scene, and renders entity positions in a 2D
-//! viewport. Supports in-memory editing (selection, drag-to-move,
-//! per-entity comment + position inputs); save-back to disk is a
-//! separate slice (needs a JSONC writer that preserves comments and
-//! unmodeled components).
+//! Scene editor — per-tab state and rendering.
 //!
-//! Memory model: the loaded scene owns an arena (see `scene_io.zig`)
-//! that lives across frames until the user picks another scene or
-//! closes the project. The module also keeps a `loaded_name` to detect
-//! when the selection has changed and needs to be reloaded from disk.
+//! No longer a top-level View-menu panel. The Scene editor opens as a
+//! tab in the main content area when the user clicks a `.jsonc` file
+//! in the project tree. `App` owns an `ArrayList(SceneState)` of open
+//! tabs; this module renders one tab's body (inspector + viewport)
+//! given a single state.
+//!
+//! Each `SceneState` carries its own arena (for path/display name
+//! strings) and a `LoadedScene` (which carries its own arena for the
+//! parsed scene data). `deinit(allocator)` frees both.
 
 const std = @import("std");
 const zgui = @import("zgui");
 
 const App = @import("../app.zig").App;
-const module = @import("../module.zig");
 const project = @import("../project.zig");
 const scene_io = @import("../scene_io.zig");
-const buf = @import("../buf.zig");
+const config = @import("../config.zig");
 
-const name_cap = 128;
-const sidebar_w: f32 = 200;
 const viewport_min_h: f32 = 240;
 
 pub const SceneState = struct {
-    /// Name (without extension) of the scene the user has clicked in
-    /// the file list. Empty = nothing selected.
-    selected_name: [name_cap:0]u8 = [_:0]u8{0} ** name_cap,
-    /// Name of the scene currently held in `loaded`. When this differs
-    /// from `selected_name`, the next `render` call reloads from disk.
-    loaded_name: [name_cap:0]u8 = [_:0]u8{0} ** name_cap,
-    loaded: ?scene_io.LoadedScene = null,
+    /// Owns `path` and `display_name`. `loaded` has its own internal
+    /// arena (created by scene_io.parseScene) for the parsed scene.
+    arena: *std.heap.ArenaAllocator,
+    /// Absolute path on disk. Used for Save and for dedup when opening.
+    path: []const u8,
+    /// Stem without `.jsonc` extension. Used for the tab label.
+    display_name: []const u8,
+    loaded: scene_io.LoadedScene,
+
     /// Index into `loaded.scene.entities`; null = nothing selected.
-    /// Reset whenever a new scene is loaded.
     selected_index: ?usize = null,
-    /// Set to true on any in-memory edit (drag, inspector input). Cleared
-    /// on scene reload. Save-back is a separate slice; for now this is
-    /// just a visual indicator that changes haven't been persisted.
+    /// True after any in-memory edit (drag, inspector input, comment).
+    /// Cleared on successful Save. Drives the dirty indicator + the
+    /// close-tab confirmation dialog.
     is_dirty: bool = false,
-    /// True between mouse-down on a selected entity and mouse-up. Gates
-    /// drag-to-move so dragging in empty canvas space (or starting a
-    /// drag from a non-hit spot) doesn't move the previously selected
-    /// entity by accident.
+    /// Set between mouse-down on a selected entity and mouse-up so a
+    /// drag started in empty canvas space doesn't move the previously
+    /// selected entity by accident.
     drag_armed: bool = false,
-    /// Viewport pan / zoom state (world-space offset + scale factor).
+    /// Viewport pan / zoom state. Per-tab — each open scene keeps its
+    /// own camera.
     pan: [2]f32 = .{ 320, 240 },
     zoom: f32 = 1.0,
-    /// Generation counter the selection was synced against. Compared
-    /// to `ProjectManager.generation` to detect project transitions —
-    /// using a counter instead of the raw `*Project` pointer avoids
-    /// the ABA hazard where GPA reuses an address after a close/new
-    /// cycle. `null` = not yet synced against any project.
-    last_generation: ?u64 = null,
-    /// Cached list of `<project>/scenes/*.jsonc` stems. Populated on
-    /// project change or by clicking Refresh — avoids opening and
-    /// iterating the scenes directory every frame, which the bot
-    /// reviewer rightly flagged as a per-frame I/O hot path.
-    /// Memory is owned by `file_list_arena`.
-    scene_files: []const []const u8 = &.{},
-    file_list_arena: ?*std.heap.ArenaAllocator = null,
 
-    pub fn deinit(self: *SceneState) void {
-        if (self.loaded) |*l| l.deinit();
-        self.loaded = null;
-        self.selected_index = null;
-        self.is_dirty = false;
-        if (self.file_list_arena) |a| {
-            const child = a.child_allocator;
-            a.deinit();
-            child.destroy(a);
-            self.file_list_arena = null;
-            self.scene_files = &.{};
-        }
+    /// Load a scene from disk and wrap it in a fresh SceneState. The
+    /// returned state owns an arena holding the path + display name,
+    /// plus the LoadedScene's own arena for parsed data.
+    pub fn open(allocator: std.mem.Allocator, path: []const u8) !SceneState {
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const a = arena.allocator();
+        const path_dup = try a.dupe(u8, path);
+        const display_name = deriveDisplayName(path_dup);
+
+        const loaded = try scene_io.loadFromFile(allocator, path);
+        return .{
+            .arena = arena,
+            .path = path_dup,
+            .display_name = display_name,
+            .loaded = loaded,
+        };
+    }
+
+    pub fn deinit(self: *SceneState, allocator: std.mem.Allocator) void {
+        self.loaded.deinit();
+        self.arena.deinit();
+        allocator.destroy(self.arena);
     }
 };
 
-pub fn makeModule(app: *App) module.Module {
-    return .{
-        .name = "scene",
-        .display_name = "Scene",
-        .is_open = &app.show_scene,
-        .render_panel = render,
-    };
+/// Returns the file basename with its `.jsonc` extension stripped.
+/// `path` must outlive the returned slice (we just slice into it).
+fn deriveDisplayName(path: []const u8) []const u8 {
+    const base = std.fs.path.basename(path);
+    const ext = ".jsonc";
+    if (std.mem.endsWith(u8, base, ext)) return base[0 .. base.len - ext.len];
+    return base;
 }
 
-fn render(app: *App) void {
-    if (!zgui.begin("Scene", .{
-        .popen = &app.show_scene,
-        .flags = .{ .menu_bar = false },
-    })) {
-        zgui.end();
-        return;
-    }
-    defer zgui.end();
-
-    const proj = app.project_manager.current_project orelse {
-        zgui.textDisabled("No project open", .{});
-        return;
-    };
-
-    syncProjectChange(&app.scene_state, app, proj);
-    maybeLoadSelected(&app.scene_state, proj);
-
-    renderFileList(&app.scene_state, app, proj);
+/// Render a single open scene as the content of a tab. Caller has
+/// already entered the tab item; we just paint the body.
+pub fn render(s: *SceneState, app: *App) void {
+    zgui.text("Scene: {s}", .{s.loaded.scene.name});
     zgui.sameLine(.{});
-    renderInspectorAndViewport(&app.scene_state, app, proj);
-}
-
-fn syncProjectChange(s: *SceneState, app: *App, proj: *project.Project) void {
-    const gen = app.project_manager.generation;
-    if (s.last_generation) |g| {
-        if (g == gen) return;
-    }
-    s.deinit();
-    @memset(&s.selected_name, 0);
-    @memset(&s.loaded_name, 0);
-    s.last_generation = gen;
-    rescanScenes(s, app, proj);
-}
-
-/// (Re)read the scenes directory and store the result in `s.scene_files`.
-/// Resets any previously held file-list arena. Called on project change
-/// and from the Refresh button. Disk I/O is bounded to this call rather
-/// than running every frame inside `renderFileList`.
-fn rescanScenes(s: *SceneState, app: *App, proj: *project.Project) void {
-    if (s.file_list_arena) |old| {
-        const child = old.child_allocator;
-        old.deinit();
-        child.destroy(old);
-        s.file_list_arena = null;
-        s.scene_files = &.{};
-    }
-
-    const dir_path = proj.dir orelse return;
-    var path_buf: [512]u8 = undefined;
-    const scenes_path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{
-        dir_path,
-        project.ProjectFolders.scenes,
-    }) catch return;
-
-    const arena = app.allocator.create(std.heap.ArenaAllocator) catch return;
-    arena.* = std.heap.ArenaAllocator.init(app.allocator);
-    errdefer {
-        arena.deinit();
-        app.allocator.destroy(arena);
-    }
-    const a = arena.allocator();
-
-    var dir = std.fs.cwd().openDir(scenes_path, .{ .iterate = true }) catch {
-        // Scenes dir missing — leave file list empty and keep the
-        // arena registered so subsequent Refreshes can refill into it.
-        s.file_list_arena = arena;
-        return;
-    };
-    defer dir.close();
-
-    var files: std.ArrayList([]const u8) = .{};
-    var it = dir.iterate();
-    while (it.next() catch null) |entry| {
-        if (entry.kind != .file) continue;
-        if (!std.mem.endsWith(u8, entry.name, ".jsonc")) continue;
-        const stem = entry.name[0 .. entry.name.len - ".jsonc".len];
-        const copy = a.dupe(u8, stem) catch continue;
-        files.append(a, copy) catch continue;
-    }
-    s.scene_files = files.toOwnedSlice(a) catch &.{};
-    s.file_list_arena = arena;
-}
-
-fn maybeLoadSelected(s: *SceneState, proj: *project.Project) void {
-    const sel = std.mem.sliceTo(&s.selected_name, 0);
-    const cur = std.mem.sliceTo(&s.loaded_name, 0);
-    if (sel.len == 0) return;
-    if (std.mem.eql(u8, sel, cur)) return;
-    const dir = proj.dir orelse return;
-
-    if (s.loaded) |*l| l.deinit();
-    s.loaded = null;
-    s.selected_index = null;
-    s.is_dirty = false;
-
-    var path_buf: [512]u8 = undefined;
-    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.jsonc", .{
-        dir,
-        project.ProjectFolders.scenes,
-        sel,
-    }) catch return;
-
-    s.loaded = scene_io.loadFromFile(proj.allocator, path) catch |err| {
-        std.log.warn("Scene module: failed to load {s}: {s}", .{ path, @errorName(err) });
-        // Clear both names so we don't retry-and-log every frame.
-        // The user can re-click the entry to attempt a fresh load.
-        @memset(&s.selected_name, 0);
-        @memset(&s.loaded_name, 0);
-        return;
-    };
-    buf.writeZeroed(&s.loaded_name, sel);
-}
-
-// ─── File list ──────────────────────────────────────────────────────────
-
-fn renderFileList(s: *SceneState, app: *App, proj: *project.Project) void {
-    _ = zgui.beginChild("##scene_files", .{
-        .w = sidebar_w,
-        .h = 0,
-        .child_flags = .{ .border = true },
-    });
-    defer zgui.endChild();
-
-    zgui.text("Scenes", .{});
-    zgui.sameLine(.{});
-    if (zgui.smallButton("Refresh")) rescanScenes(s, app, proj);
-    zgui.separator();
-
-    if (s.scene_files.len == 0) {
-        zgui.textDisabled("(no .jsonc scenes)", .{});
-        return;
-    }
-
-    for (s.scene_files) |stem| {
-        var label_buf: [name_cap + 1]u8 = undefined;
-        const label = std.fmt.bufPrintZ(&label_buf, "{s}", .{stem}) catch continue;
-
-        const is_selected = std.mem.eql(u8, std.mem.sliceTo(&s.selected_name, 0), stem);
-        if (zgui.selectable(label, .{ .selected = is_selected })) {
-            buf.writeZeroed(&s.selected_name, stem);
-        }
-    }
-}
-
-// ─── Inspector + Viewport ───────────────────────────────────────────────
-
-fn renderInspectorAndViewport(s: *SceneState, app: *App, proj: *project.Project) void {
-    _ = zgui.beginChild("##scene_main", .{
-        .w = 0,
-        .h = 0,
-        .child_flags = .{ .border = true },
-    });
-    defer zgui.endChild();
-
-    const loaded = s.loaded orelse {
-        zgui.textDisabled("Select a scene from the list.", .{});
-        return;
-    };
-
-    zgui.text("Scene: {s}", .{loaded.scene.name});
-    zgui.sameLine(.{});
-    zgui.text("(entities: {d})", .{loaded.scene.entities.len});
+    zgui.text("(entities: {d})", .{s.loaded.scene.entities.len});
     if (s.is_dirty) {
         zgui.sameLine(.{});
         zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
     }
     zgui.separator();
 
-    // Pan/zoom controls. Scroll-wheel reading isn't exposed by zgui's
-    // wrapper today, so we use buttons. Pan is middle-button drag in
-    // the canvas below.
     if (zgui.button("Reset view", .{})) {
         s.pan = .{ 320, 240 };
         s.zoom = 1.0;
@@ -267,34 +106,19 @@ fn renderInspectorAndViewport(s: *SceneState, app: *App, proj: *project.Project)
     zgui.sameLine(.{});
     zgui.text("zoom: {d:.2}x", .{s.zoom});
     zgui.sameLine(.{});
-    if (zgui.button("Save", .{})) saveCurrentScene(s, app, proj);
+    if (zgui.button("Save", .{})) saveScene(s, app);
     zgui.separator();
 
-    renderInspector(s, loaded);
+    renderInspector(s);
     zgui.separator();
-    renderViewport(s, loaded);
+    renderViewport(s);
 }
 
-/// Write the current loaded scene to its source path. Clears the
-/// dirty flag and posts a status message on success.
-fn saveCurrentScene(s: *SceneState, app: *App, proj: *project.Project) void {
-    const loaded = s.loaded orelse return;
-    const sel = std.mem.sliceTo(&s.loaded_name, 0);
-    if (sel.len == 0) return;
-    const dir = proj.dir orelse return;
-
-    var path_buf: [512]u8 = undefined;
-    const path = std.fmt.bufPrint(&path_buf, "{s}/{s}/{s}.jsonc", .{
-        dir,
-        project.ProjectFolders.scenes,
-        sel,
-    }) catch {
-        app.setStatus("Scene path too long!");
-        return;
-    };
-
-    scene_io.saveScene(app.allocator, path, loaded) catch |err| {
-        std.log.err("Scene save failed at {s}: {s}", .{ path, @errorName(err) });
+/// Write the current scene back to its source path. Clears the dirty
+/// flag and posts a status message on success.
+pub fn saveScene(s: *SceneState, app: *App) void {
+    scene_io.saveScene(app.allocator, s.path, s.loaded) catch |err| {
+        std.log.err("Scene save failed at {s}: {s}", .{ s.path, @errorName(err) });
         app.setStatus("Error saving scene!");
         return;
     };
@@ -302,14 +126,14 @@ fn saveCurrentScene(s: *SceneState, app: *App, proj: *project.Project) void {
     app.setStatus("Scene saved!");
 }
 
-fn renderInspector(s: *SceneState, loaded: scene_io.LoadedScene) void {
+fn renderInspector(s: *SceneState) void {
     if (s.selected_index) |idx| {
-        if (idx >= loaded.scene.entities.len) {
+        if (idx >= s.loaded.scene.entities.len) {
             s.selected_index = null;
             zgui.textDisabled("(selection out of range)", .{});
             return;
         }
-        const e = &loaded.scene.entities[idx];
+        const e = &s.loaded.scene.entities[idx];
         const prefab = e.prefab orelse "(no prefab)";
         zgui.text("Selected: #{d} {s}", .{ idx, prefab });
 
@@ -320,10 +144,6 @@ fn renderInspector(s: *SceneState, loaded: scene_io.LoadedScene) void {
             zgui.textDisabled("(no Position component)", .{});
         }
 
-        // Multiline comment editor. The buffer is owned by the entity
-        // and modified in place — saves still need a JSONC writer
-        // (deferred slice), but edits persist for the duration of the
-        // scene's lifetime.
         if (zgui.inputTextMultiline("##comment", .{
             .buf = &e.comment,
             .w = 0,
@@ -336,7 +156,7 @@ fn renderInspector(s: *SceneState, loaded: scene_io.LoadedScene) void {
     }
 }
 
-fn renderViewport(s: *SceneState, loaded: scene_io.LoadedScene) void {
+fn renderViewport(s: *SceneState) void {
     const avail = zgui.getContentRegionAvail();
     const canvas_h = @max(viewport_min_h, avail[1]);
     if (!zgui.beginChild("##canvas", .{
@@ -355,7 +175,6 @@ fn renderViewport(s: *SceneState, loaded: scene_io.LoadedScene) void {
     const canvas_min = cur_pos;
     const canvas_max: [2]f32 = .{ cur_pos[0] + canvas_size[0], cur_pos[1] + canvas_size[1] };
 
-    // Background.
     dl.addRectFilled(.{
         .pmin = canvas_min,
         .pmax = canvas_max,
@@ -363,46 +182,35 @@ fn renderViewport(s: *SceneState, loaded: scene_io.LoadedScene) void {
     });
 
     drawGrid(dl, canvas_min, canvas_max, s.*);
-    drawEntities(dl, canvas_min, canvas_max, s.*, loaded);
+    drawEntities(dl, canvas_min, canvas_max, s.*, s.loaded);
 
-    // Invisible button covering the canvas catches all mouse events.
     _ = zgui.invisibleButton("##canvas_drag", .{ .w = canvas_size[0], .h = canvas_size[1], .flags = .{} });
 
-    // Mouse-down: hit-test entity markers, update selection, and arm
-    // drag-to-move only when the click landed on an entity. Done
-    // *before* the drag handler so `drag_armed` reflects this frame's
-    // click before any drag-delta is consumed.
+    // Mouse-down: hit-test entity markers, arm drag-to-move only when
+    // the click landed on an entity.
     if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.left)) {
         const mouse = zgui.getMousePos();
-        const hit = hitTestEntity(loaded.scene.entities, mouse, canvas_min, s.pan, s.zoom);
+        const hit = hitTestEntity(s.loaded.scene.entities, mouse, canvas_min, s.pan, s.zoom);
         s.selected_index = hit;
         s.drag_armed = hit != null;
     }
-    // Disarm when the left button is released, even if the drag ended
-    // outside the canvas item.
     if (!zgui.isMouseDown(.left)) s.drag_armed = false;
 
     if (zgui.isItemActive()) {
-        // Pan with middle-button drag.
         if (zgui.isMouseDragging(.middle, 0)) {
             const d = zgui.getMouseDragDelta(.middle, .{});
             s.pan[0] += d[0];
             s.pan[1] += d[1];
             zgui.resetMouseDragDelta(.middle);
         }
-        // Drag-to-move on the selected entity with left-button drag —
-        // only when the drag was armed by a click on the entity itself,
-        // so a click in empty space (which deselects) followed by a drag
-        // doesn't drag the previously-selected entity.
         if (s.drag_armed) {
             if (s.selected_index) |idx| {
-                if (idx < loaded.scene.entities.len and zgui.isMouseDragging(.left, 0)) {
-                    const e = &loaded.scene.entities[idx];
+                if (idx < s.loaded.scene.entities.len and zgui.isMouseDragging(.left, 0)) {
+                    const e = &s.loaded.scene.entities[idx];
                     if (e.position) |*pos| {
                         const d = zgui.getMouseDragDelta(.left, .{});
                         pos.x += d[0] / s.zoom;
-                        // Screen +y is down but world +y is up, so a
-                        // downward mouse drag should decrease world y.
+                        // World +y is up; screen +y is down.
                         pos.y -= d[1] / s.zoom;
                         s.is_dirty = true;
                         zgui.resetMouseDragDelta(.left);
@@ -413,52 +221,16 @@ fn renderViewport(s: *SceneState, loaded: scene_io.LoadedScene) void {
     }
 }
 
-/// Pixel radius around an entity marker that counts as a click.
-pub const hit_radius: f32 = 10.0;
-
-/// Return the index of the closest entity whose screen-space marker is
-/// within `hit_radius` pixels of `mouse`, or null if none qualify.
-/// `canvas_min`, `pan`, and `zoom` determine the world-to-screen
-/// projection. Pure / no UI side effects so zspec can drive it.
-pub fn hitTestEntity(
-    entities: []scene_io.Entity,
-    mouse: [2]f32,
-    canvas_min: [2]f32,
-    pan: [2]f32,
-    zoom: f32,
-) ?usize {
-    var best: ?usize = null;
-    var best_d2: f32 = hit_radius * hit_radius;
-    for (entities, 0..) |e, i| {
-        const pos = e.position orelse continue;
-        const px = canvas_min[0] + pan[0] + pos.x * zoom;
-        // Match drawEntities — world +y is up, so subtract from screen y.
-        const py = canvas_min[1] + pan[1] - pos.y * zoom;
-        const dx = mouse[0] - px;
-        const dy = mouse[1] - py;
-        const d2 = dx * dx + dy * dy;
-        if (d2 < best_d2) {
-            best_d2 = d2;
-            best = i;
-        }
-    }
-    return best;
-}
-
 fn drawGrid(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, s: SceneState) void {
-    const grid_world: f32 = 64; // world units per cell
+    const grid_world: f32 = 64;
     const step = grid_world * s.zoom;
-    if (step <= 4) return; // too dense to be useful
+    if (step <= 4) return;
 
     const col_major: u32 = 0x40_ff_ff_ff;
-    const col_minor: u32 = 0x20_ff_ff_ff;
-    _ = col_minor;
 
-    // Where world (0,0) lands in canvas space.
     const origin_x = cmin[0] + s.pan[0];
     const origin_y = cmin[1] + s.pan[1];
 
-    // Vertical lines.
     var x = origin_x;
     while (x > cmin[0]) : (x -= step) {}
     while (x < cmax[0]) : (x += step) {
@@ -469,7 +241,6 @@ fn drawGrid(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, s: SceneState) void {
             .thickness = 1.0,
         });
     }
-    // Horizontal lines.
     var y = origin_y;
     while (y > cmin[1]) : (y -= step) {}
     while (y < cmax[1]) : (y += step) {
@@ -481,7 +252,6 @@ fn drawGrid(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, s: SceneState) void {
         });
     }
 
-    // Axis lines (slightly brighter) through world origin.
     dl.addLine(.{ .p1 = .{ origin_x, cmin[1] }, .p2 = .{ origin_x, cmax[1] }, .col = 0x80_ff_ff_ff, .thickness = 1.0 });
     dl.addLine(.{ .p1 = .{ cmin[0], origin_y }, .p2 = .{ cmax[0], origin_y }, .col = 0x80_ff_ff_ff, .thickness = 1.0 });
 }
@@ -491,9 +261,7 @@ fn drawEntities(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, s: SceneState, lo
     for (loaded.scene.entities, 0..) |e, i| {
         const pos = e.position orelse continue;
         const px = cmin[0] + s.pan[0] + pos.x * s.zoom;
-        // World +y goes up; ImGui screen +y goes down. Flip during
-        // projection so the editor's spatial intuition matches the
-        // math convention (positive y above the origin axis line).
+        // World +y is up.
         const py = cmin[1] + s.pan[1] - pos.y * s.zoom;
         const col = colorForPrefab(e.prefab);
         dl.addCircleFilled(.{
@@ -503,7 +271,6 @@ fn drawEntities(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, s: SceneState, lo
             .num_segments = 16,
         });
         if (s.selected_index == i) {
-            // Highlight ring around the selected entity.
             dl.addCircle(.{
                 .p = .{ px, py },
                 .r = 12,
@@ -518,8 +285,32 @@ fn drawEntities(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, s: SceneState, lo
     }
 }
 
-/// Stable per-prefab color. Hashes the prefab name to a hue so distinct
-/// prefabs visually separate without us shipping a palette table.
+pub const hit_radius: f32 = 10.0;
+
+pub fn hitTestEntity(
+    entities: []scene_io.Entity,
+    mouse: [2]f32,
+    canvas_min: [2]f32,
+    pan: [2]f32,
+    zoom: f32,
+) ?usize {
+    var best: ?usize = null;
+    var best_d2: f32 = hit_radius * hit_radius;
+    for (entities, 0..) |e, i| {
+        const pos = e.position orelse continue;
+        const px = canvas_min[0] + pan[0] + pos.x * zoom;
+        const py = canvas_min[1] + pan[1] - pos.y * zoom;
+        const dx = mouse[0] - px;
+        const dy = mouse[1] - py;
+        const d2 = dx * dx + dy * dy;
+        if (d2 < best_d2) {
+            best_d2 = d2;
+            best = i;
+        }
+    }
+    return best;
+}
+
 fn colorForPrefab(prefab: ?[]const u8) u32 {
     const h = if (prefab) |p| std.hash.Wyhash.hash(0, p) else 0;
     const r: u8 = @truncate((h >> 0) | 0x80);
@@ -527,4 +318,3 @@ fn colorForPrefab(prefab: ?[]const u8) u32 {
     const b: u8 = @truncate((h >> 16) | 0x80);
     return (@as(u32, 0xff) << 24) | (@as(u32, b) << 16) | (@as(u32, g) << 8) | r;
 }
-

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -8,6 +8,7 @@ const compiler = @import("compiler.zig");
 const new_scene = @import("dialogs/new_scene.zig");
 const scene_io = @import("scene_io.zig");
 const scene_module = @import("modules/scene.zig");
+const project_tree = @import("modules/project_tree.zig");
 
 test {
     zspec.runAll(@This());
@@ -581,6 +582,28 @@ pub const SceneIoTests = struct {
         var loaded = try scene_io.parseScene(allocator, src);
         defer loaded.deinit();
         try expect.toBeTrue(loaded.scene.entities[0].position == null);
+    }
+};
+
+pub const SceneRoutingTests = struct {
+    test "scene path under scenes/ is accepted" {
+        try expect.toBeTrue(project_tree.isScenePath("/p", "/p/scenes/main.jsonc"));
+        try expect.toBeTrue(project_tree.isScenePath("/p", "/p/scenes/sub/fragment.jsonc"));
+    }
+
+    test "prefab path is rejected" {
+        // Same extension, different folder — must not open as a scene
+        // (would otherwise be data-destructive on Save).
+        try expect.toBeFalse(project_tree.isScenePath("/p", "/p/prefabs/coin.jsonc"));
+    }
+
+    test "non-jsonc files are rejected" {
+        try expect.toBeFalse(project_tree.isScenePath("/p", "/p/scenes/main.json"));
+        try expect.toBeFalse(project_tree.isScenePath("/p", "/p/scenes/notes.md"));
+    }
+
+    test "no project dir → no scene routing" {
+        try expect.toBeFalse(project_tree.isScenePath(null, "/p/scenes/main.jsonc"));
     }
 };
 


### PR DESCRIPTION
## Summary

Replaces View > Scene as a togglable panel with a tab-based editor opened from the project tree. Clicking a `.jsonc` file in the tree opens it as a tab in the main content area; multiple scenes can be open simultaneously; closing a dirty tab pops a confirmation dialog.

## What changed

**Lifecycle**
- `SceneState` is now allocation-based — owns its own arena (path + display name) and a `LoadedScene` (parsed-scene arena). Constructor `open(allocator, path)`, destructor `deinit(allocator)`.
- `App.open_scenes: ArrayList(SceneState)` + `active_scene_idx` + `pending_close_idx` + `last_project_generation`.
- `openScene(path)`, `closeScene(idx)`, `requestCloseScene(idx)` (dirty-aware), `closeAllScenes`.
- Project transitions (`ProjectManager.generation` change) → `closeAllScenes` automatically.

**Routing**
- `project_tree.zig` catches the tree's "newly selected" signal and routes `.jsonc` paths to `app.openScene(path)`.

**UI**
- `renderMainContent` shows a `zgui.TabBar` when any scenes are open; otherwise the Welcome view.
- Tab labels use the path as imgui ID disambiguator and ImGui's `unsaved_document` flag for the dirty marker.
- `dialogs/close_scene.zig` modal: Save and close / Discard / Cancel.

**Removed**
- Scene from `App.modules` array (no longer in View menu).
- The in-Scene file list, Refresh button, `selected_name`/`loaded_name`/`maybeLoadSelected`/`syncProjectChange` plumbing — the project tree is the file-discovery source.

## Tests

| Layer | What |
|---|---|
| zspec | 71/71, unchanged |
| TE | 5/5 — `scene_open_save_preserves_extras` rewritten to drive the new API (`app.openScene` → in-tab edit → `scene_mod.saveScene` → reread file & verify Sprite+Position) |
| smoke | green |

The old `scene_panel_toggles` TE test is gone (no menu to toggle).

## Notable observation about Zig + TE

The previous `scene_save_preserves_extras` test referenced fields (`scene_state`, `show_scene`) that I removed in this refactor. The build still went green because Zig lazy-analyzes function bodies inside anonymous Callbacks structs used by `registerTest` — the runtime never hit them. Rewriting the test under the new API makes it actually exercise the code path.

## Test plan

- [ ] `zig build && zig build test && zig build gui-test`
- [ ] Open a project with multiple `.jsonc` scenes (e.g. `../flying-platform-labelle/`)
- [ ] Click `loading.jsonc` → opens as tab
- [ ] Click `main.jsonc` → opens as a second tab, switchable
- [ ] Edit an entity in one tab → `*` shows on tab label
- [ ] Click × on dirty tab → "Save and close / Discard / Cancel" dialog
- [ ] Cancel → tab stays. Discard → tab closes without writing. Save and close → file persists then tab closes.
- [ ] Close the project → all tabs auto-close