### PR TITLE
Sprite component — typed struct, atlas index, textured viewport

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,6 +22,11 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    const zstbi = b.dependency("zstbi", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
     const zspec = b.dependency("zspec", .{
         .target = target,
         .optimize = optimize,
@@ -46,6 +51,8 @@ pub fn build(b: *std.Build) void {
     exe.linkLibrary(zgui.artifact("imgui"));
 
     exe.root_module.addImport("nfd", nfd.module("nfd"));
+
+    exe.root_module.addImport("zstbi", zstbi.module("root"));
 
     // Windows-specific: embed DPI awareness manifest
     if (target.result.os.tag == .windows) {
@@ -72,6 +79,12 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "zspec", .module = zspec.module("zspec") },
+                // atlas.zig pulls in zopengl + zstbi at module scope
+                // (for the GL upload path); the test target only
+                // exercises the pure-parse function but still needs
+                // both modules to resolve at compile time.
+                .{ .name = "zopengl", .module = zopengl.module("root") },
+                .{ .name = "zstbi", .module = zstbi.module("root") },
             },
         }),
         .test_runner = .{ .path = zspec.path("src/runner.zig"), .mode = .simple },
@@ -108,6 +121,7 @@ pub fn build(b: *std.Build) void {
     gui_tests_exe.root_module.addImport("zopengl", zopengl.module("root"));
     gui_tests_exe.root_module.addImport("zgui", zgui_te.module("root"));
     gui_tests_exe.linkLibrary(zgui_te.artifact("imgui"));
+    gui_tests_exe.root_module.addImport("zstbi", zstbi.module("root"));
 
     const run_gui_tests = b.addRunArtifact(gui_tests_exe);
     const gui_test_step = b.step("gui-test", "Run the UI test runner");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -23,6 +23,10 @@
             .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
             .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
         },
+        .zstbi = .{
+            .url = "https://github.com/zig-gamedev/zstbi/archive/664305dd5.tar.gz",
+            .hash = "zstbi-0.11.0-dev-L0Ea_2yVBwA4uh-tHfgdhZcQaWRoZVYlNGs4Dl_WTeuR",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/app.zig
+++ b/src/app.zig
@@ -22,6 +22,7 @@ const resources_mod = @import("modules/resources.zig");
 const scene_mod = @import("modules/scene.zig");
 const prefab_mod = @import("modules/prefab.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
+const atlas = @import("atlas.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
 const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
 
@@ -125,6 +126,13 @@ pub const App = struct {
     /// `closeAllTabs` runs the frame the active project changes.
     last_project_generation: ?u64 = null,
 
+    /// Per-project atlas index (sprite name → frame + GL texture).
+    /// Built lazily the first frame the active project's generation
+    /// is observed; invalidated when the generation bumps. Inspector
+    /// + viewport consult it to validate `sprite_name` and draw the
+    /// real pixels for entities with a Sprite component.
+    atlas_index: ?atlas.Index = null,
+
     show_project_tree: bool = true,
 
     show_new_scene_dialog: bool = false,
@@ -162,10 +170,43 @@ pub const App = struct {
     pub fn deinit(self: *Self) void {
         self.closeAllTabs();
         self.open_tabs.deinit(self.allocator);
+        if (self.atlas_index) |*idx| idx.deinit();
         self.project_manager.deinit();
         self.tree_view.deinit();
         self.compiler.deinit();
         self.allocator.destroy(self);
+    }
+
+    /// Rebuild the atlas index from the active project's
+    /// `resources` block. Called whenever the project generation
+    /// changes. Closing the project invalidates the index without
+    /// rebuilding.
+    fn rebuildAtlasIndex(self: *Self) void {
+        if (self.atlas_index) |*idx| {
+            idx.deinit();
+            self.atlas_index = null;
+        }
+        const proj = self.project_manager.current_project orelse return;
+        const dir = proj.dir orelse return;
+
+        // Map ProjectConfig.resources → atlas.Resource (decoupling
+        // the atlas module from project.zig). Allocated on the
+        // stack via ArrayList because the count is small.
+        var resources: std.ArrayList(atlas.Resource) = .{};
+        defer resources.deinit(self.allocator);
+        for (proj.config.resources) |r| {
+            resources.append(self.allocator, .{
+                .name = r.name,
+                .json = r.json,
+                .texture = r.texture,
+            }) catch return;
+        }
+        self.atlas_index = atlas.Index.build(
+            self.allocator,
+            dir,
+            resources.items,
+            self.project_manager.generation,
+        );
     }
 
     // ─── Scene tabs ─────────────────────────────────────────────────────
@@ -269,10 +310,16 @@ pub const App = struct {
         // Project transitions close all open scene tabs so the next
         // frame doesn't read into freed memory belonging to the old
         // project. Detected via ProjectManager.generation, which is
-        // bumped on new/load/close.
+        // bumped on new/load/close. The atlas index is also keyed
+        // to the project so we rebuild it here.
         const gen = self.project_manager.generation;
         if (self.last_project_generation) |prev| {
-            if (prev != gen) self.closeAllTabs();
+            if (prev != gen) {
+                self.closeAllTabs();
+                self.rebuildAtlasIndex();
+            }
+        } else {
+            self.rebuildAtlasIndex();
         }
         self.last_project_generation = gen;
 

--- a/src/app.zig
+++ b/src/app.zig
@@ -29,12 +29,12 @@ const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
 const STATUS_BUF_LEN = 256;
 const SCENE_NAME_BUF_LEN = 128;
 
-/// One entry in the main-content tab strip. Today only `scene`
-/// exists; the `prefab` variant lands in a follow-up slice. The
-/// union exists now so the tab strip, close-confirmation modal, and
-/// `App.open_tabs` machinery don't need a second pass when prefab
-/// support arrives — they already dispatch through the methods
-/// below.
+/// One entry in the main-content tab strip. Each variant wraps an
+/// editor's per-tab state (loaded file, dirty flag, view state) and
+/// the tab strip + close-confirmation modal dispatch through the
+/// shared methods (`displayName`, `path`, `isDirty`, `save`, `render`,
+/// `deinit`) below. Add a new editor by adding a variant and a case
+/// to each method.
 pub const OpenTab = union(enum) {
     scene: scene_mod.SceneState,
     prefab: prefab_mod.PrefabState,
@@ -104,10 +104,10 @@ pub const App = struct {
     show_resources: bool = false,
     resources_editor: resources_mod.ResourcesEditor = .{},
 
-    /// Open editor tabs. Each entry is an `OpenTab` (currently only
-    /// scene, prefab landing in a follow-up). Populated when the
-    /// user clicks an editable file in the project tree; closed via
-    /// the × on a tab. `closeAllTabs` runs on project transitions.
+    /// Open editor tabs — scenes and prefabs share this list as
+    /// `OpenTab` variants. Populated when the user clicks an
+    /// editable file in the project tree; closed via the × on a
+    /// tab. `closeAllTabs` runs on project transitions.
     open_tabs: std.ArrayList(OpenTab) = .{},
     /// Which tab is foregrounded. null when no tabs are open.
     /// Updated each frame from whichever tab ImGui reports active.

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -80,12 +80,18 @@ pub const Index = struct {
     ) Index {
         var index: Index = .{ .allocator = allocator, .generation = generation };
         for (resources) |r| {
-            const atlas = loadOne(allocator, project_dir, r) catch |err| {
+            var atlas = loadOne(allocator, project_dir, r) catch |err| {
                 std.log.warn("Atlas '{s}' failed to load: {s}", .{ r.name, @errorName(err) });
                 continue;
             };
             const atlas_idx: u32 = @intCast(index.atlases.items.len);
-            index.atlases.append(allocator, atlas) catch continue;
+            // OOM in `append` would orphan the just-loaded atlas's GL
+            // texture handle and dup'd name; tear it down before
+            // dropping to the next resource.
+            index.atlases.append(allocator, atlas) catch {
+                atlas.deinit(allocator);
+                continue;
+            };
 
             // Mirror this atlas's name → frame map into the combined
             // lookup. First-atlas-wins on collisions; logged so the

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -1,0 +1,229 @@
+//! Per-project atlas index. Each entry in `project.labelle.resources`
+//! points at an atlas JSON manifest (TexturePacker shape) and the
+//! corresponding texture PNG. On project open we walk those entries,
+//! parse each JSON, decode the texture via zstbi, upload it to an
+//! OpenGL texture, and fold every sprite name into a single combined
+//! lookup so the inspector and viewport can resolve `sprite_name`
+//! references without caring which atlas an entry came from.
+//!
+//! The cache is owned by `App` and bound to a `ProjectManager`
+//! `generation`. When the generation bumps (project new/load/close)
+//! the cache is invalidated and texture handles are freed.
+
+const std = @import("std");
+const zstbi = @import("zstbi");
+const zopengl = @import("zopengl");
+
+const gl = zopengl.bindings;
+
+pub const Frame = struct {
+    /// Pixel rect in the atlas texture.
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+};
+
+pub const SpriteRef = struct {
+    /// Which loaded atlas owns this sprite (index into Index.atlases).
+    atlas: u32,
+    frame: Frame,
+};
+
+pub const Atlas = struct {
+    /// `resources[i].name` from `project.labelle`. Useful for
+    /// diagnostics — "sprite X belongs to atlas Y".
+    name: []const u8,
+    texture_id: c_uint,
+    width: u32,
+    height: u32,
+    /// `name → Frame` for every entry in this atlas's JSON.
+    frames: std.StringHashMapUnmanaged(Frame) = .{},
+
+    pub fn deinit(self: *Atlas, allocator: std.mem.Allocator) void {
+        var it = self.frames.iterator();
+        while (it.next()) |entry| allocator.free(entry.key_ptr.*);
+        self.frames.deinit(allocator);
+        allocator.free(self.name);
+        if (self.texture_id != 0) {
+            gl.deleteTextures(1, &self.texture_id);
+        }
+    }
+};
+
+/// The combined index: every sprite name across every atlas resolves
+/// to an `(atlas_idx, frame)` pair. The hash map's keys live in the
+/// owning Atlas's arena, so the index never needs its own allocations
+/// for the names.
+pub const Index = struct {
+    allocator: std.mem.Allocator,
+    atlases: std.ArrayListUnmanaged(Atlas) = .{},
+    by_name: std.StringHashMapUnmanaged(SpriteRef) = .{},
+    /// `ProjectManager.generation` this index was built against;
+    /// non-zero. App invalidates when the live generation changes.
+    generation: u64,
+
+    pub fn deinit(self: *Index) void {
+        for (self.atlases.items) |*a| a.deinit(self.allocator);
+        self.atlases.deinit(self.allocator);
+        self.by_name.deinit(self.allocator);
+    }
+
+    /// Build an index by loading every atlas referenced in the
+    /// project's `resources` block. Caller frees via `deinit`.
+    /// `project_dir` is used to resolve relative JSON / texture paths.
+    pub fn build(
+        allocator: std.mem.Allocator,
+        project_dir: []const u8,
+        resources: []const Resource,
+        generation: u64,
+    ) Index {
+        var index: Index = .{ .allocator = allocator, .generation = generation };
+        for (resources) |r| {
+            const atlas = loadOne(allocator, project_dir, r) catch |err| {
+                std.log.warn("Atlas '{s}' failed to load: {s}", .{ r.name, @errorName(err) });
+                continue;
+            };
+            const atlas_idx: u32 = @intCast(index.atlases.items.len);
+            index.atlases.append(allocator, atlas) catch continue;
+
+            // Mirror this atlas's name → frame map into the combined
+            // lookup. First-atlas-wins on collisions; logged so the
+            // user isn't surprised.
+            var it = index.atlases.items[atlas_idx].frames.iterator();
+            while (it.next()) |kv| {
+                const gop = index.by_name.getOrPut(allocator, kv.key_ptr.*) catch continue;
+                if (gop.found_existing) {
+                    std.log.warn("Sprite name '{s}' duplicated across atlases; keeping first hit", .{kv.key_ptr.*});
+                    continue;
+                }
+                gop.value_ptr.* = .{ .atlas = atlas_idx, .frame = kv.value_ptr.* };
+            }
+        }
+        return index;
+    }
+
+    pub fn find(self: Index, sprite_name: []const u8) ?SpriteRef {
+        return self.by_name.get(sprite_name);
+    }
+
+    pub fn textureFor(self: Index, ref: SpriteRef) c_uint {
+        if (ref.atlas >= self.atlases.items.len) return 0;
+        return self.atlases.items[ref.atlas].texture_id;
+    }
+
+    pub fn atlasSize(self: Index, ref: SpriteRef) [2]f32 {
+        if (ref.atlas >= self.atlases.items.len) return .{ 1, 1 };
+        const a = self.atlases.items[ref.atlas];
+        return .{ @floatFromInt(a.width), @floatFromInt(a.height) };
+    }
+};
+
+/// A subset of `project.ProjectConfig.resources` needed by the atlas
+/// loader — kept local so this module doesn't depend on `project.zig`.
+pub const Resource = struct {
+    name: []const u8,
+    json: []const u8,
+    texture: []const u8,
+};
+
+fn loadOne(allocator: std.mem.Allocator, project_dir: []const u8, r: Resource) !Atlas {
+    if (r.json.len == 0 or r.texture.len == 0) return error.MissingResourcePath;
+
+    const json_path = try std.fs.path.join(allocator, &.{ project_dir, r.json });
+    defer allocator.free(json_path);
+    const tex_path = try std.fs.path.join(allocator, &.{ project_dir, r.texture });
+    defer allocator.free(tex_path);
+
+    // Decode PNG. zstbi-backed; runs on the main thread for now —
+    // editor atlases are small enough that synchronous load is fine.
+    const tex_path_z = try allocator.dupeZ(u8, tex_path);
+    defer allocator.free(tex_path_z);
+    var img = try zstbi.Image.loadFromFile(tex_path_z, 4); // force RGBA
+    defer img.deinit();
+
+    // Upload to OpenGL. NEAREST filter so pixel art doesn't blur
+    // at integer zoom levels; CLAMP_TO_EDGE so neighbour-frame
+    // bleeding doesn't happen at frame boundaries.
+    var tex_id: c_uint = 0;
+    gl.genTextures(1, &tex_id);
+    gl.bindTexture(gl.TEXTURE_2D, tex_id);
+    gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA,
+        @intCast(img.width),
+        @intCast(img.height),
+        0,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        img.data.ptr,
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    var atlas: Atlas = .{
+        .name = try allocator.dupe(u8, r.name),
+        .texture_id = tex_id,
+        .width = img.width,
+        .height = img.height,
+    };
+    errdefer atlas.deinit(allocator);
+
+    try populateFramesFromJson(allocator, json_path, &atlas);
+    return atlas;
+}
+
+/// Parse a TexturePacker-style JSON manifest into `atlas.frames`.
+/// Format: `{ "frames": { "<sprite_name>": { "frame": {x,y,w,h}, ... }, ... } }`.
+/// We intentionally only consume the `frame` rect — pivot / source-
+/// size / trimmed are needed later for accurate placement but not
+/// for the first slice of viewport rendering.
+fn populateFramesFromJson(allocator: std.mem.Allocator, json_path: []const u8, atlas: *Atlas) !void {
+    const raw = try std.fs.cwd().readFileAlloc(allocator, json_path, 16 * 1024 * 1024);
+    defer allocator.free(raw);
+    try parseFramesFromJsonText(allocator, raw, atlas);
+}
+
+/// Pure parsing variant: takes the JSON text directly, no GL or
+/// filesystem dependency. Extracted so zspec can exercise the
+/// manifest-shape contract without needing an OpenGL context or a
+/// real PNG on disk.
+pub fn parseFramesFromJsonText(allocator: std.mem.Allocator, raw: []const u8, atlas: *Atlas) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, raw, .{});
+    defer parsed.deinit();
+
+    const frames_obj = blk: {
+        if (parsed.value != .object) return error.NotAnObject;
+        const v = parsed.value.object.get("frames") orelse return error.MissingFramesKey;
+        if (v != .object) return error.FramesNotAnObject;
+        break :blk v.object;
+    };
+
+    var it = frames_obj.iterator();
+    while (it.next()) |kv| {
+        const entry = kv.value_ptr.*;
+        if (entry != .object) continue;
+        const frame_v = entry.object.get("frame") orelse continue;
+        if (frame_v != .object) continue;
+        const x = jsonU32(frame_v.object.get("x")) orelse continue;
+        const y = jsonU32(frame_v.object.get("y")) orelse continue;
+        const w = jsonU32(frame_v.object.get("w")) orelse continue;
+        const h = jsonU32(frame_v.object.get("h")) orelse continue;
+
+        const name_copy = try allocator.dupe(u8, kv.key_ptr.*);
+        errdefer allocator.free(name_copy);
+        try atlas.frames.put(allocator, name_copy, .{ .x = x, .y = y, .w = w, .h = h });
+    }
+}
+
+fn jsonU32(v: ?std.json.Value) ?u32 {
+    const val = v orelse return null;
+    return switch (val) {
+        .integer => |i| if (i >= 0) @intCast(i) else null,
+        .float => |f| if (f >= 0) @intFromFloat(f) else null,
+        else => null,
+    };
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zglfw = @import("zglfw");
 const zopengl = @import("zopengl");
 const zgui = @import("zgui");
+const zstbi = @import("zstbi");
 
 const icons = @import("icons.zig");
 const config = @import("config.zig");
@@ -59,6 +60,12 @@ pub fn main() !void {
     zgui.init(allocator);
     defer zgui.deinit();
     zgui.io.setIniFilename(null);
+
+    // stb_image needs a global allocator before any `Image.loadFromFile`.
+    // The atlas module decodes PNGs through this, so init it once
+    // at startup; the call is idempotent across the gui lifetime.
+    zstbi.init(allocator);
+    defer zstbi.deinit();
 
     const scale_factor = window.getContentScale()[0];
     g_initial_scale = scale_factor;

--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 const zgui = @import("zgui");
 
 const scene_io = @import("../scene_io.zig");
+const atlas = @import("../atlas.zig");
 
 /// Render the editable surface for one entity:
 ///
@@ -29,6 +30,7 @@ pub fn renderEntity(
     component_extras: []const scene_io.ComponentExtra,
     is_dirty: *bool,
     entity_index: ?usize,
+    atlas_index: ?*const atlas.Index,
 ) void {
     if (entity_index) |n| {
         zgui.text("Entity #{d}", .{n});
@@ -52,6 +54,17 @@ pub fn renderEntity(
     if (entity.sprite) |sprite| {
         if (zgui.collapsingHeader("Sprite", .{ .default_open = true })) {
             if (zgui.inputText("sprite_name", .{ .buf = &sprite.sprite_name })) is_dirty.* = true;
+            // Resolve the typed sprite name against the project's
+            // atlas index; surface a soft `(missing)` hint when it
+            // doesn't match anything. Doesn't block edits — the
+            // engine ultimately decides what's valid; we just guide.
+            if (atlas_index) |idx| {
+                const name_str = std.mem.sliceTo(&sprite.sprite_name, 0);
+                if (name_str.len > 0 and idx.find(name_str) == null) {
+                    zgui.sameLine(.{});
+                    zgui.textColored(.{ 1.0, 0.5, 0.4, 1.0 }, "(missing)", .{});
+                }
+            }
             if (zgui.inputText("pivot", .{ .buf = &sprite.pivot })) is_dirty.* = true;
             if (zgui.inputText("layer", .{ .buf = &sprite.layer })) is_dirty.* = true;
 

--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -49,6 +49,24 @@ pub fn renderEntity(
         }
     }
 
+    if (entity.sprite) |sprite| {
+        if (zgui.collapsingHeader("Sprite", .{ .default_open = true })) {
+            if (zgui.inputText("sprite_name", .{ .buf = &sprite.sprite_name })) is_dirty.* = true;
+            if (zgui.inputText("pivot", .{ .buf = &sprite.pivot })) is_dirty.* = true;
+            if (zgui.inputText("layer", .{ .buf = &sprite.layer })) is_dirty.* = true;
+
+            // z_index is optional in the source; the checkbox toggles
+            // whether we emit it at all. Editing the int alone (with
+            // the box unchecked) doesn't suddenly add a `"z_index"`
+            // key to the file — the user has to opt in explicitly.
+            if (zgui.checkbox("z_index?", .{ .v = &sprite.has_z_index })) is_dirty.* = true;
+            if (sprite.has_z_index) {
+                zgui.sameLine(.{});
+                if (zgui.inputInt("##z_index", .{ .v = &sprite.z_index })) is_dirty.* = true;
+            }
+        }
+    }
+
     if (zgui.collapsingHeader("Comment", .{})) {
         if (zgui.inputTextMultiline("##comment", .{
             .buf = &entity.comment,

--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -1,7 +1,7 @@
 //! Shared entity inspector — renders an entity's properties +
 //! components into the current imgui window. Called from both the
-//! Scene module (one selected entity at a time) and, once it lands,
-//! the Prefab module (the single entity that is the prefab).
+//! Scene module (one selected entity at a time) and the Prefab
+//! module (the prefab body itself or a selected child).
 //!
 //! `is_dirty` is a `*bool` so the caller can hand in whatever tracks
 //! "needs save" on its side — `SceneState.is_dirty` for scenes,

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -93,6 +93,8 @@ pub fn render(s: *PrefabState, app: *App) void {
     const total_w = zgui.getContentRegionAvail()[0];
     const viewport_w = @max(120.0, total_w - inspector_w - split_gap);
 
+    const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
+
     if (zgui.beginChild("##prefab_viewport_col", .{ .w = viewport_w, .h = 0 })) {
         viewport.render(.{
             .pan = &s.pan,
@@ -100,7 +102,7 @@ pub fn render(s: *PrefabState, app: *App) void {
             .selected_idx = &s.selected_child_idx,
             .is_dirty = &s.is_dirty,
             .drag_armed = &s.drag_armed,
-        }, s.loaded.children);
+        }, s.loaded.children, atlas_index_ptr);
     }
     zgui.endChild();
     zgui.sameLine(.{});
@@ -109,7 +111,7 @@ pub fn render(s: *PrefabState, app: *App) void {
         .h = 0,
         .child_flags = .{ .border = true },
     })) {
-        renderInspector(s);
+        renderInspector(s, atlas_index_ptr);
     }
     zgui.endChild();
 }
@@ -124,7 +126,7 @@ pub fn savePrefab(s: *PrefabState, app: *App) void {
     app.setStatus("Prefab saved!");
 }
 
-fn renderInspector(s: *PrefabState) void {
+fn renderInspector(s: *PrefabState, atlas_index: ?*const @import("../atlas.zig").Index) void {
     zgui.text("Inspector", .{});
     zgui.separator();
 
@@ -146,14 +148,14 @@ fn renderInspector(s: *PrefabState) void {
         else
             &[_]scene_io.ComponentExtra{};
 
-        inspector.renderEntity(child, extras, &s.is_dirty, idx);
+        inspector.renderEntity(child, extras, &s.is_dirty, idx, atlas_index);
         return;
     }
 
     // Nothing selected → show the prefab's own components.
     zgui.text("Prefab body", .{});
     zgui.spacing();
-    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null);
+    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null, atlas_index);
 
     if (s.loaded.children.len > 0) {
         zgui.spacing();

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -62,12 +62,11 @@ fn render(app: *App) void {
     } })) {
         if (app.project_manager.current_project) |proj| {
             // Tree returns true on the frame a file is newly clicked.
-            // Route `.jsonc` files under the project's `scenes/` dir
-            // to the scene editor. Prefabs (also `.jsonc`, but under
-            // `prefabs/`) intentionally fall through here — they
-            // need their own editor (not yet implemented) and must
-            // not open in the scene editor, since saving back would
-            // overwrite the prefab as an empty scene.
+            // `.jsonc` files under `scenes/` route to the scene
+            // editor; `.jsonc` files under `prefabs/` route to the
+            // prefab editor. The two paths are mutually exclusive
+            // (see `isScenePath` / `isPrefabPath`) so a single click
+            // never opens both.
             if (app.tree_view.render(proj.getProjectDir())) {
                 if (app.tree_view.getSelectedPath()) |path| {
                     const proj_dir = proj.getProjectDir();

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -117,8 +117,10 @@ pub fn render(s: *SceneState, app: *App) void {
     const total_w = zgui.getContentRegionAvail()[0];
     const viewport_w = @max(120.0, total_w - inspector_w - split_gap);
 
+    const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
+
     if (zgui.beginChild("##viewport_col", .{ .w = viewport_w, .h = 0 })) {
-        renderViewport(s);
+        renderViewport(s, atlas_index_ptr);
     }
     zgui.endChild();
     zgui.sameLine(.{});
@@ -127,7 +129,7 @@ pub fn render(s: *SceneState, app: *App) void {
         .h = 0,
         .child_flags = .{ .border = true },
     })) {
-        renderInspector(s);
+        renderInspector(s, atlas_index_ptr);
     }
     zgui.endChild();
 }
@@ -144,7 +146,7 @@ pub fn saveScene(s: *SceneState, app: *App) void {
     app.setStatus("Scene saved!");
 }
 
-fn renderInspector(s: *SceneState) void {
+fn renderInspector(s: *SceneState, atlas_index: ?*const @import("../atlas.zig").Index) void {
     zgui.text("Inspector", .{});
     zgui.separator();
 
@@ -164,17 +166,17 @@ fn renderInspector(s: *SceneState) void {
     else
         &[_]scene_io.ComponentExtra{};
 
-    inspector.renderEntity(entity, extras, &s.is_dirty, idx);
+    inspector.renderEntity(entity, extras, &s.is_dirty, idx, atlas_index);
 }
 
-fn renderViewport(s: *SceneState) void {
+fn renderViewport(s: *SceneState, atlas_index: ?*const @import("../atlas.zig").Index) void {
     viewport.render(.{
         .pan = &s.pan,
         .zoom = &s.zoom,
         .selected_idx = &s.selected_index,
         .is_dirty = &s.is_dirty,
         .drag_armed = &s.drag_armed,
-    }, s.loaded.scene.entities);
+    }, s.loaded.scene.entities, atlas_index);
 }
 
 /// Re-exported so existing zspec tests (and any other caller of

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 const zgui = @import("zgui");
 
 const scene_io = @import("../scene_io.zig");
+const atlas = @import("../atlas.zig");
 
 pub const min_h: f32 = 240;
 
@@ -30,7 +31,7 @@ pub const hit_radius: f32 = 10.0;
 /// Render the viewport canvas for `entities` into the current
 /// imgui window. Caller is responsible for the surrounding container
 /// (e.g. a beginChild) and any controls bar.
-pub fn render(state: State, entities: []scene_io.Entity) void {
+pub fn render(state: State, entities: []scene_io.Entity, atlas_index: ?*const atlas.Index) void {
     const avail = zgui.getContentRegionAvail();
     const canvas_h = @max(min_h, avail[1]);
     if (!zgui.beginChild("##canvas", .{
@@ -56,7 +57,7 @@ pub fn render(state: State, entities: []scene_io.Entity) void {
     });
 
     drawGrid(dl, canvas_min, canvas_max, state.pan.*, state.zoom.*);
-    drawEntities(dl, canvas_min, state, entities);
+    drawEntities(dl, canvas_min, state, entities, atlas_index);
 
     _ = zgui.invisibleButton("##canvas_drag", .{ .w = canvas_size[0], .h = canvas_size[1], .flags = .{} });
 
@@ -130,19 +131,39 @@ fn drawGrid(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, pan: [2]f32, zoom: f3
     dl.addLine(.{ .p1 = .{ cmin[0], origin_y }, .p2 = .{ cmax[0], origin_y }, .col = 0x80_ff_ff_ff, .thickness = 1.0 });
 }
 
-fn drawEntities(dl: zgui.DrawList, cmin: [2]f32, state: State, entities: []scene_io.Entity) void {
+fn drawEntities(
+    dl: zgui.DrawList,
+    cmin: [2]f32,
+    state: State,
+    entities: []scene_io.Entity,
+    atlas_index: ?*const atlas.Index,
+) void {
     for (entities, 0..) |e, i| {
         const pos = e.position orelse continue;
         const px = cmin[0] + state.pan[0] + pos.x * state.zoom.*;
         const py = cmin[1] + state.pan[1] - pos.y * state.zoom.*;
-        const col = colorForPrefab(e.prefab);
-        dl.addCircleFilled(.{
-            .p = .{ px, py },
-            .r = 6,
-            .col = col,
-            .num_segments = 16,
-        });
-        if (state.selected_idx.* == i) {
+        const selected = state.selected_idx.* == i;
+
+        // Try to render the sprite texture if one is declared and the
+        // current atlas index can resolve it; otherwise fall through
+        // to the colored-circle marker. A declared-but-unresolved
+        // sprite gets a `?` overlay so it's distinguishable from
+        // entities that simply don't have a Sprite.
+        const drew_sprite = drawSpriteIfResolved(dl, e, px, py, state.zoom.*, atlas_index);
+        if (!drew_sprite) {
+            const col = colorForPrefab(e.prefab);
+            dl.addCircleFilled(.{
+                .p = .{ px, py },
+                .r = 6,
+                .col = col,
+                .num_segments = 16,
+            });
+            if (e.sprite != null) {
+                dl.addText(.{ px - 3, py - 7 }, 0xff_ff_ff_ff, "?", .{});
+            }
+        }
+
+        if (selected) {
             dl.addCircle(.{
                 .p = .{ px, py },
                 .r = 12,
@@ -155,6 +176,86 @@ fn drawEntities(dl: zgui.DrawList, cmin: [2]f32, state: State, entities: []scene
             dl.addText(.{ px + 8, py - 8 }, 0xff_e0_e0_e0, "{s}", .{p});
         }
     }
+}
+
+/// Returns true if a textured quad was drawn at `(px, py)` for the
+/// given entity. False means caller should fall back to the colored-
+/// marker path.
+fn drawSpriteIfResolved(
+    dl: zgui.DrawList,
+    e: scene_io.Entity,
+    px: f32,
+    py: f32,
+    zoom: f32,
+    atlas_index: ?*const atlas.Index,
+) bool {
+    const sprite = e.sprite orelse return false;
+    const idx = atlas_index orelse return false;
+
+    const name = std.mem.sliceTo(&sprite.sprite_name, 0);
+    if (name.len == 0) return false;
+    const ref = idx.find(name) orelse return false;
+
+    const tex_id = idx.textureFor(ref);
+    if (tex_id == 0) return false;
+    const atlas_size = idx.atlasSize(ref);
+
+    // World-space size of one screen pixel of the sprite. No DPI
+    // factor — the canvas itself is screen-space.
+    const w = @as(f32, @floatFromInt(ref.frame.w)) * zoom;
+    const h = @as(f32, @floatFromInt(ref.frame.h)) * zoom;
+
+    const pivot_name = std.mem.sliceTo(&sprite.pivot, 0);
+    const pivot = pivotOffset(pivot_name);
+    // pivot is the fraction of the sprite to the right/below the
+    // anchor point. e.g. center → (0.5, 0.5); world +y is up, screen
+    // +y is down, so we shift the rect down by pivot.y * h.
+    const x0 = px - pivot[0] * w;
+    const y0 = py - (1.0 - pivot[1]) * h;
+    const x1 = x0 + w;
+    const y1 = y0 + h;
+
+    const uv0: [2]f32 = .{
+        @as(f32, @floatFromInt(ref.frame.x)) / atlas_size[0],
+        @as(f32, @floatFromInt(ref.frame.y)) / atlas_size[1],
+    };
+    const uv1: [2]f32 = .{
+        @as(f32, @floatFromInt(ref.frame.x + ref.frame.w)) / atlas_size[0],
+        @as(f32, @floatFromInt(ref.frame.y + ref.frame.h)) / atlas_size[1],
+    };
+
+    // ImGui 1.92+ TextureRef carries either a managed TextureData
+    // pointer (new dynamic-texture API) or a raw backend handle in
+    // `tex_id`. The opengl3 backend reads `tex_id` directly when
+    // `tex_data` is null, which is exactly what we want for atlas
+    // textures we manage ourselves.
+    const tex_ref: zgui.TextureRef = .{
+        .tex_data = null,
+        .tex_id = @enumFromInt(@as(u64, tex_id)),
+    };
+    dl.addImage(tex_ref, .{
+        .pmin = .{ x0, y0 },
+        .pmax = .{ x1, y1 },
+        .uvmin = uv0,
+        .uvmax = uv1,
+    });
+    return true;
+}
+
+/// Convert a pivot name (matching labelle-gfx pivot enums) to a
+/// (x, y) fraction in [0, 1] where (0, 0) is bottom-left and (1, 1)
+/// is top-right of the sprite. Unknown → center.
+fn pivotOffset(name: []const u8) [2]f32 {
+    if (std.mem.eql(u8, name, "center")) return .{ 0.5, 0.5 };
+    if (std.mem.eql(u8, name, "bottom_center")) return .{ 0.5, 0.0 };
+    if (std.mem.eql(u8, name, "top_center")) return .{ 0.5, 1.0 };
+    if (std.mem.eql(u8, name, "bottom_left")) return .{ 0.0, 0.0 };
+    if (std.mem.eql(u8, name, "bottom_right")) return .{ 1.0, 0.0 };
+    if (std.mem.eql(u8, name, "top_left")) return .{ 0.0, 1.0 };
+    if (std.mem.eql(u8, name, "top_right")) return .{ 1.0, 1.0 };
+    if (std.mem.eql(u8, name, "left_center")) return .{ 0.0, 0.5 };
+    if (std.mem.eql(u8, name, "right_center")) return .{ 1.0, 0.5 };
+    return .{ 0.5, 0.5 };
 }
 
 /// Return the index of the closest entity whose screen-space marker

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -418,6 +418,29 @@ fn jsonNumberAsF32(v: ?std.json.Value) ?f32 {
     };
 }
 
+/// Emit `s` as a JSON-escaped string literal (`"..."`) into `writer`.
+/// Handles the escapes the JSON spec requires for byte values < 0x20
+/// plus the two embeddable bytes (`"` and `\`); leaves the rest of
+/// the UTF-8 stream untouched. Sufficient for the inspector-driven
+/// short identifier fields on `Sprite` — the assembler's parser is
+/// a standard JSON reader, so anything we escape per the spec
+/// round-trips faithfully.
+fn writeJsonString(writer: anytype, s: []const u8) !void {
+    try writer.writeByte('"');
+    for (s) |c| switch (c) {
+        '"' => try writer.writeAll("\\\""),
+        '\\' => try writer.writeAll("\\\\"),
+        '\n' => try writer.writeAll("\\n"),
+        '\r' => try writer.writeAll("\\r"),
+        '\t' => try writer.writeAll("\\t"),
+        0x08 => try writer.writeAll("\\b"),
+        0x0C => try writer.writeAll("\\f"),
+        0x00...0x07, 0x0B, 0x0E...0x1F => try writer.print("\\u{x:0>4}", .{c}),
+        else => try writer.writeByte(c),
+    };
+    try writer.writeByte('"');
+}
+
 /// Emit `"Sprite": { ... }` into `writer` from the typed sprite
 /// fields. Used by both the scene and prefab writers as part of
 /// the per-entity `components` block. Returns `true` if anything
@@ -432,18 +455,25 @@ fn emitSprite(writer: anytype, sprite: Sprite) !bool {
 
     try writer.writeAll(" \"Sprite\": {");
     var first = true;
+    // sprite_name / pivot / layer come straight from inspector text
+    // buffers, so they can in principle hold a `"` or `\`. Escape
+    // them so the rendered file stays valid JSONC even with hostile
+    // input.
     if (name.len > 0) {
-        try writer.print(" \"sprite_name\": \"{s}\"", .{name});
+        try writer.writeAll(" \"sprite_name\": ");
+        try writeJsonString(writer, name);
         first = false;
     }
     if (pivot.len > 0) {
         if (!first) try writer.writeAll(",");
-        try writer.print(" \"pivot\": \"{s}\"", .{pivot});
+        try writer.writeAll(" \"pivot\": ");
+        try writeJsonString(writer, pivot);
         first = false;
     }
     if (layer.len > 0) {
         if (!first) try writer.writeAll(",");
-        try writer.print(" \"layer\": \"{s}\"", .{layer});
+        try writer.writeAll(" \"layer\": ");
+        try writeJsonString(writer, layer);
         first = false;
     }
     if (sprite.has_z_index) {

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -24,13 +24,39 @@ pub const Position = struct {
 /// scenes with room to grow.
 pub const comment_cap = 1024;
 
+/// Buffer sizes for the typed Sprite component. The inspector edits
+/// these in place via `zgui.inputText`, so the buffers live on the
+/// Sprite struct itself rather than as caller-owned scratch.
+pub const sprite_name_cap = 128;
+pub const sprite_pivot_cap = 32;
+pub const sprite_layer_cap = 32;
+
+/// Typed model of the `Sprite` component (issue #31, slice 1).
+/// Parsed verbatim into the edit buffers when a scene/prefab loads;
+/// re-emitted from the buffers on save. Sub-fields beyond these
+/// four (sprite_name / pivot / layer / z_index) are not preserved
+/// yet — slice 2's merge work picks that up. Most real Sprite
+/// blocks use only the four below, so the immediate data loss
+/// risk is small.
+pub const Sprite = struct {
+    sprite_name: [sprite_name_cap:0]u8 = [_:0]u8{0} ** sprite_name_cap,
+    pivot: [sprite_pivot_cap:0]u8 = [_:0]u8{0} ** sprite_pivot_cap,
+    layer: [sprite_layer_cap:0]u8 = [_:0]u8{0} ** sprite_layer_cap,
+    z_index: i32 = 0,
+    has_z_index: bool = false,
+};
+
 pub const Entity = struct {
     prefab: ?[]const u8 = null,
     /// Parsed once on load; viewport reads it when drawing the entity
     /// marker. Components that aren't known to this struct are ignored,
     /// which lets the gui open scenes that reference component types
-    /// we don't model yet (Sprite, Shape, user-defined components).
+    /// we don't model yet (Shape, user-defined components).
     position: ?Position = null,
+    /// Typed `Sprite` component when the source had one. Null
+    /// otherwise. Heap-allocated in the LoadedScene/LoadedPrefab
+    /// arena so the inspector can edit the buffers in place.
+    sprite: ?*Sprite = null,
     /// Leading `//` comments captured from the source file, attached
     /// to the first entity that follows them — same rule we use for
     /// project.labelle pass-through. Lines keep their `//` markers and
@@ -157,12 +183,13 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
 
     const entity: Entity = .{
         .position = readPosition(parsed.value.components),
+        .sprite = try readSprite(arena.allocator(), parsed.value.components),
     };
 
     // Re-use the entity-body scanner — walks `{ ... }`, finds the
-    // `components` key, captures every non-Position entry as
-    // verbatim extras. Works the same for prefab body and child
-    // bodies.
+    // `components` key, captures every non-Position / non-Sprite
+    // entry as verbatim extras. Works the same for prefab body and
+    // child bodies.
     const component_extras = try extractComponentExtras(arena.allocator(), raw);
 
     // Children: mutable so the editor can drag-to-move them. Each
@@ -175,6 +202,7 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
         children[i] = .{
             .prefab = if (c.prefab) |p| try arena.allocator().dupe(u8, p) else null,
             .position = readPosition(c.components),
+            .sprite = try readSprite(arena.allocator(), c.components),
         };
         if (i < child_comments.len) {
             buf.writeZeroed(&children[i].comment, child_comments[i]);
@@ -214,6 +242,11 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
         try w.print(" \"Position\": {{ \"x\": {d}, \"y\": {d} }}", .{ p.x, p.y });
         first = false;
     }
+    if (loaded.entity.sprite) |sp| {
+        if (!first) try w.writeAll(",");
+        _ = try emitSprite(&w, sp.*);
+        first = false;
+    }
     for (loaded.component_extras) |extra| {
         if (!first) try w.writeAll(",");
         try w.print(" \"{s}\": {s}", .{ extra.name, extra.value_text });
@@ -244,13 +277,18 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
                 loaded.children_extras[i]
             else
                 &[_]ComponentExtra{};
-            const has_components = child.position != null or cextras.len > 0;
+            const has_components = child.position != null or child.sprite != null or cextras.len > 0;
             if (has_components) {
                 if (!c_first) try w.writeAll(",");
                 try w.writeAll(" \"components\": {");
                 var cc_first = true;
                 if (child.position) |p| {
                     try w.print(" \"Position\": {{ \"x\": {d}, \"y\": {d} }}", .{ p.x, p.y });
+                    cc_first = false;
+                }
+                if (child.sprite) |sp| {
+                    if (!cc_first) try w.writeAll(",");
+                    _ = try emitSprite(&w, sp.*);
                     cc_first = false;
                 }
                 for (cextras) |extra| {
@@ -310,6 +348,7 @@ pub fn parseScene(allocator: std.mem.Allocator, raw: []const u8) !LoadedScene {
         entities[i] = .{
             .prefab = if (e.prefab) |p| try arena.allocator().dupe(u8, p) else null,
             .position = readPosition(e.components),
+            .sprite = try readSprite(arena.allocator(), e.components),
         };
         // Comments are extracted on a best-effort basis: if the scanner
         // landed fewer entries than parser saw entities (recovery from
@@ -349,6 +388,27 @@ fn readPosition(components: ?std.json.Value) ?Position {
     };
 }
 
+fn readSprite(arena: std.mem.Allocator, components: ?std.json.Value) !?*Sprite {
+    const c = components orelse return null;
+    if (c != .object) return null;
+    const s_val = c.object.get("Sprite") orelse return null;
+    if (s_val != .object) return null;
+
+    const out = try arena.create(Sprite);
+    out.* = .{};
+    if (s_val.object.get("sprite_name")) |v| if (v == .string) buf.writeZeroed(&out.sprite_name, v.string);
+    if (s_val.object.get("pivot")) |v| if (v == .string) buf.writeZeroed(&out.pivot, v.string);
+    if (s_val.object.get("layer")) |v| if (v == .string) buf.writeZeroed(&out.layer, v.string);
+    if (s_val.object.get("z_index")) |v| switch (v) {
+        .integer => |i| {
+            out.z_index = @intCast(i);
+            out.has_z_index = true;
+        },
+        else => {},
+    };
+    return out;
+}
+
 fn jsonNumberAsF32(v: ?std.json.Value) ?f32 {
     const value = v orelse return null;
     return switch (value) {
@@ -356,6 +416,44 @@ fn jsonNumberAsF32(v: ?std.json.Value) ?f32 {
         .float => |f| @floatCast(f),
         else => null,
     };
+}
+
+/// Emit `"Sprite": { ... }` into `writer` from the typed sprite
+/// fields. Used by both the scene and prefab writers as part of
+/// the per-entity `components` block. Returns `true` if anything
+/// was written so the caller can manage commas between sibling
+/// components — an entirely-empty Sprite still emits `"Sprite": {}`
+/// because we know the entity *has* a Sprite component, just no
+/// non-default fields.
+fn emitSprite(writer: anytype, sprite: Sprite) !bool {
+    const name = std.mem.sliceTo(&sprite.sprite_name, 0);
+    const pivot = std.mem.sliceTo(&sprite.pivot, 0);
+    const layer = std.mem.sliceTo(&sprite.layer, 0);
+
+    try writer.writeAll(" \"Sprite\": {");
+    var first = true;
+    if (name.len > 0) {
+        try writer.print(" \"sprite_name\": \"{s}\"", .{name});
+        first = false;
+    }
+    if (pivot.len > 0) {
+        if (!first) try writer.writeAll(",");
+        try writer.print(" \"pivot\": \"{s}\"", .{pivot});
+        first = false;
+    }
+    if (layer.len > 0) {
+        if (!first) try writer.writeAll(",");
+        try writer.print(" \"layer\": \"{s}\"", .{layer});
+        first = false;
+    }
+    if (sprite.has_z_index) {
+        if (!first) try writer.writeAll(",");
+        try writer.print(" \"z_index\": {d}", .{sprite.z_index});
+        first = false;
+    }
+    if (first) try writer.writeAll(" ");
+    try writer.writeAll(" }");
+    return true;
 }
 
 /// Strip a trailing `.jsonc` extension from a path's basename and
@@ -699,7 +797,11 @@ fn extractComponentExtras(arena: std.mem.Allocator, entity_body: []const u8) ![]
         scanValueJson(entity_body, &i);
         const value_end = i;
 
-        if (!std.mem.eql(u8, key, "Position")) {
+        // Skip components the gui models structurally; their fields
+        // are re-emitted by the writer from the typed Entity, so
+        // capturing them as extras would round-trip them twice.
+        const is_managed = std.mem.eql(u8, key, "Position") or std.mem.eql(u8, key, "Sprite");
+        if (!is_managed) {
             try out.append(arena, .{
                 .name = try arena.dupe(u8, key),
                 .value_text = try arena.dupe(u8, std.mem.trim(u8, entity_body[value_start..value_end], " \t\r\n")),
@@ -866,13 +968,18 @@ pub fn renderSceneJsonc(allocator: std.mem.Allocator, loaded: LoadedScene) ![]u8
             loaded.extras.entity_components[i]
         else
             &[_]ComponentExtra{};
-        const has_components = e.position != null or extras.len > 0;
+        const has_components = e.position != null or e.sprite != null or extras.len > 0;
         if (has_components) {
             if (!first) try w.writeAll(",");
             try w.writeAll(" \"components\": {");
             var c_first = true;
             if (e.position) |p| {
                 try w.print(" \"Position\": {{ \"x\": {d}, \"y\": {d} }}", .{ p.x, p.y });
+                c_first = false;
+            }
+            if (e.sprite) |sp| {
+                if (!c_first) try w.writeAll(",");
+                _ = try emitSprite(&w, sp.*);
                 c_first = false;
             }
             for (extras) |extra| {

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -147,6 +147,12 @@ pub const LoadedPrefab = struct {
     children: []Entity,
     /// Per-child unmodeled components, parallel to `children`.
     children_extras: []const []const ComponentExtra,
+    /// Top-level keys other than `components` / `children` that the
+    /// gui doesn't model (custom prefab metadata, future schema
+    /// extensions). Captured verbatim at load and re-emitted on save
+    /// so editing a prefab never silently drops fields the gui
+    /// doesn't know about — same contract scenes use.
+    top_level_extras: []const TopLevelExtra = &.{},
 
     pub fn deinit(self: *LoadedPrefab) void {
         const child_alloc = self.arena.child_allocator;
@@ -209,12 +215,19 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
         }
     }
 
+    // Capture every other top-level key verbatim so the writer can
+    // splice them back in unchanged. Closes the data-loss gap where
+    // editing+saving a prefab would silently drop schema fields the
+    // gui doesn't model.
+    const top_level_extras = try extractPrefabTopLevelExtras(arena.allocator(), raw);
+
     return .{
         .arena = arena,
         .entity = entity,
         .component_extras = component_extras,
         .children = children,
         .children_extras = child_extras,
+        .top_level_extras = top_level_extras,
     };
 }
 
@@ -305,6 +318,14 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
             try w.writeAll("\n");
         }
         try w.writeAll("    ]");
+    }
+
+    // Splice unmodeled top-level keys back in, after the modeled
+    // fields. Order shifts relative to the source (managed first)
+    // but the content is faithful — same trade-off scenes make.
+    for (loaded.top_level_extras) |kv| {
+        try w.writeAll(",\n");
+        try w.print("    \"{s}\": {s}", .{ kv.name, kv.value_text });
     }
 
     try w.writeAll("\n}\n");
@@ -695,10 +716,15 @@ pub fn stripLineComments(allocator: std.mem.Allocator, src: []const u8) ![]u8 {
 // ─── Pass-through extras: capture + writer ─────────────────────────────
 
 /// Scan the top-level JSON object and capture every `"key": value` pair
-/// where `key` isn't one of the names this gui models (`name`,
-/// `entities`). Value text spans from the first non-whitespace byte
-/// after `:` through to just before the trailing `,` or `}`.
-fn extractTopLevelExtras(arena: std.mem.Allocator, raw: []const u8) ![]const TopLevelExtra {
+/// whose key the caller's `isManaged` predicate doesn't claim. Value
+/// text spans from the first non-whitespace byte after `:` through to
+/// just before the trailing `,` or `}`. Scenes and prefabs share this
+/// scanner — they differ only in which keys count as managed.
+fn extractTopLevelExtrasFiltered(
+    arena: std.mem.Allocator,
+    raw: []const u8,
+    isManaged: *const fn ([]const u8) bool,
+) ![]const TopLevelExtra {
     var out: std.ArrayList(TopLevelExtra) = .{};
     errdefer out.deinit(arena);
 
@@ -737,7 +763,7 @@ fn extractTopLevelExtras(arena: std.mem.Allocator, raw: []const u8) ![]const Top
         scanValueJson(raw, &i);
         const value_end = i;
 
-        if (!isManagedTopLevelKey(key)) {
+        if (!isManaged(key)) {
             try out.append(arena, .{
                 .name = try arena.dupe(u8, key),
                 .value_text = try arena.dupe(u8, std.mem.trim(u8, raw[value_start..value_end], " \t\r\n")),
@@ -745,6 +771,14 @@ fn extractTopLevelExtras(arena: std.mem.Allocator, raw: []const u8) ![]const Top
         }
     }
     return out.toOwnedSlice(arena);
+}
+
+fn extractTopLevelExtras(arena: std.mem.Allocator, raw: []const u8) ![]const TopLevelExtra {
+    return extractTopLevelExtrasFiltered(arena, raw, isManagedTopLevelKey);
+}
+
+fn extractPrefabTopLevelExtras(arena: std.mem.Allocator, raw: []const u8) ![]const TopLevelExtra {
+    return extractTopLevelExtrasFiltered(arena, raw, isManagedPrefabTopLevelKey);
 }
 
 /// Per-entity: scan each `{ ... }` in the entities array. Inside,
@@ -939,6 +973,10 @@ fn scanValueJson(raw: []const u8, i: *usize) void {
 
 fn isManagedTopLevelKey(name: []const u8) bool {
     return std.mem.eql(u8, name, "name") or std.mem.eql(u8, name, "entities");
+}
+
+fn isManagedPrefabTopLevelKey(name: []const u8) bool {
+    return std.mem.eql(u8, name, "components") or std.mem.eql(u8, name, "children");
 }
 
 // ─── Writer ────────────────────────────────────────────────────────────

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -811,6 +811,41 @@ pub const SceneIoTests = struct {
         try expect.equal(loaded2.children[0].position.?.x, 99);
     }
 
+    test "parsePrefab preserves unmodeled top-level keys verbatim" {
+        // Regression for copilot PR #30 review: a prefab with custom
+        // top-level keys (metadata, schema_version, anything outside
+        // `components` / `children`) must round-trip those fields
+        // unchanged. Without this, editing+saving a prefab would
+        // silently drop everything the gui doesn't model.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "components": { "Coin": {} },
+            \\    "metadata": { "author": "alex", "tags": ["currency", "pickup"] },
+            \\    "schema_version": 3
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+
+        try expect.equal(loaded.top_level_extras.len, 2);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.top_level_extras[0].name, "metadata"));
+        try expect.toBeTrue(std.mem.eql(u8, loaded.top_level_extras[1].name, "schema_version"));
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+
+        // Both extras must reappear in the output…
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"metadata\":") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"author\": \"alex\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"schema_version\": 3") != null);
+        // …and the output must re-parse cleanly, with the same
+        // extras captured the second time.
+        var loaded2 = try scene_io.parsePrefab(allocator, text);
+        defer loaded2.deinit();
+        try expect.equal(loaded2.top_level_extras.len, 2);
+    }
+
     test "parsePrefab captures extras when file has leading whitespace + comment" {
         // Regression for cursor[bot] PR #30 review: findKeyObject
         // used to bail when the body didn't start with `{` (because

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9,6 +9,7 @@ const new_scene = @import("dialogs/new_scene.zig");
 const scene_io = @import("scene_io.zig");
 const scene_module = @import("modules/scene.zig");
 const project_tree = @import("modules/project_tree.zig");
+const atlas = @import("atlas.zig");
 
 test {
     zspec.runAll(@This());
@@ -830,6 +831,109 @@ pub const SceneIoTests = struct {
         var loaded = try scene_io.parseScene(allocator, src);
         defer loaded.deinit();
         try expect.toBeTrue(loaded.scene.entities[0].position == null);
+    }
+};
+
+pub const AtlasJsonTests = struct {
+    fn emptyAtlas(allocator: std.mem.Allocator) !atlas.Atlas {
+        return .{
+            // Atlas.deinit frees `name`; dupe a placeholder so the
+            // test cleanup path matches the production path. texture_id
+            // stays 0 → deinit skips the GL call.
+            .name = try allocator.dupe(u8, "test"),
+            .texture_id = 0,
+            .width = 0,
+            .height = 0,
+        };
+    }
+
+    test "parses TexturePacker frames into the atlas map" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\  "frames": {
+            \\    "coin": { "frame": { "x": 0, "y": 0, "w": 16, "h": 16 } },
+            \\    "wall": { "frame": { "x": 16, "y": 0, "w": 32, "h": 32 } }
+            \\  },
+            \\  "meta": { "image": "sprites.png" }
+            \\}
+        ;
+        var a = try emptyAtlas(allocator);
+        defer a.deinit(allocator);
+        try atlas.parseFramesFromJsonText(allocator, src, &a);
+
+        try expect.equal(a.frames.count(), 2);
+        const coin = a.frames.get("coin") orelse return error.MissingFrame;
+        try expect.equal(coin.x, 0);
+        try expect.equal(coin.w, 16);
+        const wall = a.frames.get("wall") orelse return error.MissingFrame;
+        try expect.equal(wall.x, 16);
+        try expect.equal(wall.h, 32);
+    }
+
+    test "missing frames key returns an error" {
+        // A manifest without the top-level "frames" object isn't a
+        // valid TexturePacker file — surface a typed error so the
+        // loader can warn and continue instead of silently producing
+        // an empty atlas.
+        const allocator = std.testing.allocator;
+        const src = "{ \"meta\": {} }";
+        var a = try emptyAtlas(allocator);
+        defer a.deinit(allocator);
+        try expect.toBeTrue(std.meta.isError(atlas.parseFramesFromJsonText(allocator, src, &a)));
+    }
+
+    test "skips entries without a frame rect" {
+        // Malformed entries inside an otherwise-valid manifest should
+        // be skipped, not abort the whole parse. This keeps a single
+        // bad sprite from taking out every other sprite in the atlas.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\  "frames": {
+            \\    "ok": { "frame": { "x": 1, "y": 2, "w": 3, "h": 4 } },
+            \\    "no_frame": { "rotated": false },
+            \\    "negative_x": { "frame": { "x": -1, "y": 0, "w": 8, "h": 8 } }
+            \\  }
+            \\}
+        ;
+        var a = try emptyAtlas(allocator);
+        defer a.deinit(allocator);
+        try atlas.parseFramesFromJsonText(allocator, src, &a);
+
+        // Only `ok` survives — the other two are malformed in
+        // ways the parser is documented to ignore.
+        try expect.equal(a.frames.count(), 1);
+        try expect.toBeTrue(a.frames.get("ok") != null);
+    }
+
+    test "accepts float coordinates produced by some exporters" {
+        // Some exporters emit `1.0` instead of `1` for integer
+        // coordinates. The parser should accept both shapes (and
+        // truncate floats to u32).
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\  "frames": {
+            \\    "tile": { "frame": { "x": 10.0, "y": 20.0, "w": 8.0, "h": 8.0 } }
+            \\  }
+            \\}
+        ;
+        var a = try emptyAtlas(allocator);
+        defer a.deinit(allocator);
+        try atlas.parseFramesFromJsonText(allocator, src, &a);
+
+        const tile = a.frames.get("tile") orelse return error.MissingFrame;
+        try expect.equal(tile.x, 10);
+        try expect.equal(tile.w, 8);
+    }
+
+    test "top-level not-an-object surfaces a typed error" {
+        const allocator = std.testing.allocator;
+        const src = "[]";
+        var a = try emptyAtlas(allocator);
+        defer a.deinit(allocator);
+        try expect.toBeTrue(std.meta.isError(atlas.parseFramesFromJsonText(allocator, src, &a)));
     }
 };
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -543,6 +543,62 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "scenes/obstacles.jsonc") != null);
     }
 
+    test "Sprite component round-trips with all four typed fields" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "name": "x",
+            \\    "entities": [
+            \\        { "components": { "Position": { "x": 0, "y": 0 }, "Sprite": { "sprite_name": "coin", "pivot": "center", "layer": "world", "z_index": -5 } } }
+            \\    ]
+            \\}
+        ;
+        var loaded = try scene_io.parseScene(allocator, src);
+        defer loaded.deinit();
+        const sprite = loaded.scene.entities[0].sprite orelse return error.MissingSprite;
+        try expect.toBeTrue(std.mem.eql(u8, std.mem.sliceTo(&sprite.sprite_name, 0), "coin"));
+        try expect.toBeTrue(std.mem.eql(u8, std.mem.sliceTo(&sprite.pivot, 0), "center"));
+        try expect.toBeTrue(std.mem.eql(u8, std.mem.sliceTo(&sprite.layer, 0), "world"));
+        try expect.toBeTrue(sprite.has_z_index);
+        try expect.equal(sprite.z_index, -5);
+
+        const text = try scene_io.renderSceneJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"sprite_name\": \"coin\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"pivot\": \"center\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"layer\": \"world\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"z_index\": -5") != null);
+    }
+
+    test "edit Sprite.sprite_name in memory; saved output reflects it" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "components": { "Sprite": { "sprite_name": "old" } } }
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        // In-place edit via the inspector's path (mutate the buffer).
+        const sprite = loaded.entity.sprite orelse return error.MissingSprite;
+        @memset(&sprite.sprite_name, 0);
+        const new_name = "new";
+        @memcpy(sprite.sprite_name[0..new_name.len], new_name);
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"sprite_name\": \"new\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"sprite_name\": \"old\"") == null);
+    }
+
+    test "entity without Sprite component leaves sprite null" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "components": { "Coin": {} } }
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        try expect.toBeTrue(loaded.entity.sprite == null);
+    }
+
     test "renderSceneJsonc output re-parses cleanly" {
         // End-to-end: scene → render → re-parse → render again
         // should give us the same managed state plus the same extras.
@@ -552,7 +608,7 @@ pub const SceneIoTests = struct {
             \\    "name": "x",
             \\    "entities": [
             \\        // c
-            \\        { "prefab": "p", "components": { "Position": { "x": 1, "y": 2 }, "Sprite": { "n": "s" } } }
+            \\        { "prefab": "p", "components": { "Position": { "x": 1, "y": 2 }, "Sprite": { "sprite_name": "s" } } }
             \\    ]
             \\}
         ;
@@ -567,8 +623,13 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, loaded2.scene.entities[0].prefab.?, "p"));
         try expect.equal(loaded2.scene.entities[0].position.?.x, 1);
         try expect.equal(loaded2.scene.entities[0].position.?.y, 2);
-        try expect.equal(loaded2.extras.entity_components[0].len, 1);
-        try expect.toBeTrue(std.mem.eql(u8, loaded2.extras.entity_components[0][0].name, "Sprite"));
+        // Sprite is typed now, so it's read out of the entity, not
+        // captured in extras. Entity should carry the typed Sprite
+        // with `sprite_name` round-tripped from the source.
+        try expect.equal(loaded2.extras.entity_components[0].len, 0);
+        try expect.toBeTrue(loaded2.scene.entities[0].sprite != null);
+        const sprite_name = std.mem.sliceTo(&loaded2.scene.entities[0].sprite.?.sprite_name, 0);
+        try expect.toBeTrue(std.mem.eql(u8, sprite_name, "s"));
     }
 
     test "parsePrefab reads Position + extras from a prefab body" {
@@ -587,10 +648,16 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(loaded.entity.position != null);
         try expect.equal(loaded.entity.position.?.x, 5);
         try expect.equal(loaded.entity.position.?.y, 10);
-        try expect.equal(loaded.component_extras.len, 2);
-        // Order matches source: Sprite first, then Coin.
-        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[0].name, "Sprite"));
-        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[1].name, "Coin"));
+        // Sprite is typed (issue #31 slice 1) so it lives on
+        // entity.sprite, not in extras. Coin remains an unmodeled
+        // extra.
+        try expect.equal(loaded.component_extras.len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[0].name, "Coin"));
+        try expect.toBeTrue(loaded.entity.sprite != null);
+        const sn = std.mem.sliceTo(&loaded.entity.sprite.?.sprite_name, 0);
+        const pv = std.mem.sliceTo(&loaded.entity.sprite.?.pivot, 0);
+        try expect.toBeTrue(std.mem.eql(u8, sn, "coin"));
+        try expect.toBeTrue(std.mem.eql(u8, pv, "center"));
     }
 
     test "renderPrefabJsonc round-trips a prefab with extras" {
@@ -614,11 +681,13 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"sprite_name\": \"coin\"") != null);
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"Coin\"") != null);
 
-        // Re-parse the rendered text to confirm the writer's output is
-        // self-consistent — same shape, same extras.
+        // Re-parse the rendered text to confirm the writer's output
+        // is self-consistent — Sprite back on entity.sprite, Coin
+        // back in extras.
         var loaded2 = try scene_io.parsePrefab(allocator, text);
         defer loaded2.deinit();
-        try expect.equal(loaded2.component_extras.len, 2);
+        try expect.equal(loaded2.component_extras.len, 1);
+        try expect.toBeTrue(loaded2.entity.sprite != null);
     }
 
     test "parsePrefab reads children with positions and extras" {
@@ -655,11 +724,13 @@ pub const SceneIoTests = struct {
         try expect.equal(loaded.children[0].position.?.x, 15);
         try expect.equal(loaded.children[1].position.?.y, 12);
 
-        // Child-level component extras are captured parallel to
-        // children, with Sprite preserved verbatim.
+        // Sprite is typed now (#31 slice 1) — sits on
+        // child.sprite, not in children_extras.
         try expect.equal(loaded.children_extras.len, 2);
-        try expect.equal(loaded.children_extras[0].len, 1);
-        try expect.toBeTrue(std.mem.eql(u8, loaded.children_extras[0][0].name, "Sprite"));
+        try expect.equal(loaded.children_extras[0].len, 0);
+        try expect.toBeTrue(loaded.children[0].sprite != null);
+        const sn = std.mem.sliceTo(&loaded.children[0].sprite.?.sprite_name, 0);
+        try expect.toBeTrue(std.mem.eql(u8, sn, "bg.png"));
 
         // Leading // comments ride along with the child they precede.
         const c0 = std.mem.sliceTo(&loaded.children[0].comment, 0);
@@ -669,13 +740,16 @@ pub const SceneIoTests = struct {
     }
 
     test "renderPrefabJsonc round-trips children + extras" {
+        // Uses real Sprite fields (sprite_name) since the typed
+        // model only round-trips the four canonical fields; unmodeled
+        // sub-fields like `n` would be silently dropped (#31 follow-up).
         const allocator = std.testing.allocator;
         const src =
             \\{
             \\    "components": { "Room": { "room_type": "x" } },
             \\    "children": [
-            \\        { "components": { "Sprite": { "n": "a" }, "Position": { "x": 1, "y": 2 } } },
-            \\        { "components": { "Sprite": { "n": "b" }, "Position": { "x": 3, "y": 4 } } }
+            \\        { "components": { "Sprite": { "sprite_name": "a" }, "Position": { "x": 1, "y": 2 } } },
+            \\        { "components": { "Sprite": { "sprite_name": "b" }, "Position": { "x": 3, "y": 4 } } }
             \\    ]
             \\}
         ;
@@ -691,8 +765,8 @@ pub const SceneIoTests = struct {
 
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"children\":") != null);
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"x\": 99") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"n\": \"a\"") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"n\": \"b\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"sprite_name\": \"a\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"sprite_name\": \"b\"") != null);
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"Room\":") != null);
 
         // Re-parse the rendered text — same shape, same children
@@ -716,16 +790,17 @@ pub const SceneIoTests = struct {
             \\
             \\{
             \\    "components": {
-            \\        "Sprite": { "n": "x" },
+            \\        "Sprite": { "sprite_name": "x" },
             \\        "Coin": {}
             \\    }
             \\}
         ;
         var loaded = try scene_io.parsePrefab(allocator, src);
         defer loaded.deinit();
-        try expect.equal(loaded.component_extras.len, 2);
-        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[0].name, "Sprite"));
-        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[1].name, "Coin"));
+        // Sprite typed → on entity. Coin unmodeled → still in extras.
+        try expect.equal(loaded.component_extras.len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.component_extras[0].name, "Coin"));
+        try expect.toBeTrue(loaded.entity.sprite != null);
     }
 
     test "renderPrefabJsonc reflects in-memory Position edits" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -571,6 +571,39 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"z_index\": -5") != null);
     }
 
+    test "Sprite string fields are JSON-escaped on emit" {
+        // Regression for gemini PR #32 review: sprite_name/pivot/layer
+        // come from inspector text buffers and may contain `"` or `\`.
+        // The writer must escape them so the rendered .jsonc stays
+        // parseable.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "components": { "Sprite": { "sprite_name": "x" } } }
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        const sprite = loaded.entity.sprite orelse return error.MissingSprite;
+
+        // Stuff a hostile name (quote + backslash) into the buffer.
+        @memset(&sprite.sprite_name, 0);
+        const hostile = "weird\"\\name";
+        @memcpy(sprite.sprite_name[0..hostile.len], hostile);
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+
+        // Output must escape both bytes — the resulting file must
+        // re-parse cleanly through the same path.
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\\\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\\\\") != null);
+
+        var loaded2 = try scene_io.parsePrefab(allocator, text);
+        defer loaded2.deinit();
+        const sprite2 = loaded2.entity.sprite orelse return error.MissingSprite;
+        const name2 = std.mem.sliceTo(&sprite2.sprite_name, 0);
+        try expect.toBeTrue(std.mem.eql(u8, name2, hostile));
+    }
+
     test "edit Sprite.sprite_name in memory; saved output reflects it" {
         const allocator = std.testing.allocator;
         const src =


### PR DESCRIPTION
Closes #31. Adds first-class support for the `Sprite` component, end-to-end from `.jsonc` source through the editor inspector and the viewport.

## Summary
- **Typed Sprite struct** in `scene_io` with edit buffers for `sprite_name`, `pivot`, `layer`, plus an optional `z_index` toggle. Parser and writer treat Sprite as managed (no longer in `component_extras`); both scene and prefab IO round-trip every typed field.
- **Inspector** renders a Sprite section with `inputText` fields and a `(missing)` hint when the entered `sprite_name` doesn't resolve against the current project's atlases.
- **Atlas index** (`src/atlas.zig`) loads every `project.labelle` resource on project open — decodes the PNG via `zstbi`, uploads an OpenGL texture, parses the TexturePacker JSON manifest, and folds every sprite name into a single combined lookup. Rebuilt on `ProjectManager.generation` change so project new/close/load drops the previous index cleanly.
- **Viewport** draws the actual atlas frame (pivot-aware placement, zoom-correct sizing) for any entity with a resolved Sprite; falls back to the colored-circle marker with a `?` overlay when a Sprite is declared but unresolved.
- New build deps: `zstbi` (pinned to a pre-Zig-0.16 commit, same convention as the other zig-gamedev pins).

## Test plan
- [x] `zig build` clean
- [x] `zig build test` — 92/92 passing (5 new `AtlasJsonTests` cover frame extraction, missing-`frames`-key error, malformed-entry skipping, float coordinates, top-level-not-an-object)
- [x] `zig build gui-test` — 6/6 passing
- [x] `zig build smoke` — generate + build via the launcher OK
- [x] Live-verified against `../flying-platform-labelle/`: hydroponics prefab tiles render as real atlas textures in the prefab editor's viewport