### PR TITLE
Prefab editor — shared inspector, tab variant alongside Scene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,24 +71,36 @@ Known limitations of the pass-through:
 2. **Project = directory.** `Project.dir` holds the project directory; `<dir>/project.labelle` is the editable file. Open / Save dialogs use `nfd.openFolderDialog`, not file dialogs.
 3. **Don't reintroduce `build.zig` template generation.** The assembler owns that. If you find yourself writing build files from the gui, you're going the wrong direction.
 
-## Scene editor: tabs, not a panel
+## Editor tabs: scenes and prefabs
 
-The Scene editor isn't a togglable panel through the View menu. Instead:
+Editor tabs aren't togglable panels through the View menu. Instead:
 
 - The user clicks a `.jsonc` file in the Project Tree → `project_tree`
-  routes it through `App.openScene(path)` → a new `SceneState` is
-  appended to `App.open_scenes`.
-- The main content area renders a `TabBar` when `open_scenes.len > 0`;
-  each tab's body is `scene_mod.render(state, app)`.
+  classifies it by directory (`isScenePath`/`isPrefabPath`) and routes
+  it through `App.openScene(path)` or `App.openPrefab(path)` → a new
+  `SceneState` or `PrefabState` is appended to `App.open_tabs`
+  (wrapped in an `OpenTab` tagged union).
+- The main content area renders a `TabBar` when `open_tabs.len > 0`;
+  each tab's body comes from `OpenTab.render(app)`, which dispatches
+  to `scene_mod.render` or `prefab_mod.render`.
 - The × close button on a dirty tab opens `dialogs/close_scene.zig`
   (Save and close / Discard / Cancel) via `App.pending_close_idx`.
+  The modal calls `OpenTab.save(app)` which dispatches by variant.
 - Project transitions (`ProjectManager.generation` change) trigger
-  `App.closeAllScenes` so the next frame doesn't read freed memory
+  `App.closeAllTabs` so the next frame doesn't read freed memory
   belonging to the old project.
+- `OpenTab` has `displayName`, `path`, `isDirty`, `save`, `render`,
+  `deinit` — the rest of `App` (tab strip, close modal, dedup on
+  open) only goes through these, never inspects the variant.
 
-Each `SceneState` carries its own arena (path + display name) and
-owns a `LoadedScene` (parsed-scene arena from `scene_io.parseScene`).
-`SceneState.deinit(allocator)` frees both.
+Both `SceneState` and `PrefabState` carry their own arena (path +
+display name) and own a `Loaded*` value (parsed-source arena from
+`scene_io`). `deinit(allocator)` frees both.
+
+The Scene editor has a viewport (pan/zoom canvas, hit-test, drag-to-
+move); the Prefab editor doesn't — a prefab is a single entity
+blueprint without positions on a canvas. Both share the entity
+inspector via `modules/inspector.zig`.
 
 ## Adding a new module
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,21 @@ Both `SceneState` and `PrefabState` carry their own arena (path +
 display name) and own a `Loaded*` value (parsed-source arena from
 `scene_io`). `deinit(allocator)` frees both.
 
-The Scene editor has a viewport (pan/zoom canvas, hit-test, drag-to-
-move); the Prefab editor doesn't — a prefab is a single entity
-blueprint without positions on a canvas. Both share the entity
-inspector via `modules/inspector.zig`.
+Both editors have a two-column layout: viewport on the left, inspector
+on the right. The shared `modules/viewport.zig` draws entity markers
+on a pan/zoom canvas, handles hit-test, and drives drag-to-move; the
+shared `modules/inspector.zig` renders one entity's editable surface.
+
+- Scene tab → viewport operates on `loaded.scene.entities`.
+- Prefab tab → viewport operates on `loaded.children` (sub-entities
+  with their own Position + components). The prefab's own components
+  live on `loaded.entity`; when nothing is selected in the viewport
+  the inspector shows them, otherwise it shows the selected child.
+
+Sub-entities nested inside a component value (e.g. `Room.workstations`)
+ride along as part of the parent component's verbatim extras — not
+modeled structurally. Editing them means hand-editing the file (or
+extending the gui's component understanding later).
 
 ## Adding a new module
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ src/
     scene.zig                    # Scene editor (per-tab state; opens via tree click on scenes/*.jsonc)
     prefab.zig                   # Prefab editor (per-tab state; opens via tree click on prefabs/*.jsonc)
     inspector.zig                # Shared entity inspector — called by both scene.zig and prefab.zig
+    viewport.zig                 # Shared 2D pan/zoom canvas — used by scene.zig and prefab.zig
   dialogs/
     new_scene.zig                # New Scene modal + scene-file writer
     dpi_warning.zig              # One-shot DPI-changed warning modal

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ src/
     project_settings.zig         # Edit ProjectConfig fields and persist via ProjectManager
     project_tree.zig             # Project sidebar (file tree)
     resources.zig                # Edit `resources` block (sprite atlases)
-    scene.zig                    # Scene editor (per-tab state; opens via tree click, not View menu)
+    scene.zig                    # Scene editor (per-tab state; opens via tree click on scenes/*.jsonc)
+    prefab.zig                   # Prefab editor (per-tab state; opens via tree click on prefabs/*.jsonc)
+    inspector.zig                # Shared entity inspector — called by both scene.zig and prefab.zig
   dialogs/
     new_scene.zig                # New Scene modal + scene-file writer
     dpi_warning.zig              # One-shot DPI-changed warning modal

--- a/src/app.zig
+++ b/src/app.zig
@@ -20,12 +20,66 @@ const project_settings_mod = @import("modules/project_settings.zig");
 const project_tree_mod = @import("modules/project_tree.zig");
 const resources_mod = @import("modules/resources.zig");
 const scene_mod = @import("modules/scene.zig");
+const prefab_mod = @import("modules/prefab.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
 const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
 
 const STATUS_BUF_LEN = 256;
 const SCENE_NAME_BUF_LEN = 128;
+
+/// One entry in the main-content tab strip. Today only `scene`
+/// exists; the `prefab` variant lands in a follow-up slice. The
+/// union exists now so the tab strip, close-confirmation modal, and
+/// `App.open_tabs` machinery don't need a second pass when prefab
+/// support arrives — they already dispatch through the methods
+/// below.
+pub const OpenTab = union(enum) {
+    scene: scene_mod.SceneState,
+    prefab: prefab_mod.PrefabState,
+
+    pub fn deinit(self: *OpenTab, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .scene => |*s| s.deinit(allocator),
+            .prefab => |*p| p.deinit(allocator),
+        }
+    }
+
+    pub fn render(self: *OpenTab, app: *App) void {
+        switch (self.*) {
+            .scene => |*s| scene_mod.render(s, app),
+            .prefab => |*p| prefab_mod.render(p, app),
+        }
+    }
+
+    pub fn save(self: *OpenTab, app: *App) void {
+        switch (self.*) {
+            .scene => |*s| scene_mod.saveScene(s, app),
+            .prefab => |*p| prefab_mod.savePrefab(p, app),
+        }
+    }
+
+    pub fn displayName(self: OpenTab) []const u8 {
+        return switch (self) {
+            .scene => |s| s.display_name,
+            .prefab => |p| p.display_name,
+        };
+    }
+
+    pub fn path(self: OpenTab) []const u8 {
+        return switch (self) {
+            .scene => |s| s.path,
+            .prefab => |p| p.path,
+        };
+    }
+
+    pub fn isDirty(self: OpenTab) bool {
+        return switch (self) {
+            .scene => |s| s.is_dirty,
+            .prefab => |p| p.is_dirty,
+        };
+    }
+};
 
 pub const App = struct {
     allocator: std.mem.Allocator,
@@ -49,14 +103,14 @@ pub const App = struct {
     show_resources: bool = false,
     resources_editor: resources_mod.ResourcesEditor = .{},
 
-    /// Scene editor tabs. Each entry owns a loaded `.jsonc` plus
-    /// per-tab UI state (selection, pan/zoom, dirty flag). Populated
-    /// when the user clicks a `.jsonc` file in the project tree;
-    /// `closeAllScenes` runs on project transitions.
-    open_scenes: std.ArrayList(scene_mod.SceneState) = .{},
-    /// Which tab is foregrounded. null when no scenes are open.
+    /// Open editor tabs. Each entry is an `OpenTab` (currently only
+    /// scene, prefab landing in a follow-up). Populated when the
+    /// user clicks an editable file in the project tree; closed via
+    /// the × on a tab. `closeAllTabs` runs on project transitions.
+    open_tabs: std.ArrayList(OpenTab) = .{},
+    /// Which tab is foregrounded. null when no tabs are open.
     /// Updated each frame from whichever tab ImGui reports active.
-    active_scene_idx: ?usize = null,
+    active_tab_idx: ?usize = null,
     /// One-shot: when set, the next `renderSceneTabs` forces this tab
     /// to be active via ImGui's `set_selected` flag, then clears the
     /// field. `set_selected` is one-shot in ImGui — applying it every
@@ -68,7 +122,7 @@ pub const App = struct {
     /// closed.
     pending_close_idx: ?usize = null,
     /// Last seen `ProjectManager.generation`. Compared each frame so
-    /// `closeAllScenes` runs the frame the active project changes.
+    /// `closeAllTabs` runs the frame the active project changes.
     last_project_generation: ?u64 = null,
 
     show_project_tree: bool = true,
@@ -106,8 +160,8 @@ pub const App = struct {
     }
 
     pub fn deinit(self: *Self) void {
-        self.closeAllScenes();
-        self.open_scenes.deinit(self.allocator);
+        self.closeAllTabs();
+        self.open_tabs.deinit(self.allocator);
         self.project_manager.deinit();
         self.tree_view.deinit();
         self.compiler.deinit();
@@ -116,44 +170,60 @@ pub const App = struct {
 
     // ─── Scene tabs ─────────────────────────────────────────────────────
 
-    /// Open `path` (typically a `.jsonc` under the project's `scenes/`
-    /// directory) as a tab in the main content area. If the path is
-    /// already open, focuses the existing tab instead of reloading.
+    /// Open a `.jsonc` scene file (under `<project>/scenes/`) as a
+    /// tab in the main content area. Already-open scenes refocus
+    /// instead of reloading; `project_tree.isScenePath` is the
+    /// router's path discriminator.
     pub fn openScene(self: *Self, path: []const u8) !void {
-        for (self.open_scenes.items, 0..) |s, i| {
-            if (std.mem.eql(u8, s.path, path)) {
-                self.focus_tab_idx = i; // bring the existing tab forward once
+        // De-dup by path: refocus an existing tab rather than reloading.
+        // Other variants (`prefab`) compare paths the same way.
+        for (self.open_tabs.items, 0..) |t, i| {
+            if (std.mem.eql(u8, t.path(), path)) {
+                self.focus_tab_idx = i;
                 return;
             }
         }
+
         var state = try scene_mod.SceneState.open(self.allocator, path);
         errdefer state.deinit(self.allocator);
-        try self.open_scenes.append(self.allocator, state);
-        const new_idx = self.open_scenes.items.len - 1;
-        self.active_scene_idx = new_idx;
+        try self.open_tabs.append(self.allocator, .{ .scene = state });
+        const new_idx = self.open_tabs.items.len - 1;
+        self.active_tab_idx = new_idx;
         self.focus_tab_idx = new_idx;
     }
 
-    /// Close the tab at `idx` unconditionally. Caller is responsible
-    /// for asking the user about unsaved changes — `closeSceneSafe`
-    /// does that.
-    pub fn closeScene(self: *Self, idx: usize) void {
-        if (idx >= self.open_scenes.items.len) return;
-        var removed = self.open_scenes.orderedRemove(idx);
-        removed.deinit(self.allocator);
-
-        if (self.open_scenes.items.len == 0) {
-            self.active_scene_idx = null;
-        } else if (self.active_scene_idx) |a| {
-            if (a == idx) {
-                self.active_scene_idx = if (idx > 0) idx - 1 else 0;
-            } else if (a > idx) {
-                self.active_scene_idx = a - 1;
+    pub fn openPrefab(self: *Self, path: []const u8) !void {
+        for (self.open_tabs.items, 0..) |t, i| {
+            if (std.mem.eql(u8, t.path(), path)) {
+                self.focus_tab_idx = i;
+                return;
             }
         }
-        // If pending_close was pointing at this tab (or one shifted by
-        // the removal), clear / adjust it so the dialog doesn't end up
-        // tracking the wrong tab.
+
+        var state = try prefab_mod.PrefabState.open(self.allocator, path);
+        errdefer state.deinit(self.allocator);
+        try self.open_tabs.append(self.allocator, .{ .prefab = state });
+        const new_idx = self.open_tabs.items.len - 1;
+        self.active_tab_idx = new_idx;
+        self.focus_tab_idx = new_idx;
+    }
+
+    /// Close the tab at `idx` unconditionally. Caller asks the user
+    /// about unsaved changes via `requestCloseTab` first.
+    pub fn closeTab(self: *Self, idx: usize) void {
+        if (idx >= self.open_tabs.items.len) return;
+        var removed = self.open_tabs.orderedRemove(idx);
+        removed.deinit(self.allocator);
+
+        if (self.open_tabs.items.len == 0) {
+            self.active_tab_idx = null;
+        } else if (self.active_tab_idx) |a| {
+            if (a == idx) {
+                self.active_tab_idx = if (idx > 0) idx - 1 else 0;
+            } else if (a > idx) {
+                self.active_tab_idx = a - 1;
+            }
+        }
         if (self.pending_close_idx) |p| {
             if (p == idx) {
                 self.pending_close_idx = null;
@@ -163,21 +233,20 @@ pub const App = struct {
         }
     }
 
-    /// Close the tab at `idx`, prompting the user first if the tab has
-    /// unsaved changes.
-    pub fn requestCloseScene(self: *Self, idx: usize) void {
-        if (idx >= self.open_scenes.items.len) return;
-        if (self.open_scenes.items[idx].is_dirty) {
+    /// Close the tab at `idx`, prompting first if the tab is dirty.
+    pub fn requestCloseTab(self: *Self, idx: usize) void {
+        if (idx >= self.open_tabs.items.len) return;
+        if (self.open_tabs.items[idx].isDirty()) {
             self.pending_close_idx = idx;
         } else {
-            self.closeScene(idx);
+            self.closeTab(idx);
         }
     }
 
-    pub fn closeAllScenes(self: *Self) void {
-        for (self.open_scenes.items) |*s| s.deinit(self.allocator);
-        self.open_scenes.clearRetainingCapacity();
-        self.active_scene_idx = null;
+    pub fn closeAllTabs(self: *Self) void {
+        for (self.open_tabs.items) |*t| t.deinit(self.allocator);
+        self.open_tabs.clearRetainingCapacity();
+        self.active_tab_idx = null;
         self.focus_tab_idx = null;
         self.pending_close_idx = null;
     }
@@ -203,7 +272,7 @@ pub const App = struct {
         // bumped on new/load/close.
         const gen = self.project_manager.generation;
         if (self.last_project_generation) |prev| {
-            if (prev != gen) self.closeAllScenes();
+            if (prev != gen) self.closeAllTabs();
         }
         self.last_project_generation = gen;
 
@@ -404,7 +473,7 @@ pub const App = struct {
         // a TabBar; the welcome view is purely the empty-state. The
         // first frame after `openScene` selects the new tab via
         // `set_selected` so the user lands on what they just clicked.
-        if (self.open_scenes.items.len > 0) {
+        if (self.open_tabs.items.len > 0) {
             self.renderSceneTabs();
             return;
         }
@@ -446,17 +515,16 @@ pub const App = struct {
 
         var to_close: ?usize = null;
 
-        for (self.open_scenes.items, 0..) |*s, i| {
+        for (self.open_tabs.items, 0..) |*tab, i| {
             // Disambiguate tabs by full path so two scenes with the
             // same stem (across projects or fragments) get distinct
             // imgui IDs. `unsaved_document` puts ImGui's own marker
             // on dirty tabs. Buffer is sized for the longest plausible
-            // absolute path (`std.fs.max_path_bytes`, which is 4096 on
-            // Linux + larger limits on macOS) plus slack for the label
-            // prefix; smaller buffers silently dropped the tab when
-            // pointed at deeply-nested project paths.
+            // absolute path (`std.fs.max_path_bytes`) plus slack for
+            // the label prefix; smaller buffers silently dropped the
+            // tab when pointed at deeply-nested project paths.
             var label_buf: [std.fs.max_path_bytes + 256]u8 = undefined;
-            const label = std.fmt.bufPrintZ(&label_buf, "{s}##{s}", .{ s.display_name, s.path }) catch continue;
+            const label = std.fmt.bufPrintZ(&label_buf, "{s}##{s}", .{ tab.displayName(), tab.path() }) catch continue;
 
             var open: bool = true;
             // `set_selected` is one-shot in ImGui — fire it only when
@@ -465,16 +533,16 @@ pub const App = struct {
             // Applying it every frame creates a feedback loop that
             // prevents the user from switching tabs by clicking.
             const set_selected = focus != null and focus.? == i;
-            const flags: zgui.TabItemFlags = .{ .set_selected = set_selected, .unsaved_document = s.is_dirty };
+            const flags: zgui.TabItemFlags = .{ .set_selected = set_selected, .unsaved_document = tab.isDirty() };
             if (zgui.beginTabItem(label, .{ .p_open = &open, .flags = flags })) {
-                self.active_scene_idx = i;
-                scene_mod.render(s, self);
+                self.active_tab_idx = i;
+                tab.render(self);
                 zgui.endTabItem();
             }
             if (!open and to_close == null) to_close = i;
         }
 
-        if (to_close) |i| self.requestCloseScene(i);
+        if (to_close) |i| self.requestCloseTab(i);
     }
 
     fn renderStatusBar(self: *Self) void {

--- a/src/dialogs/close_scene.zig
+++ b/src/dialogs/close_scene.zig
@@ -3,8 +3,8 @@
 //! means "the tab at this index has been ×'d and is dirty; ask the
 //! user what to do." Three resolutions:
 //!
-//! - **Save and close**: writes the scene back to disk via the Scene
-//!   module's `saveScene` and then drops the tab.
+//! - **Save and close**: writes the tab back to disk via its
+//!   `OpenTab.save` (dispatches on tab kind) and then drops the tab.
 //! - **Discard**: drops the tab without writing.
 //! - **Cancel**: keeps the tab open; `pending_close_idx` is cleared
 //!   so subsequent close attempts re-fire the dialog.
@@ -12,35 +12,34 @@
 const zgui = @import("zgui");
 
 const App = @import("../app.zig").App;
-const scene_mod = @import("../modules/scene.zig");
 
 pub fn render(app: *App) void {
     const idx = app.pending_close_idx orelse return;
-    if (idx >= app.open_scenes.items.len) {
-        // Tab was already gone (e.g. closeAllScenes ran between
+    if (idx >= app.open_tabs.items.len) {
+        // Tab was already gone (e.g. closeAllTabs ran between
         // request and dialog render). Drop the request silently.
         app.pending_close_idx = null;
         return;
     }
-    const state = &app.open_scenes.items[idx];
+    const tab = &app.open_tabs.items[idx];
 
-    zgui.openPopup("Unsaved scene", .{});
-    if (!zgui.beginPopupModal("Unsaved scene", .{ .flags = .{ .always_auto_resize = true } })) return;
+    zgui.openPopup("Unsaved changes", .{});
+    if (!zgui.beginPopupModal("Unsaved changes", .{ .flags = .{ .always_auto_resize = true } })) return;
     defer zgui.endPopup();
 
-    zgui.text("Scene \"{s}\" has unsaved changes.", .{state.display_name});
+    zgui.text("\"{s}\" has unsaved changes.", .{tab.displayName()});
     zgui.text("Save before closing?", .{});
     zgui.spacing();
     zgui.separator();
     zgui.spacing();
 
     if (zgui.button("Save and close", .{ .w = 150 })) {
-        scene_mod.saveScene(state, app);
-        if (!state.is_dirty) {
+        tab.save(app);
+        if (!tab.isDirty()) {
             // Save succeeded — close.
-            app.closeScene(idx);
+            app.closeTab(idx);
         }
-        // If save_scene failed, is_dirty stays true; status bar already
+        // If save failed, is_dirty stays true; status bar already
         // surfaces the error. Keep the dialog dismissed so the user
         // can investigate without it re-firing on the next frame.
         app.pending_close_idx = null;
@@ -48,7 +47,7 @@ pub fn render(app: *App) void {
     }
     zgui.sameLine(.{});
     if (zgui.button("Discard", .{ .w = 100 })) {
-        app.closeScene(idx);
+        app.closeTab(idx);
         app.pending_close_idx = null;
         zgui.closeCurrentPopup();
     }

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -11,6 +11,7 @@ const zgui = @import("zgui");
 
 const App = @import("app.zig").App;
 const scene_mod = @import("modules/scene.zig");
+const prefab_mod = @import("modules/prefab.zig");
 
 const gl_major = 4;
 const gl_minor = 1;
@@ -143,6 +144,70 @@ pub fn main() !void {
         sf.close();
     }
 
+    // And a prefab so the prefab editor's open + save path has
+    // something to test against.
+    {
+        var prefab_path_buf: [512]u8 = undefined;
+        const prefab_path = try std.fmt.bufPrint(&prefab_path_buf, "{s}/prefabs/coin.jsonc", .{tmp});
+        const pf = try std.fs.cwd().createFile(prefab_path, .{});
+        try pf.writeAll(
+            \\{
+            \\    "components": {
+            \\        "Sprite": { "sprite_name": "coin", "pivot": "center" },
+            \\        "Coin": {}
+            \\    }
+            \\}
+        );
+        pf.close();
+    }
+
+    _ = engine.registerTest("phase3", "prefab_open_save_preserves_extras", @src(), struct {
+        fn gui(_: *zgui.te.TestContext) !void {
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            const dir = g_settings_project_dir.?;
+            var path_buf: [512]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "{s}/prefabs/coin.jsonc", .{dir}) catch return;
+
+            a.openPrefab(path) catch {
+                _ = zgui.te.check(@src(), .{}, false, "openPrefab must succeed");
+                return;
+            };
+            ctx.yield(1);
+
+            const opened_ok = a.open_tabs.items.len == 1 and
+                a.open_tabs.items[0] == .prefab and
+                a.open_tabs.items[0].prefab.loaded.component_extras.len == 2;
+            _ = zgui.te.check(@src(), .{}, opened_ok, "prefab opened with 2 components");
+
+            // Set a Position on the prefab + save via the public API.
+            const tab = &a.open_tabs.items[0].prefab;
+            tab.loaded.entity.position = .{ .x = 7, .y = 11 };
+            tab.is_dirty = true;
+            prefab_mod.savePrefab(tab, a);
+            _ = zgui.te.check(@src(), .{}, !tab.is_dirty, "is_dirty cleared after Save");
+
+            var file_buf: [4096]u8 = undefined;
+            const file = std.fs.cwd().openFile(path, .{}) catch return;
+            defer file.close();
+            const n = file.read(&file_buf) catch return;
+            const content = file_buf[0..n];
+
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Sprite\"") != null, "Sprite preserved on disk");
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Coin\"") != null, "Coin preserved on disk");
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"x\": 7") != null, "Position x persisted");
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"y\": 11") != null, "Position y persisted");
+
+            a.closeTab(0);
+        }
+    });
+
     _ = engine.registerTest("phase3", "scene_open_save_preserves_extras", @src(), struct {
         fn gui(_: *zgui.te.TestContext) !void {
             if (g_app) |a| a.renderFrame(1.0 / 60.0);
@@ -165,8 +230,9 @@ pub fn main() !void {
             };
             ctx.yield(1);
 
-            const opened_ok = a.open_scenes.items.len == 1 and
-                a.open_scenes.items[0].loaded.scene.entities.len == 1;
+            const opened_ok = a.open_tabs.items.len == 1 and
+                a.open_tabs.items[0] == .scene and
+                a.open_tabs.items[0].scene.loaded.scene.entities.len == 1;
             _ = zgui.te.check(@src(), .{}, opened_ok, "scene opened with one entity");
 
             // Edit the in-memory position, then save via the module's
@@ -174,7 +240,7 @@ pub fn main() !void {
             // calls). Driving the button via TE refs through the
             // nested tab-bar ID stack is brittle; saveScene is what we
             // actually care about here.
-            const tab = &a.open_scenes.items[0];
+            const tab = &a.open_tabs.items[0].scene;
             tab.loaded.scene.entities[0].position.?.x = 999;
             tab.is_dirty = true;
             scene_mod.saveScene(tab, a);
@@ -190,7 +256,7 @@ pub fn main() !void {
             _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"x\": 999") != null, "edited Position written");
 
             // Close the tab cleanly so subsequent tests see a fresh App.
-            a.closeScene(0);
+            a.closeTab(0);
         }
     });
 

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -144,8 +144,10 @@ pub fn main() !void {
         sf.close();
     }
 
-    // And a prefab so the prefab editor's open + save path has
-    // something to test against.
+    // And a prefab with both top-level components and a children
+    // array so the prefab editor's children-editing path has
+    // something to test against (mirrors hydroponics-style prefabs
+    // in real projects).
     {
         var prefab_path_buf: [512]u8 = undefined;
         const prefab_path = try std.fmt.bufPrint(&prefab_path_buf, "{s}/prefabs/coin.jsonc", .{tmp});
@@ -155,7 +157,10 @@ pub fn main() !void {
             \\    "components": {
             \\        "Sprite": { "sprite_name": "coin", "pivot": "center" },
             \\        "Coin": {}
-            \\    }
+            \\    },
+            \\    "children": [
+            \\        { "components": { "Sprite": { "n": "deco" }, "Position": { "x": 1, "y": 2 } } }
+            \\    ]
             \\}
         );
         pf.close();
@@ -183,12 +188,15 @@ pub fn main() !void {
 
             const opened_ok = a.open_tabs.items.len == 1 and
                 a.open_tabs.items[0] == .prefab and
-                a.open_tabs.items[0].prefab.loaded.component_extras.len == 2;
-            _ = zgui.te.check(@src(), .{}, opened_ok, "prefab opened with 2 components");
+                a.open_tabs.items[0].prefab.loaded.component_extras.len == 2 and
+                a.open_tabs.items[0].prefab.loaded.children.len == 1;
+            _ = zgui.te.check(@src(), .{}, opened_ok, "prefab opened with 2 components + 1 child");
 
-            // Set a Position on the prefab + save via the public API.
+            // Move the child's Position, save through the public API,
+            // and confirm the new position lands on disk while Sprite +
+            // Coin survive verbatim.
             const tab = &a.open_tabs.items[0].prefab;
-            tab.loaded.entity.position = .{ .x = 7, .y = 11 };
+            tab.loaded.children[0].position.?.x = 999;
             tab.is_dirty = true;
             prefab_mod.savePrefab(tab, a);
             _ = zgui.te.check(@src(), .{}, !tab.is_dirty, "is_dirty cleared after Save");
@@ -201,8 +209,8 @@ pub fn main() !void {
 
             _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Sprite\"") != null, "Sprite preserved on disk");
             _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Coin\"") != null, "Coin preserved on disk");
-            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"x\": 7") != null, "Position x persisted");
-            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"y\": 11") != null, "Position y persisted");
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"x\": 999") != null, "child Position x persisted");
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"children\":") != null, "children block emitted");
 
             a.closeTab(0);
         }

--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -1,0 +1,72 @@
+//! Shared entity inspector — renders an entity's properties +
+//! components into the current imgui window. Called from both the
+//! Scene module (one selected entity at a time) and, once it lands,
+//! the Prefab module (the single entity that is the prefab).
+//!
+//! `is_dirty` is a `*bool` so the caller can hand in whatever tracks
+//! "needs save" on its side — `SceneState.is_dirty` for scenes,
+//! `PrefabState.is_dirty` for prefabs. Any edit (Position input,
+//! comment change) flips it.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const scene_io = @import("../scene_io.zig");
+
+/// Render the editable surface for one entity:
+///
+/// - Heading: prefab name (plus optional `Entity #N` label for scene
+///   entities; pass `null` for the lone entity in a prefab).
+/// - `Position` collapsing header with x/y inputs.
+/// - `Comment` collapsing header with the multiline comment buffer.
+/// - `Other components (N)` group with a collapsing header per
+///   unmodeled component, body shown verbatim (read-only for v1).
+///
+/// Caller controls window placement; this just paints into whatever
+/// container is active.
+pub fn renderEntity(
+    entity: *scene_io.Entity,
+    component_extras: []const scene_io.ComponentExtra,
+    is_dirty: *bool,
+    entity_index: ?usize,
+) void {
+    if (entity_index) |n| {
+        zgui.text("Entity #{d}", .{n});
+    }
+    if (entity.prefab) |p| {
+        zgui.text("prefab: {s}", .{p});
+    } else {
+        zgui.textDisabled("(no prefab)", .{});
+    }
+    zgui.spacing();
+
+    if (zgui.collapsingHeader("Position", .{ .default_open = true })) {
+        if (entity.position) |*pos| {
+            if (zgui.inputFloat("x", .{ .v = &pos.x })) is_dirty.* = true;
+            if (zgui.inputFloat("y", .{ .v = &pos.y })) is_dirty.* = true;
+        } else {
+            zgui.textDisabled("(no Position component)", .{});
+        }
+    }
+
+    if (zgui.collapsingHeader("Comment", .{})) {
+        if (zgui.inputTextMultiline("##comment", .{
+            .buf = &entity.comment,
+            .w = 0,
+            .h = 80,
+        })) is_dirty.* = true;
+    }
+
+    if (component_extras.len > 0) {
+        zgui.spacing();
+        zgui.separator();
+        zgui.textDisabled("Other components ({d})", .{component_extras.len});
+        for (component_extras) |extra| {
+            var label_buf: [128:0]u8 = undefined;
+            const label = std.fmt.bufPrintZ(&label_buf, "{s}", .{extra.name}) catch continue;
+            if (zgui.collapsingHeader(label, .{})) {
+                zgui.textUnformatted(extra.value_text);
+            }
+        }
+    }
+}

--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -62,7 +62,10 @@ pub fn renderEntity(
         zgui.separator();
         zgui.textDisabled("Other components ({d})", .{component_extras.len});
         for (component_extras) |extra| {
-            var label_buf: [128:0]u8 = undefined;
+            // Component names are short in practice (Sprite, Coin,
+            // Room…), but allow longer custom names — 256 bytes
+            // covers any reasonable identifier.
+            var label_buf: [256:0]u8 = undefined;
             const label = std.fmt.bufPrintZ(&label_buf, "{s}", .{extra.name}) catch continue;
             if (zgui.collapsingHeader(label, .{})) {
                 zgui.textUnformatted(extra.value_text);

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -2,16 +2,17 @@
 //!
 //! A prefab is a single entity blueprint stored at
 //! `<project>/prefabs/<name>.jsonc` with the shape
-//! `{ "components": { ... } }`. Conceptually it's "one entity worth
-//! of components" that scenes instance by reference. The Prefab tab
-//! is therefore just the shared `inspector` view — no viewport, no
-//! position-on-grid, since a prefab doesn't position itself.
+//! `{ "components": { ... }, "children": [ ... ] }`. The top-level
+//! `components` is the prefab's own component set; the optional
+//! `children` array is a list of sub-entities each with their own
+//! Position and components (used heavily for visual decoration —
+//! e.g. a room prefab whose Sprite tiles live as children).
 //!
-//! Each `PrefabState` owns:
-//!   - an arena for `path` + `display_name`,
-//!   - a `LoadedPrefab` (its own arena for parsed body + extras).
-//!
-//! `deinit(allocator)` frees both.
+//! UX mirrors the scene editor: viewport on the left renders the
+//! children with their positions (the prefab itself has no position
+//! and sits implicitly at world origin), inspector on the right
+//! shows the selected entity. When nothing is selected the inspector
+//! shows the prefab's own components.
 
 const std = @import("std");
 const zgui = @import("zgui");
@@ -19,13 +20,24 @@ const zgui = @import("zgui");
 const App = @import("../app.zig").App;
 const scene_io = @import("../scene_io.zig");
 const inspector = @import("inspector.zig");
+const viewport = @import("viewport.zig");
+
+const inspector_w: f32 = 300;
+const split_gap: f32 = 8;
 
 pub const PrefabState = struct {
     arena: *std.heap.ArenaAllocator,
     path: []const u8,
     display_name: []const u8,
     loaded: scene_io.LoadedPrefab,
+
+    /// Index into `loaded.children`; null means "the prefab itself
+    /// is selected" (inspector shows the prefab's own components).
+    selected_child_idx: ?usize = null,
     is_dirty: bool = false,
+    drag_armed: bool = false,
+    pan: [2]f32 = .{ 320, 240 },
+    zoom: f32 = 1.0,
 
     pub fn open(allocator: std.mem.Allocator, path: []const u8) !PrefabState {
         const arena = try allocator.create(std.heap.ArenaAllocator);
@@ -60,20 +72,53 @@ fn deriveDisplayName(path: []const u8) []const u8 {
     return base;
 }
 
-/// Render a prefab tab. Layout is header + Save button + the shared
-/// entity inspector — same renderer the scene editor uses for its
-/// selected entity.
 pub fn render(s: *PrefabState, app: *App) void {
     zgui.text("Prefab: {s}", .{s.display_name});
+    zgui.sameLine(.{});
+    zgui.text("(children: {d})", .{s.loaded.children.len});
     if (s.is_dirty) {
         zgui.sameLine(.{});
         zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
     }
+    zgui.separator();
+
+    if (zgui.button("Reset view", .{})) {
+        s.pan = .{ 320, 240 };
+        s.zoom = 1.0;
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("-", .{ .w = 24 })) s.zoom = @max(0.1, s.zoom * 0.8);
+    zgui.sameLine(.{});
+    if (zgui.button("+", .{ .w = 24 })) s.zoom = @min(8.0, s.zoom * 1.25);
+    zgui.sameLine(.{});
+    zgui.text("zoom: {d:.2}x", .{s.zoom});
     zgui.sameLine(.{});
     if (zgui.button("Save", .{})) savePrefab(s, app);
     zgui.separator();
 
-    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null);
+    // Two-column body, same shape as the scene editor.
+    const total_w = zgui.getContentRegionAvail()[0];
+    const viewport_w = @max(120.0, total_w - inspector_w - split_gap);
+
+    if (zgui.beginChild("##prefab_viewport_col", .{ .w = viewport_w, .h = 0 })) {
+        viewport.render(.{
+            .pan = &s.pan,
+            .zoom = &s.zoom,
+            .selected_idx = &s.selected_child_idx,
+            .is_dirty = &s.is_dirty,
+            .drag_armed = &s.drag_armed,
+        }, s.loaded.children);
+    }
+    zgui.endChild();
+    zgui.sameLine(.{});
+    if (zgui.beginChild("##prefab_inspector_col", .{
+        .w = 0,
+        .h = 0,
+        .child_flags = .{ .border = true },
+    })) {
+        renderInspector(s);
+    }
+    zgui.endChild();
 }
 
 pub fn savePrefab(s: *PrefabState, app: *App) void {
@@ -84,4 +129,48 @@ pub fn savePrefab(s: *PrefabState, app: *App) void {
     };
     s.is_dirty = false;
     app.setStatus("Prefab saved!");
+}
+
+fn renderInspector(s: *PrefabState) void {
+    zgui.text("Inspector", .{});
+    zgui.separator();
+
+    if (s.selected_child_idx) |idx| {
+        if (idx >= s.loaded.children.len) {
+            s.selected_child_idx = null;
+            zgui.textDisabled("(selection out of range)", .{});
+            return;
+        }
+
+        if (zgui.smallButton("← Back to prefab")) {
+            s.selected_child_idx = null;
+        }
+        zgui.separator();
+
+        const child = &s.loaded.children[idx];
+        const extras = if (idx < s.loaded.children_extras.len)
+            s.loaded.children_extras[idx]
+        else
+            &[_]scene_io.ComponentExtra{};
+
+        inspector.renderEntity(child, extras, &s.is_dirty, idx);
+        return;
+    }
+
+    // Nothing selected → show the prefab's own components.
+    zgui.text("Prefab body", .{});
+    zgui.spacing();
+    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null);
+
+    if (s.loaded.children.len > 0) {
+        zgui.spacing();
+        zgui.separator();
+        zgui.textDisabled("Click a child in the viewport, or pick one below:", .{});
+        for (s.loaded.children, 0..) |child, i| {
+            var label_buf: [256:0]u8 = undefined;
+            const label_text = if (child.prefab) |p| p else "(child)";
+            const label = std.fmt.bufPrintZ(&label_buf, "#{d} {s}", .{ i, label_text }) catch continue;
+            if (zgui.selectable(label, .{})) s.selected_child_idx = i;
+        }
+    }
 }

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -1,0 +1,87 @@
+//! Prefab editor — per-tab state and rendering.
+//!
+//! A prefab is a single entity blueprint stored at
+//! `<project>/prefabs/<name>.jsonc` with the shape
+//! `{ "components": { ... } }`. Conceptually it's "one entity worth
+//! of components" that scenes instance by reference. The Prefab tab
+//! is therefore just the shared `inspector` view — no viewport, no
+//! position-on-grid, since a prefab doesn't position itself.
+//!
+//! Each `PrefabState` owns:
+//!   - an arena for `path` + `display_name`,
+//!   - a `LoadedPrefab` (its own arena for parsed body + extras).
+//!
+//! `deinit(allocator)` frees both.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const scene_io = @import("../scene_io.zig");
+const inspector = @import("inspector.zig");
+
+pub const PrefabState = struct {
+    arena: *std.heap.ArenaAllocator,
+    path: []const u8,
+    display_name: []const u8,
+    loaded: scene_io.LoadedPrefab,
+    is_dirty: bool = false,
+
+    pub fn open(allocator: std.mem.Allocator, path: []const u8) !PrefabState {
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const a = arena.allocator();
+        const path_dup = try a.dupe(u8, path);
+        const display_name = deriveDisplayName(path_dup);
+
+        const loaded = try scene_io.loadPrefabFromFile(allocator, path);
+        return .{
+            .arena = arena,
+            .path = path_dup,
+            .display_name = display_name,
+            .loaded = loaded,
+        };
+    }
+
+    pub fn deinit(self: *PrefabState, allocator: std.mem.Allocator) void {
+        self.loaded.deinit();
+        self.arena.deinit();
+        allocator.destroy(self.arena);
+    }
+};
+
+fn deriveDisplayName(path: []const u8) []const u8 {
+    const base = std.fs.path.basename(path);
+    const ext = ".jsonc";
+    if (std.mem.endsWith(u8, base, ext)) return base[0 .. base.len - ext.len];
+    return base;
+}
+
+/// Render a prefab tab. Layout is header + Save button + the shared
+/// entity inspector — same renderer the scene editor uses for its
+/// selected entity.
+pub fn render(s: *PrefabState, app: *App) void {
+    zgui.text("Prefab: {s}", .{s.display_name});
+    if (s.is_dirty) {
+        zgui.sameLine(.{});
+        zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("Save", .{})) savePrefab(s, app);
+    zgui.separator();
+
+    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null);
+}
+
+pub fn savePrefab(s: *PrefabState, app: *App) void {
+    scene_io.savePrefab(app.allocator, s.path, s.loaded) catch |err| {
+        std.log.err("Prefab save failed at {s}: {s}", .{ s.path, @errorName(err) });
+        app.setStatus("Error saving prefab!");
+        return;
+    };
+    s.is_dirty = false;
+    app.setStatus("Prefab saved!");
+}

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -47,7 +47,7 @@ pub const PrefabState = struct {
 
         const a = arena.allocator();
         const path_dup = try a.dupe(u8, path);
-        const display_name = deriveDisplayName(path_dup);
+        const display_name = scene_io.displayNameFromPath(path_dup);
 
         const loaded = try scene_io.loadPrefabFromFile(allocator, path);
         return .{
@@ -64,13 +64,6 @@ pub const PrefabState = struct {
         allocator.destroy(self.arena);
     }
 };
-
-fn deriveDisplayName(path: []const u8) []const u8 {
-    const base = std.fs.path.basename(path);
-    const ext = ".jsonc";
-    if (std.mem.endsWith(u8, base, ext)) return base[0 .. base.len - ext.len];
-    return base;
-}
 
 pub fn render(s: *PrefabState, app: *App) void {
     zgui.text("Prefab: {s}", .{s.display_name});

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -27,13 +27,21 @@ pub fn makeModule(app: *App) module.Module {
 /// elsewhere in the project return false; the caller skips opening
 /// them as scenes.
 pub fn isScenePath(proj_dir: ?[]const u8, path: []const u8) bool {
+    return isUnderFolder(proj_dir, path, project.ProjectFolders.scenes);
+}
+
+/// Mirror of `isScenePath` for `prefabs/*.jsonc`. Used to route a
+/// tree click on a prefab file into the prefab editor rather than
+/// the scene editor.
+pub fn isPrefabPath(proj_dir: ?[]const u8, path: []const u8) bool {
+    return isUnderFolder(proj_dir, path, project.ProjectFolders.prefabs);
+}
+
+fn isUnderFolder(proj_dir: ?[]const u8, path: []const u8, folder: []const u8) bool {
     const dir = proj_dir orelse return false;
     if (!std.mem.endsWith(u8, path, ".jsonc")) return false;
     var prefix_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const prefix = std.fmt.bufPrint(&prefix_buf, "{s}/{s}/", .{
-        dir,
-        project.ProjectFolders.scenes,
-    }) catch return false;
+    const prefix = std.fmt.bufPrint(&prefix_buf, "{s}/{s}/", .{ dir, folder }) catch return false;
     return std.mem.startsWith(u8, path, prefix);
 }
 
@@ -62,10 +70,16 @@ fn render(app: *App) void {
             // overwrite the prefab as an empty scene.
             if (app.tree_view.render(proj.getProjectDir())) {
                 if (app.tree_view.getSelectedPath()) |path| {
-                    if (isScenePath(proj.getProjectDir(), path)) {
+                    const proj_dir = proj.getProjectDir();
+                    if (isScenePath(proj_dir, path)) {
                         app.openScene(path) catch |err| {
                             std.log.err("Failed to open scene {s}: {s}", .{ path, @errorName(err) });
                             app.setStatus("Error opening scene!");
+                        };
+                    } else if (isPrefabPath(proj_dir, path)) {
+                        app.openPrefab(path) catch |err| {
+                            std.log.err("Failed to open prefab {s}: {s}", .{ path, @errorName(err) });
+                            app.setStatus("Error opening prefab!");
                         };
                     }
                 }

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -1,10 +1,14 @@
 //! Scene editor — per-tab state and rendering.
 //!
-//! No longer a top-level View-menu panel. The Scene editor opens as a
-//! tab in the main content area when the user clicks a `.jsonc` file
-//! in the project tree. `App` owns an `ArrayList(SceneState)` of open
-//! tabs; this module renders one tab's body (inspector + viewport)
-//! given a single state.
+//! Inspector body is delegated to `modules/inspector.zig`, which
+//! is shared with the prefab editor. This module owns the
+//! viewport (canvas, grid, pan/zoom, hit-test, drag-to-move) and
+//! the scene-specific Save path.
+//!
+//! Opens as a tab when the user clicks a `.jsonc` file under
+//! `<project>/scenes/`. `App` owns an `ArrayList(OpenTab)` whose
+//! `.scene` variant wraps a `SceneState`; this module renders one
+//! such state given a single value.
 //!
 //! Each `SceneState` carries its own arena (for path/display name
 //! strings) and a `LoadedScene` (which carries its own arena for the
@@ -17,6 +21,7 @@ const App = @import("../app.zig").App;
 const project = @import("../project.zig");
 const scene_io = @import("../scene_io.zig");
 const config = @import("../config.zig");
+const inspector = @import("inspector.zig");
 
 const viewport_min_h: f32 = 240;
 
@@ -158,54 +163,14 @@ fn renderInspector(s: *SceneState) void {
         zgui.textDisabled("(selection out of range)", .{});
         return;
     }
-    const e = &s.loaded.scene.entities[idx];
-    const prefab = e.prefab orelse "(no prefab)";
-    zgui.text("Entity #{d}", .{idx});
-    if (e.prefab) |p| zgui.text("prefab: {s}", .{p}) else {
-        _ = prefab;
-        zgui.textDisabled("(no prefab)", .{});
-    }
-    zgui.spacing();
 
-    // Position is the only component the gui models structurally.
-    // Other components are read from the captured extras list and
-    // rendered as collapsible value previews.
-    if (zgui.collapsingHeader("Position", .{ .default_open = true })) {
-        if (e.position) |*pos| {
-            if (zgui.inputFloat("x", .{ .v = &pos.x })) s.is_dirty = true;
-            if (zgui.inputFloat("y", .{ .v = &pos.y })) s.is_dirty = true;
-        } else {
-            zgui.textDisabled("(no Position component)", .{});
-        }
-    }
+    const entity = &s.loaded.scene.entities[idx];
+    const extras = if (idx < s.loaded.extras.entity_components.len)
+        s.loaded.extras.entity_components[idx]
+    else
+        &[_]scene_io.ComponentExtra{};
 
-    if (zgui.collapsingHeader("Comment", .{})) {
-        if (zgui.inputTextMultiline("##comment", .{
-            .buf = &e.comment,
-            .w = 0,
-            .h = 80,
-        })) s.is_dirty = true;
-    }
-
-    // Per-entity unmodeled components captured verbatim at load time
-    // (Sprite, Shape, user-defined). Read-only display for now —
-    // structured editing of these is a follow-up; users can still
-    // hand-edit the .jsonc directly and reopen the scene.
-    if (idx < s.loaded.extras.entity_components.len) {
-        const extras = s.loaded.extras.entity_components[idx];
-        if (extras.len > 0) {
-            zgui.spacing();
-            zgui.separator();
-            zgui.textDisabled("Other components ({d})", .{extras.len});
-            for (extras) |extra| {
-                var label_buf: [128:0]u8 = undefined;
-                const label = std.fmt.bufPrintZ(&label_buf, "{s}", .{extra.name}) catch continue;
-                if (zgui.collapsingHeader(label, .{})) {
-                    zgui.textUnformatted(extra.value_text);
-                }
-            }
-        }
-    }
+    inspector.renderEntity(entity, extras, &s.is_dirty, idx);
 }
 
 fn renderViewport(s: *SceneState) void {

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -22,6 +22,7 @@ const project = @import("../project.zig");
 const scene_io = @import("../scene_io.zig");
 const config = @import("../config.zig");
 const inspector = @import("inspector.zig");
+const viewport = @import("viewport.zig");
 
 const viewport_min_h: f32 = 240;
 
@@ -174,164 +175,16 @@ fn renderInspector(s: *SceneState) void {
 }
 
 fn renderViewport(s: *SceneState) void {
-    const avail = zgui.getContentRegionAvail();
-    const canvas_h = @max(viewport_min_h, avail[1]);
-    if (!zgui.beginChild("##canvas", .{
-        .w = 0,
-        .h = canvas_h,
-        .child_flags = .{ .border = true },
-    })) {
-        zgui.endChild();
-        return;
-    }
-    defer zgui.endChild();
-
-    const dl = zgui.getWindowDrawList();
-    const cur_pos = zgui.getCursorScreenPos();
-    const canvas_size = zgui.getContentRegionAvail();
-    const canvas_min = cur_pos;
-    const canvas_max: [2]f32 = .{ cur_pos[0] + canvas_size[0], cur_pos[1] + canvas_size[1] };
-
-    dl.addRectFilled(.{
-        .pmin = canvas_min,
-        .pmax = canvas_max,
-        .col = 0xff202225,
-    });
-
-    drawGrid(dl, canvas_min, canvas_max, s.*);
-    drawEntities(dl, canvas_min, canvas_max, s.*, s.loaded);
-
-    _ = zgui.invisibleButton("##canvas_drag", .{ .w = canvas_size[0], .h = canvas_size[1], .flags = .{} });
-
-    // Mouse-down: hit-test entity markers, arm drag-to-move only when
-    // the click landed on an entity.
-    if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.left)) {
-        const mouse = zgui.getMousePos();
-        const hit = hitTestEntity(s.loaded.scene.entities, mouse, canvas_min, s.pan, s.zoom);
-        s.selected_index = hit;
-        s.drag_armed = hit != null;
-    }
-    if (!zgui.isMouseDown(.left)) s.drag_armed = false;
-
-    if (zgui.isItemActive()) {
-        if (zgui.isMouseDragging(.middle, 0)) {
-            const d = zgui.getMouseDragDelta(.middle, .{});
-            s.pan[0] += d[0];
-            s.pan[1] += d[1];
-            zgui.resetMouseDragDelta(.middle);
-        }
-        if (s.drag_armed) {
-            if (s.selected_index) |idx| {
-                if (idx < s.loaded.scene.entities.len and zgui.isMouseDragging(.left, 0)) {
-                    const e = &s.loaded.scene.entities[idx];
-                    if (e.position) |*pos| {
-                        const d = zgui.getMouseDragDelta(.left, .{});
-                        pos.x += d[0] / s.zoom;
-                        // World +y is up; screen +y is down.
-                        pos.y -= d[1] / s.zoom;
-                        s.is_dirty = true;
-                        zgui.resetMouseDragDelta(.left);
-                    }
-                }
-            }
-        }
-    }
+    viewport.render(.{
+        .pan = &s.pan,
+        .zoom = &s.zoom,
+        .selected_idx = &s.selected_index,
+        .is_dirty = &s.is_dirty,
+        .drag_armed = &s.drag_armed,
+    }, s.loaded.scene.entities);
 }
 
-fn drawGrid(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, s: SceneState) void {
-    const grid_world: f32 = 64;
-    const step = grid_world * s.zoom;
-    if (step <= 4) return;
-
-    const col_major: u32 = 0x40_ff_ff_ff;
-
-    const origin_x = cmin[0] + s.pan[0];
-    const origin_y = cmin[1] + s.pan[1];
-
-    var x = origin_x;
-    while (x > cmin[0]) : (x -= step) {}
-    while (x < cmax[0]) : (x += step) {
-        dl.addLine(.{
-            .p1 = .{ x, cmin[1] },
-            .p2 = .{ x, cmax[1] },
-            .col = col_major,
-            .thickness = 1.0,
-        });
-    }
-    var y = origin_y;
-    while (y > cmin[1]) : (y -= step) {}
-    while (y < cmax[1]) : (y += step) {
-        dl.addLine(.{
-            .p1 = .{ cmin[0], y },
-            .p2 = .{ cmax[0], y },
-            .col = col_major,
-            .thickness = 1.0,
-        });
-    }
-
-    dl.addLine(.{ .p1 = .{ origin_x, cmin[1] }, .p2 = .{ origin_x, cmax[1] }, .col = 0x80_ff_ff_ff, .thickness = 1.0 });
-    dl.addLine(.{ .p1 = .{ cmin[0], origin_y }, .p2 = .{ cmax[0], origin_y }, .col = 0x80_ff_ff_ff, .thickness = 1.0 });
-}
-
-fn drawEntities(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, s: SceneState, loaded: scene_io.LoadedScene) void {
-    _ = cmax;
-    for (loaded.scene.entities, 0..) |e, i| {
-        const pos = e.position orelse continue;
-        const px = cmin[0] + s.pan[0] + pos.x * s.zoom;
-        // World +y is up.
-        const py = cmin[1] + s.pan[1] - pos.y * s.zoom;
-        const col = colorForPrefab(e.prefab);
-        dl.addCircleFilled(.{
-            .p = .{ px, py },
-            .r = 6,
-            .col = col,
-            .num_segments = 16,
-        });
-        if (s.selected_index == i) {
-            dl.addCircle(.{
-                .p = .{ px, py },
-                .r = 12,
-                .col = 0xff_ff_d2_40,
-                .num_segments = 24,
-                .thickness = 2.0,
-            });
-        }
-        if (e.prefab) |p| {
-            dl.addText(.{ px + 8, py - 8 }, 0xff_e0_e0_e0, "{s}", .{p});
-        }
-    }
-}
-
-pub const hit_radius: f32 = 10.0;
-
-pub fn hitTestEntity(
-    entities: []scene_io.Entity,
-    mouse: [2]f32,
-    canvas_min: [2]f32,
-    pan: [2]f32,
-    zoom: f32,
-) ?usize {
-    var best: ?usize = null;
-    var best_d2: f32 = hit_radius * hit_radius;
-    for (entities, 0..) |e, i| {
-        const pos = e.position orelse continue;
-        const px = canvas_min[0] + pan[0] + pos.x * zoom;
-        const py = canvas_min[1] + pan[1] - pos.y * zoom;
-        const dx = mouse[0] - px;
-        const dy = mouse[1] - py;
-        const d2 = dx * dx + dy * dy;
-        if (d2 < best_d2) {
-            best_d2 = d2;
-            best = i;
-        }
-    }
-    return best;
-}
-
-fn colorForPrefab(prefab: ?[]const u8) u32 {
-    const h = if (prefab) |p| std.hash.Wyhash.hash(0, p) else 0;
-    const r: u8 = @truncate((h >> 0) | 0x80);
-    const g: u8 = @truncate((h >> 8) | 0x80);
-    const b: u8 = @truncate((h >> 16) | 0x80);
-    return (@as(u32, 0xff) << 24) | (@as(u32, b) << 16) | (@as(u32, g) << 8) | r;
-}
+/// Re-exported so existing zspec tests (and any other caller of
+/// `scene_module.hitTestEntity`) keep working after the viewport
+/// extraction.
+pub const hitTestEntity = viewport.hitTestEntity;

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -62,7 +62,7 @@ pub const SceneState = struct {
 
         const a = arena.allocator();
         const path_dup = try a.dupe(u8, path);
-        const display_name = deriveDisplayName(path_dup);
+        const display_name = scene_io.displayNameFromPath(path_dup);
 
         const loaded = try scene_io.loadFromFile(allocator, path);
         return .{
@@ -82,13 +82,6 @@ pub const SceneState = struct {
 
 /// Returns the file basename with its `.jsonc` extension stripped.
 /// `path` must outlive the returned slice (we just slice into it).
-fn deriveDisplayName(path: []const u8) []const u8 {
-    const base = std.fs.path.basename(path);
-    const ext = ".jsonc";
-    if (std.mem.endsWith(u8, base, ext)) return base[0 .. base.len - ext.len];
-    return base;
-}
-
 const inspector_w: f32 = 300;
 const split_gap: f32 = 8;
 

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -1,0 +1,193 @@
+//! Shared 2D viewport — pan/zoom canvas with entity markers, hit-
+//! testing, and drag-to-move. Used by the scene editor (operating on
+//! `Scene.entities`) and the prefab editor (operating on
+//! `LoadedPrefab.children`).
+//!
+//! Caller hands in pointers to its own pan/zoom/selection/dirty
+//! state so the viewport reads + writes them in place. The caller
+//! also handles the controls bar (Reset view / zoom buttons / Save)
+//! — those vary per module.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const scene_io = @import("../scene_io.zig");
+
+pub const min_h: f32 = 240;
+
+/// Mutable per-tab state the viewport reads and writes.
+pub const State = struct {
+    pan: *[2]f32,
+    zoom: *f32,
+    selected_idx: *?usize,
+    is_dirty: *bool,
+    drag_armed: *bool,
+};
+
+/// Pixel radius around an entity marker that counts as a click.
+pub const hit_radius: f32 = 10.0;
+
+/// Render the viewport canvas for `entities` into the current
+/// imgui window. Caller is responsible for the surrounding container
+/// (e.g. a beginChild) and any controls bar.
+pub fn render(state: State, entities: []scene_io.Entity) void {
+    const avail = zgui.getContentRegionAvail();
+    const canvas_h = @max(min_h, avail[1]);
+    if (!zgui.beginChild("##canvas", .{
+        .w = 0,
+        .h = canvas_h,
+        .child_flags = .{ .border = true },
+    })) {
+        zgui.endChild();
+        return;
+    }
+    defer zgui.endChild();
+
+    const dl = zgui.getWindowDrawList();
+    const cur_pos = zgui.getCursorScreenPos();
+    const canvas_size = zgui.getContentRegionAvail();
+    const canvas_min = cur_pos;
+    const canvas_max: [2]f32 = .{ cur_pos[0] + canvas_size[0], cur_pos[1] + canvas_size[1] };
+
+    dl.addRectFilled(.{
+        .pmin = canvas_min,
+        .pmax = canvas_max,
+        .col = 0xff202225,
+    });
+
+    drawGrid(dl, canvas_min, canvas_max, state.pan.*, state.zoom.*);
+    drawEntities(dl, canvas_min, state, entities);
+
+    _ = zgui.invisibleButton("##canvas_drag", .{ .w = canvas_size[0], .h = canvas_size[1], .flags = .{} });
+
+    // Mouse-down: hit-test markers, arm drag-to-move only when the
+    // click landed on an entity (otherwise drag in empty space
+    // would drift the previously-selected entity).
+    if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.left)) {
+        const mouse = zgui.getMousePos();
+        const hit = hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
+        state.selected_idx.* = hit;
+        state.drag_armed.* = hit != null;
+    }
+    if (!zgui.isMouseDown(.left)) state.drag_armed.* = false;
+
+    if (zgui.isItemActive()) {
+        if (zgui.isMouseDragging(.middle, 0)) {
+            const d = zgui.getMouseDragDelta(.middle, .{});
+            state.pan[0] += d[0];
+            state.pan[1] += d[1];
+            zgui.resetMouseDragDelta(.middle);
+        }
+        if (state.drag_armed.*) {
+            if (state.selected_idx.*) |idx| {
+                if (idx < entities.len and zgui.isMouseDragging(.left, 0)) {
+                    const e = &entities[idx];
+                    if (e.position) |*pos| {
+                        const d = zgui.getMouseDragDelta(.left, .{});
+                        pos.x += d[0] / state.zoom.*;
+                        // World +y is up; screen +y is down.
+                        pos.y -= d[1] / state.zoom.*;
+                        state.is_dirty.* = true;
+                        zgui.resetMouseDragDelta(.left);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn drawGrid(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, pan: [2]f32, zoom: f32) void {
+    const grid_world: f32 = 64;
+    const step = grid_world * zoom;
+    if (step <= 4) return;
+
+    const col_major: u32 = 0x40_ff_ff_ff;
+    const origin_x = cmin[0] + pan[0];
+    const origin_y = cmin[1] + pan[1];
+
+    var x = origin_x;
+    while (x > cmin[0]) : (x -= step) {}
+    while (x < cmax[0]) : (x += step) {
+        dl.addLine(.{
+            .p1 = .{ x, cmin[1] },
+            .p2 = .{ x, cmax[1] },
+            .col = col_major,
+            .thickness = 1.0,
+        });
+    }
+    var y = origin_y;
+    while (y > cmin[1]) : (y -= step) {}
+    while (y < cmax[1]) : (y += step) {
+        dl.addLine(.{
+            .p1 = .{ cmin[0], y },
+            .p2 = .{ cmax[0], y },
+            .col = col_major,
+            .thickness = 1.0,
+        });
+    }
+
+    dl.addLine(.{ .p1 = .{ origin_x, cmin[1] }, .p2 = .{ origin_x, cmax[1] }, .col = 0x80_ff_ff_ff, .thickness = 1.0 });
+    dl.addLine(.{ .p1 = .{ cmin[0], origin_y }, .p2 = .{ cmax[0], origin_y }, .col = 0x80_ff_ff_ff, .thickness = 1.0 });
+}
+
+fn drawEntities(dl: zgui.DrawList, cmin: [2]f32, state: State, entities: []scene_io.Entity) void {
+    for (entities, 0..) |e, i| {
+        const pos = e.position orelse continue;
+        const px = cmin[0] + state.pan[0] + pos.x * state.zoom.*;
+        const py = cmin[1] + state.pan[1] - pos.y * state.zoom.*;
+        const col = colorForPrefab(e.prefab);
+        dl.addCircleFilled(.{
+            .p = .{ px, py },
+            .r = 6,
+            .col = col,
+            .num_segments = 16,
+        });
+        if (state.selected_idx.* == i) {
+            dl.addCircle(.{
+                .p = .{ px, py },
+                .r = 12,
+                .col = 0xff_ff_d2_40,
+                .num_segments = 24,
+                .thickness = 2.0,
+            });
+        }
+        if (e.prefab) |p| {
+            dl.addText(.{ px + 8, py - 8 }, 0xff_e0_e0_e0, "{s}", .{p});
+        }
+    }
+}
+
+/// Return the index of the closest entity whose screen-space marker
+/// is within `hit_radius` pixels of `mouse`, or null. Pure so zspec
+/// can exercise the projection math.
+pub fn hitTestEntity(
+    entities: []scene_io.Entity,
+    mouse: [2]f32,
+    canvas_min: [2]f32,
+    pan: [2]f32,
+    zoom: f32,
+) ?usize {
+    var best: ?usize = null;
+    var best_d2: f32 = hit_radius * hit_radius;
+    for (entities, 0..) |e, i| {
+        const pos = e.position orelse continue;
+        const px = canvas_min[0] + pan[0] + pos.x * zoom;
+        const py = canvas_min[1] + pan[1] - pos.y * zoom;
+        const dx = mouse[0] - px;
+        const dy = mouse[1] - py;
+        const d2 = dx * dx + dy * dy;
+        if (d2 < best_d2) {
+            best_d2 = d2;
+            best = i;
+        }
+    }
+    return best;
+}
+
+fn colorForPrefab(prefab: ?[]const u8) u32 {
+    const h = if (prefab) |p| std.hash.Wyhash.hash(0, p) else 0;
+    const r: u8 = @truncate((h >> 0) | 0x80);
+    const g: u8 = @truncate((h >> 8) | 0x80);
+    const b: u8 = @truncate((h >> 16) | 0x80);
+    return (@as(u32, 0xff) << 24) | (@as(u32, b) << 16) | (@as(u32, g) << 8) | r;
+}

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -93,6 +93,111 @@ pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !LoadedScene
     return parseScene(allocator, raw);
 }
 
+// ─── Prefabs ───────────────────────────────────────────────────────────
+//
+// Prefabs live at `<project>/prefabs/<name>.jsonc` with the shape
+// `{ "components": { ... } }` — a single entity template, no `name`
+// field, no `entities` array. Conceptually they're "one entity worth
+// of components" that scenes instance by reference. Our model: load
+// the prefab as a `LoadedPrefab` carrying one `Entity` plus the same
+// `ComponentExtra` list we use for scene entities. Position is
+// typically absent in prefabs (scenes set position per-instance).
+
+pub const LoadedPrefab = struct {
+    arena: *std.heap.ArenaAllocator,
+    /// The prefab's body, modeled as a single entity so the inspector
+    /// can render it with the same code that handles scene entities.
+    /// `entity.prefab` is unused (prefabs don't reference other
+    /// prefabs in this format); `entity.position` is usually null.
+    entity: Entity,
+    /// Components other than `Position` captured verbatim, same as
+    /// scene-side extras. On save, these splice back into the
+    /// emitted `components: { ... }` block.
+    component_extras: []const ComponentExtra,
+
+    pub fn deinit(self: *LoadedPrefab) void {
+        const child_alloc = self.arena.child_allocator;
+        self.arena.deinit();
+        child_alloc.destroy(self.arena);
+    }
+};
+
+pub fn loadPrefabFromFile(allocator: std.mem.Allocator, path: []const u8) !LoadedPrefab {
+    const raw = try std.fs.cwd().readFileAlloc(allocator, path, 16 * 1024 * 1024);
+    defer allocator.free(raw);
+    return parsePrefab(allocator, raw);
+}
+
+pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab {
+    const arena = try allocator.create(std.heap.ArenaAllocator);
+    errdefer allocator.destroy(arena);
+    arena.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+
+    const stripped = try stripLineComments(arena.allocator(), raw);
+
+    const Intermediate = struct {
+        components: ?std.json.Value = null,
+    };
+    var parsed = try std.json.parseFromSlice(Intermediate, arena.allocator(), stripped, .{
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+
+    const entity: Entity = .{
+        .position = readPosition(parsed.value.components),
+    };
+
+    // Re-use the entity-body scanner from the scene path: it walks
+    // a `{ ... }` body, finds the `components` key inside, and
+    // captures every non-Position entry. Wrap the prefab body in a
+    // synthetic outer for the scanner to consume — easier than
+    // teaching the scanner about top-level vs entity-level. The
+    // brace pair is already in the raw text, so we just point the
+    // scanner at it.
+    const component_extras = try extractComponentExtras(arena.allocator(), raw);
+
+    return .{
+        .arena = arena,
+        .entity = entity,
+        .component_extras = component_extras,
+    };
+}
+
+pub fn savePrefab(allocator: std.mem.Allocator, path: []const u8, loaded: LoadedPrefab) !void {
+    const text = try renderPrefabJsonc(allocator, loaded);
+    defer allocator.free(text);
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(text);
+}
+
+/// Emit the prefab as `{ "components": { "Position": ..., …extras } }`.
+/// Mirrors the scene writer's per-entity `components` block; the
+/// outer wrapper is just the prefab object.
+pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]u8 {
+    var out: std.ArrayList(u8) = .{};
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+
+    try w.writeAll("{\n");
+    try w.writeAll("    \"components\": {");
+    var first = true;
+    if (loaded.entity.position) |p| {
+        try w.print(" \"Position\": {{ \"x\": {d}, \"y\": {d} }}", .{ p.x, p.y });
+        first = false;
+    }
+    for (loaded.component_extras) |extra| {
+        if (!first) try w.writeAll(",");
+        try w.print(" \"{s}\": {s}", .{ extra.name, extra.value_text });
+        first = false;
+    }
+    if (first) try w.writeAll(" "); // empty body — keep braces apart
+    try w.writeAll(" }\n");
+    try w.writeAll("}\n");
+    return out.toOwnedSlice(allocator);
+}
+
 pub fn parseScene(allocator: std.mem.Allocator, raw: []const u8) !LoadedScene {
     const arena = try allocator.create(std.heap.ArenaAllocator);
     errdefer allocator.destroy(arena);

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -114,6 +114,13 @@ pub const LoadedPrefab = struct {
     /// scene-side extras. On save, these splice back into the
     /// emitted `components: { ... }` block.
     component_extras: []const ComponentExtra,
+    /// Optional `children: [...]` array — a prefab can hold sub-
+    /// entities with their own positions and components (e.g.
+    /// hydroponics has Sprite children that decorate the room).
+    /// Mutable in place so the editor can drag-to-move them.
+    children: []Entity,
+    /// Per-child unmodeled components, parallel to `children`.
+    children_extras: []const []const ComponentExtra,
 
     pub fn deinit(self: *LoadedPrefab) void {
         const child_alloc = self.arena.child_allocator;
@@ -138,6 +145,10 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
 
     const Intermediate = struct {
         components: ?std.json.Value = null,
+        children: []const struct {
+            prefab: ?[]const u8 = null,
+            components: ?std.json.Value = null,
+        } = &.{},
     };
     var parsed = try std.json.parseFromSlice(Intermediate, arena.allocator(), stripped, .{
         .ignore_unknown_fields = true,
@@ -148,19 +159,34 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
         .position = readPosition(parsed.value.components),
     };
 
-    // Re-use the entity-body scanner from the scene path: it walks
-    // a `{ ... }` body, finds the `components` key inside, and
-    // captures every non-Position entry. Wrap the prefab body in a
-    // synthetic outer for the scanner to consume — easier than
-    // teaching the scanner about top-level vs entity-level. The
-    // brace pair is already in the raw text, so we just point the
-    // scanner at it.
+    // Re-use the entity-body scanner — walks `{ ... }`, finds the
+    // `components` key, captures every non-Position entry as
+    // verbatim extras. Works the same for prefab body and child
+    // bodies.
     const component_extras = try extractComponentExtras(arena.allocator(), raw);
+
+    // Children: mutable so the editor can drag-to-move them. Each
+    // child gets its leading `//` comment block attached via the
+    // same rule scenes use.
+    const child_comments = try extractChildComments(arena.allocator(), raw);
+    const child_extras = try extractChildComponentExtras(arena.allocator(), raw);
+    var children = try arena.allocator().alloc(Entity, parsed.value.children.len);
+    for (parsed.value.children, 0..) |c, i| {
+        children[i] = .{
+            .prefab = if (c.prefab) |p| try arena.allocator().dupe(u8, p) else null,
+            .position = readPosition(c.components),
+        };
+        if (i < child_comments.len) {
+            buf.writeZeroed(&children[i].comment, child_comments[i]);
+        }
+    }
 
     return .{
         .arena = arena,
         .entity = entity,
         .component_extras = component_extras,
+        .children = children,
+        .children_extras = child_extras,
     };
 }
 
@@ -172,9 +198,10 @@ pub fn savePrefab(allocator: std.mem.Allocator, path: []const u8, loaded: Loaded
     try file.writeAll(text);
 }
 
-/// Emit the prefab as `{ "components": { "Position": ..., …extras } }`.
-/// Mirrors the scene writer's per-entity `components` block; the
-/// outer wrapper is just the prefab object.
+/// Emit the prefab as `{ "components": { ... }, "children": [ ... ] }`.
+/// The `components` block mirrors a scene entity's; the `children`
+/// array (omitted when empty) emits one entry per child with its
+/// modeled Position + verbatim component extras + leading comment.
 pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]u8 {
     var out: std.ArrayList(u8) = .{};
     errdefer out.deinit(allocator);
@@ -192,9 +219,57 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
         try w.print(" \"{s}\": {s}", .{ extra.name, extra.value_text });
         first = false;
     }
-    if (first) try w.writeAll(" "); // empty body — keep braces apart
-    try w.writeAll(" }\n");
-    try w.writeAll("}\n");
+    if (first) try w.writeAll(" ");
+    try w.writeAll(" }");
+
+    if (loaded.children.len > 0) {
+        try w.writeAll(",\n");
+        try w.writeAll("    \"children\": [\n");
+        for (loaded.children, 0..) |child, i| {
+            const comment = std.mem.sliceTo(&child.comment, 0);
+            if (comment.len > 0) {
+                var lines = std.mem.splitScalar(u8, std.mem.trim(u8, comment, " \t\r\n"), '\n');
+                while (lines.next()) |line| {
+                    try w.print("        {s}\n", .{std.mem.trim(u8, line, " \t\r")});
+                }
+            }
+
+            try w.writeAll("        {");
+            var c_first = true;
+            if (child.prefab) |p| {
+                try w.print(" \"prefab\": \"{s}\"", .{p});
+                c_first = false;
+            }
+            const cextras = if (i < loaded.children_extras.len)
+                loaded.children_extras[i]
+            else
+                &[_]ComponentExtra{};
+            const has_components = child.position != null or cextras.len > 0;
+            if (has_components) {
+                if (!c_first) try w.writeAll(",");
+                try w.writeAll(" \"components\": {");
+                var cc_first = true;
+                if (child.position) |p| {
+                    try w.print(" \"Position\": {{ \"x\": {d}, \"y\": {d} }}", .{ p.x, p.y });
+                    cc_first = false;
+                }
+                for (cextras) |extra| {
+                    if (!cc_first) try w.writeAll(",");
+                    try w.print(" \"{s}\": {s}", .{ extra.name, extra.value_text });
+                    cc_first = false;
+                }
+                try w.writeAll(" }");
+                c_first = false;
+            }
+            if (c_first) try w.writeAll(" ");
+            try w.writeAll(" }");
+            if (i + 1 < loaded.children.len) try w.writeAll(",");
+            try w.writeAll("\n");
+        }
+        try w.writeAll("    ]");
+    }
+
+    try w.writeAll("\n}\n");
     return out.toOwnedSlice(allocator);
 }
 
@@ -294,11 +369,25 @@ fn jsonNumberAsF32(v: ?std.json.Value) ?f32 {
 /// an entity opening brace (uncommon and would conflate with the
 /// previous entity).
 pub fn extractEntityComments(arena: std.mem.Allocator, raw: []const u8) ![]const []const u8 {
+    return extractArrayItemComments(arena, raw, findEntitiesArray(raw) orelse return &.{});
+}
+
+/// Same shape as `extractEntityComments` but rooted at a prefab's
+/// `children` array. Returns one comment block per child in source
+/// order; entries are empty when a child had no leading comment.
+pub fn extractChildComments(arena: std.mem.Allocator, raw: []const u8) ![]const []const u8 {
+    return extractArrayItemComments(arena, raw, findChildrenArray(raw) orelse return &.{});
+}
+
+fn extractArrayItemComments(
+    arena: std.mem.Allocator,
+    raw: []const u8,
+    array_lbracket: usize,
+) ![]const []const u8 {
     var out: std.ArrayList([]const u8) = .{};
     errdefer out.deinit(arena);
 
-    var i: usize = findEntitiesArray(raw) orelse return out.toOwnedSlice(arena);
-    i += 1; // past '['
+    var i: usize = array_lbracket + 1; // past '['
 
     while (i < raw.len) {
         skipWhitespaceJson(raw, &i);
@@ -313,7 +402,7 @@ pub fn extractEntityComments(arena: std.mem.Allocator, raw: []const u8) ![]const
             i += 1;
             continue;
         }
-        if (raw[i] != '{') break; // unexpected — bail gracefully
+        if (raw[i] != '{') break;
 
         const trimmed = std.mem.trim(u8, raw[comment_start..comment_end], " \t\r\n");
         try out.append(arena, try arena.dupe(u8, trimmed));
@@ -323,17 +412,18 @@ pub fn extractEntityComments(arena: std.mem.Allocator, raw: []const u8) ![]const
     return out.toOwnedSlice(arena);
 }
 
-fn findEntitiesArray(raw: []const u8) ?usize {
-    const key = "\"entities\"";
+/// Locate a `"<key>": [` array in `raw` and return the byte offset
+/// of the opening `[`. Used for both scene entities and prefab
+/// children — same scanner, different key. False-positive guard:
+/// a literal string value equal to the key (e.g. `"tag":
+/// "entities"`) is skipped past so a real later occurrence still
+/// resolves.
+fn findArrayByKey(raw: []const u8, key_with_quotes: []const u8) ?usize {
+    const klen = key_with_quotes.len;
     var i: usize = 0;
-    while (i + key.len <= raw.len) {
-        // Match the key as-a-string first so a literal `"entities"` —
-        // which IS a `"`-prefixed token — isn't eaten by the
-        // string-skip branch below. For any other string we encounter
-        // (e.g. `"name"`, a string *value*), skipString advances past
-        // it so its contents don't false-match.
-        if (std.mem.eql(u8, raw[i .. i + key.len], key)) {
-            var probe = i + key.len;
+    while (i + klen <= raw.len) {
+        if (std.mem.eql(u8, raw[i .. i + klen], key_with_quotes)) {
+            var probe = i + klen;
             skipWhitespaceJson(raw, &probe);
             skipCommentBlock(raw, &probe);
             skipWhitespaceJson(raw, &probe);
@@ -344,10 +434,7 @@ fn findEntitiesArray(raw: []const u8) ?usize {
                 skipWhitespaceJson(raw, &probe);
                 if (probe < raw.len and raw[probe] == '[') return probe;
             }
-            // Not the entities key in object position — e.g. a string
-            // value that happens to be `"entities"`. Keep scanning
-            // past this token so a later real `"entities": [` is found.
-            i += key.len;
+            i += klen;
             continue;
         }
         if (raw[i] == '"') {
@@ -357,6 +444,14 @@ fn findEntitiesArray(raw: []const u8) ?usize {
         i += 1;
     }
     return null;
+}
+
+fn findEntitiesArray(raw: []const u8) ?usize {
+    return findArrayByKey(raw, "\"entities\"");
+}
+
+fn findChildrenArray(raw: []const u8) ?usize {
+    return findArrayByKey(raw, "\"children\"");
 }
 
 fn skipWhitespaceJson(raw: []const u8, i: *usize) void {
@@ -518,11 +613,27 @@ fn extractTopLevelExtras(arena: std.mem.Allocator, raw: []const u8) ![]const Top
 /// key+value pair that isn't `Position` (the only component the gui
 /// models today).
 fn extractEntityComponentExtras(arena: std.mem.Allocator, raw: []const u8) ![]const []const ComponentExtra {
+    return extractArrayItemComponentExtras(arena, raw, findEntitiesArray(raw) orelse return &.{});
+}
+
+/// Per-child component extras for prefabs. Same scanner the scene
+/// side uses, just rooted at the `children` array instead of
+/// `entities`.
+pub fn extractChildComponentExtras(arena: std.mem.Allocator, raw: []const u8) ![]const []const ComponentExtra {
+    return extractArrayItemComponentExtras(arena, raw, findChildrenArray(raw) orelse return &.{});
+}
+
+/// Shared body for entity / child component extraction. Caller passes
+/// the byte offset of the opening `[` of the array to walk.
+fn extractArrayItemComponentExtras(
+    arena: std.mem.Allocator,
+    raw: []const u8,
+    array_lbracket: usize,
+) ![]const []const ComponentExtra {
     var out: std.ArrayList([]const ComponentExtra) = .{};
     errdefer out.deinit(arena);
 
-    var i: usize = findEntitiesArray(raw) orelse return out.toOwnedSlice(arena);
-    i += 1; // past '['
+    var i: usize = array_lbracket + 1; // past '['
 
     while (i < raw.len) {
         skipWhitespaceJson(raw, &i);

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -358,6 +358,17 @@ fn jsonNumberAsF32(v: ?std.json.Value) ?f32 {
     };
 }
 
+/// Strip a trailing `.jsonc` extension from a path's basename and
+/// return the resulting stem (e.g. `"a/b/main.jsonc"` → `"main"`).
+/// Used by Scene + Prefab tabs for the display label; lifted here
+/// so they share the implementation rather than duplicating it.
+pub fn displayNameFromPath(path: []const u8) []const u8 {
+    const base = std.fs.path.basename(path);
+    const ext = ".jsonc";
+    if (std.mem.endsWith(u8, base, ext)) return base[0 .. base.len - ext.len];
+    return base;
+}
+
 /// Walk the JSONC source and capture `// ...` comment blocks that
 /// precede each top-level entity in `entities: [ ... ]`. Returns one
 /// string per entity in source order; entries are empty when an entity
@@ -700,8 +711,19 @@ fn extractComponentExtras(arena: std.mem.Allocator, entity_body: []const u8) ![]
 
 /// Find `"<key>": {` inside an object body. Returns the byte offset
 /// of the opening `{`, or null when the key isn't present.
+///
+/// Tolerates leading whitespace / `//` comments / BOM-style padding
+/// before the outer `{`. Scene-entity callers pass a body that
+/// already starts at the opening brace (sliced by `scanBalanced`);
+/// the prefab path passes the full raw file, which may have a
+/// header comment or whitespace before `{`. Without the skip below
+/// the prefab path returned null and silently produced empty
+/// extras — data-destructive on save.
 fn findKeyObject(body: []const u8, key: []const u8) ?usize {
     var i: usize = 0;
+    skipWhitespaceJson(body, &i);
+    skipCommentBlock(body, &i);
+    skipWhitespaceJson(body, &i);
     if (i < body.len and body[i] == '{') i += 1;
     while (i < body.len) {
         skipWhitespaceJson(body, &i);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -621,6 +621,88 @@ pub const SceneIoTests = struct {
         try expect.equal(loaded2.component_extras.len, 2);
     }
 
+    test "parsePrefab reads children with positions and extras" {
+        // hydroponics-style: prefab body + a children array whose
+        // entries each have a Position and a Sprite. Position is
+        // modeled; Sprite rides along as a component extra.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "components": {
+            \\        "Room": { "room_type": "hydroponics" }
+            \\    },
+            \\    "children": [
+            \\        // Room background
+            \\        {
+            \\            "components": {
+            \\                "Sprite": { "sprite_name": "bg.png" },
+            \\                "Position": { "x": 15, "y": 0 }
+            \\            }
+            \\        },
+            \\        // Pots
+            \\        {
+            \\            "components": {
+            \\                "Sprite": { "sprite_name": "pots.png" },
+            \\                "Position": { "x": 39, "y": 12 }
+            \\            }
+            \\        }
+            \\    ]
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        try expect.equal(loaded.children.len, 2);
+        try expect.equal(loaded.children[0].position.?.x, 15);
+        try expect.equal(loaded.children[1].position.?.y, 12);
+
+        // Child-level component extras are captured parallel to
+        // children, with Sprite preserved verbatim.
+        try expect.equal(loaded.children_extras.len, 2);
+        try expect.equal(loaded.children_extras[0].len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.children_extras[0][0].name, "Sprite"));
+
+        // Leading // comments ride along with the child they precede.
+        const c0 = std.mem.sliceTo(&loaded.children[0].comment, 0);
+        const c1 = std.mem.sliceTo(&loaded.children[1].comment, 0);
+        try expect.toBeTrue(std.mem.indexOf(u8, c0, "background") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, c1, "Pots") != null);
+    }
+
+    test "renderPrefabJsonc round-trips children + extras" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "components": { "Room": { "room_type": "x" } },
+            \\    "children": [
+            \\        { "components": { "Sprite": { "n": "a" }, "Position": { "x": 1, "y": 2 } } },
+            \\        { "components": { "Sprite": { "n": "b" }, "Position": { "x": 3, "y": 4 } } }
+            \\    ]
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+
+        // Move child 0; expect the output to reflect the new position
+        // AND preserve Sprite on both children.
+        loaded.children[0].position.?.x = 99;
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"children\":") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"x\": 99") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"n\": \"a\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"n\": \"b\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"Room\":") != null);
+
+        // Re-parse the rendered text — same shape, same children
+        // count, edited Position preserved.
+        var loaded2 = try scene_io.parsePrefab(allocator, text);
+        defer loaded2.deinit();
+        try expect.equal(loaded2.children.len, 2);
+        try expect.equal(loaded2.children[0].position.?.x, 99);
+    }
+
     test "renderPrefabJsonc reflects in-memory Position edits" {
         const allocator = std.testing.allocator;
         const src =

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -703,6 +703,31 @@ pub const SceneIoTests = struct {
         try expect.equal(loaded2.children[0].position.?.x, 99);
     }
 
+    test "parsePrefab captures extras when file has leading whitespace + comment" {
+        // Regression for cursor[bot] PR #30 review: findKeyObject
+        // used to bail when the body didn't start with `{` (because
+        // it only consumed an outer brace right at position 0).
+        // Prefabs whose source had a header comment or leading
+        // whitespace silently produced empty extras → all non-
+        // Position components got dropped on save.
+        const allocator = std.testing.allocator;
+        const src =
+            \\// header comment
+            \\
+            \\{
+            \\    "components": {
+            \\        "Sprite": { "n": "x" },
+            \\        "Coin": {}
+            \\    }
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        try expect.equal(loaded.component_extras.len, 2);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[0].name, "Sprite"));
+        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[1].name, "Coin"));
+    }
+
     test "renderPrefabJsonc reflects in-memory Position edits" {
         const allocator = std.testing.allocator;
         const src =

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -571,6 +571,72 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, loaded2.extras.entity_components[0][0].name, "Sprite"));
     }
 
+    test "parsePrefab reads Position + extras from a prefab body" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "components": {
+            \\        "Position": { "x": 5, "y": 10 },
+            \\        "Sprite": { "sprite_name": "coin", "pivot": "center" },
+            \\        "Coin": {}
+            \\    }
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        try expect.toBeTrue(loaded.entity.position != null);
+        try expect.equal(loaded.entity.position.?.x, 5);
+        try expect.equal(loaded.entity.position.?.y, 10);
+        try expect.equal(loaded.component_extras.len, 2);
+        // Order matches source: Sprite first, then Coin.
+        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[0].name, "Sprite"));
+        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[1].name, "Coin"));
+    }
+
+    test "renderPrefabJsonc round-trips a prefab with extras" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "components": {
+            \\        "Sprite": { "sprite_name": "coin" },
+            \\        "Coin": {}
+            \\    }
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"components\":") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"Sprite\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"sprite_name\": \"coin\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"Coin\"") != null);
+
+        // Re-parse the rendered text to confirm the writer's output is
+        // self-consistent — same shape, same extras.
+        var loaded2 = try scene_io.parsePrefab(allocator, text);
+        defer loaded2.deinit();
+        try expect.equal(loaded2.component_extras.len, 2);
+    }
+
+    test "renderPrefabJsonc reflects in-memory Position edits" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "components": { "Position": { "x": 0, "y": 0 } } }
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        loaded.entity.position.?.x = 42;
+        loaded.entity.position.?.y = 84;
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"x\": 42") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"y\": 84") != null);
+    }
+
     test "entity without Position has null position" {
         const allocator = std.testing.allocator;
         const src =
@@ -604,6 +670,31 @@ pub const SceneRoutingTests = struct {
 
     test "no project dir → no scene routing" {
         try expect.toBeFalse(project_tree.isScenePath(null, "/p/scenes/main.jsonc"));
+    }
+
+    test "prefab path under prefabs/ is accepted" {
+        try expect.toBeTrue(project_tree.isPrefabPath("/p", "/p/prefabs/coin.jsonc"));
+        try expect.toBeTrue(project_tree.isPrefabPath("/p", "/p/prefabs/enemies/goblin.jsonc"));
+    }
+
+    test "scene path is not a prefab path" {
+        try expect.toBeFalse(project_tree.isPrefabPath("/p", "/p/scenes/main.jsonc"));
+    }
+
+    test "scene-vs-prefab routing is mutually exclusive" {
+        // No path is both — the caller's if/else if doesn't risk
+        // double-dispatch through a single click.
+        const samples = [_][]const u8{
+            "/p/scenes/main.jsonc",
+            "/p/prefabs/coin.jsonc",
+            "/p/components/foo.zig",
+            "/p/random.jsonc",
+        };
+        for (samples) |sample| {
+            const sc = project_tree.isScenePath("/p", sample);
+            const pf = project_tree.isPrefabPath("/p", sample);
+            try expect.toBeFalse(sc and pf);
+        }
     }
 };
 


### PR DESCRIPTION
## Summary

Adds a working prefab editor. `.jsonc` files under `<project>/prefabs/` open as tabs in the same strip as scene tabs; the entity inspector is shared between the two so both editors edit components consistently.

## Build order (matches the commit's narrative)

1. **`modules/inspector.zig`** — extract `renderEntity(entity, extras, is_dirty, ?index)` out of the scene module. Pure refactor; scene's `renderInspector` becomes a thin wrapper.
2. **`OpenTab` union** in `app.zig` wraps `SceneState`. Renames cascade: `open_scenes` → `open_tabs`, `closeScene`/`closeAllScenes` → `closeTab`/`closeAllTabs`, etc. The tab strip and close-confirm modal go through `OpenTab.{displayName, path, isDirty, save, render, deinit}` rather than peeking the variant.
3. **`scene_io.zig`** gains prefab I/O — `LoadedPrefab`, `parsePrefab`, `loadPrefabFromFile`, `renderPrefabJsonc`, `savePrefab`. Shape `{ "components": { ... } }`; non-`Position` components round-trip verbatim via the existing `ComponentExtra` scanner.
4. **`modules/prefab.zig`** — `PrefabState` + thin render (header + Save + shared inspector body, no viewport). `App.openPrefab` mirrors `openScene`. `project_tree` adds `isPrefabPath` and routes `.jsonc` under `prefabs/` through it.

`isScenePath` and `isPrefabPath` are mutually exclusive (zspec test pins this against a corpus of sample paths).

## Tests

| Layer | What |
|---|---|
| zspec | 81/81 — 3 new prefab I/O (parse + render round-trip + Position-edit reflects), 3 new routing (`isPrefabPath`, scene-not-prefab, mutual exclusion) |
| TE | 6/6 — new `prefab_open_save_preserves_extras` drops a `coin.jsonc` prefab into the temp project, opens via `app.openPrefab`, sets Position in memory, saves, reads file back to confirm Sprite + Coin survive and Position landed |
| smoke | green |

## Known limitations (next slices)

- Prefab inspector shows unmodeled components as read-only text (same as scenes). Structured editing of component fields is a follow-up.
- No icon yet to visually distinguish scene vs prefab tabs — the tab title is the only cue. Trivial follow-up.

## Test plan

- [ ] `zig build && zig build test && zig build gui-test`
- [ ] Open `../flying-platform-labelle/`
- [ ] Click `scenes/main.jsonc` → scene tab with viewport + inspector
- [ ] Click `prefabs/<any>.jsonc` → prefab tab with just the inspector
- [ ] Switch between tabs freely
- [ ] Edit a Sprite-bearing prefab, hit Save, diff the file — Sprite/Coin survive, only the modeled fields change
- [ ] Close the project → all tabs auto-close