### PR TITLE
Rectangle geometry component (#6 slice 1)

### DIFF
--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -95,10 +95,13 @@ pub fn renderEntity(
                 @as(f32, @floatFromInt(rect.a)) / 255.0,
             };
             if (zgui.colorEdit4("color", .{ .col = &col4 })) {
-                rect.r = @intFromFloat(@round(col4[0] * 255.0));
-                rect.g = @intFromFloat(@round(col4[1] * 255.0));
-                rect.b = @intFromFloat(@round(col4[2] * 255.0));
-                rect.a = @intFromFloat(@round(col4[3] * 255.0));
+                // Clamp before casting: `@intFromFloat` is safety-checked
+                // and would panic on values outside `[0, 255]`, which can
+                // happen due to float precision or manual hex/int input.
+                rect.r = @intFromFloat(@round(std.math.clamp(col4[0] * 255.0, 0.0, 255.0)));
+                rect.g = @intFromFloat(@round(std.math.clamp(col4[1] * 255.0, 0.0, 255.0)));
+                rect.b = @intFromFloat(@round(std.math.clamp(col4[2] * 255.0, 0.0, 255.0)));
+                rect.a = @intFromFloat(@round(std.math.clamp(col4[3] * 255.0, 0.0, 255.0)));
                 is_dirty.* = true;
             }
             if (zgui.checkbox("filled", .{ .v = &rect.filled })) is_dirty.* = true;

--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -80,6 +80,31 @@ pub fn renderEntity(
         }
     }
 
+    if (entity.rectangle) |rect| {
+        if (zgui.collapsingHeader("Rectangle", .{ .default_open = true })) {
+            if (zgui.inputFloat("width", .{ .v = &rect.width })) is_dirty.* = true;
+            if (zgui.inputFloat("height", .{ .v = &rect.height })) is_dirty.* = true;
+
+            // Convert u8 RGBA to imgui's float-in-[0,1] color picker
+            // and back. The reverse conversion rounds to the nearest
+            // u8 so the source round-trip is stable across saves.
+            var col4: [4]f32 = .{
+                @as(f32, @floatFromInt(rect.r)) / 255.0,
+                @as(f32, @floatFromInt(rect.g)) / 255.0,
+                @as(f32, @floatFromInt(rect.b)) / 255.0,
+                @as(f32, @floatFromInt(rect.a)) / 255.0,
+            };
+            if (zgui.colorEdit4("color", .{ .col = &col4 })) {
+                rect.r = @intFromFloat(@round(col4[0] * 255.0));
+                rect.g = @intFromFloat(@round(col4[1] * 255.0));
+                rect.b = @intFromFloat(@round(col4[2] * 255.0));
+                rect.a = @intFromFloat(@round(col4[3] * 255.0));
+                is_dirty.* = true;
+            }
+            if (zgui.checkbox("filled", .{ .v = &rect.filled })) is_dirty.* = true;
+        }
+    }
+
     if (zgui.collapsingHeader("Comment", .{})) {
         if (zgui.inputTextMultiline("##comment", .{
             .buf = &entity.comment,

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -148,7 +148,8 @@ fn drawEntities(
         // atlas) > rectangle geometry > colored-circle marker.
         // A declared-but-unresolved sprite still gets a `?` overlay
         // on whatever fallback it falls into.
-        var drew_visual = drawSpriteIfResolved(dl, e, px, py, state.zoom.*, atlas_index);
+        const drew_sprite = drawSpriteIfResolved(dl, e, px, py, state.zoom.*, atlas_index);
+        var drew_visual = drew_sprite;
         if (!drew_visual and e.rectangle != null) {
             drawRectangle(dl, e.rectangle.?.*, px, py, state.zoom.*);
             drew_visual = true;
@@ -161,9 +162,9 @@ fn drawEntities(
                 .col = col,
                 .num_segments = 16,
             });
-            if (e.sprite != null) {
-                dl.addText(.{ px - 3, py - 7 }, 0xff_ff_ff_ff, "?", .{});
-            }
+        }
+        if (!drew_sprite and e.sprite != null) {
+            dl.addText(.{ px - 3, py - 7 }, 0xff_ff_ff_ff, "?", .{});
         }
 
         if (selected) {

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -144,13 +144,16 @@ fn drawEntities(
         const py = cmin[1] + state.pan[1] - pos.y * state.zoom.*;
         const selected = state.selected_idx.* == i;
 
-        // Try to render the sprite texture if one is declared and the
-        // current atlas index can resolve it; otherwise fall through
-        // to the colored-circle marker. A declared-but-unresolved
-        // sprite gets a `?` overlay so it's distinguishable from
-        // entities that simply don't have a Sprite.
-        const drew_sprite = drawSpriteIfResolved(dl, e, px, py, state.zoom.*, atlas_index);
-        if (!drew_sprite) {
+        // Render priority: sprite (when it resolves against the
+        // atlas) > rectangle geometry > colored-circle marker.
+        // A declared-but-unresolved sprite still gets a `?` overlay
+        // on whatever fallback it falls into.
+        var drew_visual = drawSpriteIfResolved(dl, e, px, py, state.zoom.*, atlas_index);
+        if (!drew_visual and e.rectangle != null) {
+            drawRectangle(dl, e.rectangle.?.*, px, py, state.zoom.*);
+            drew_visual = true;
+        }
+        if (!drew_visual) {
             const col = colorForPrefab(e.prefab);
             dl.addCircleFilled(.{
                 .p = .{ px, py },
@@ -240,6 +243,27 @@ fn drawSpriteIfResolved(
         .uvmax = uv1,
     });
     return true;
+}
+
+/// Draw a `Rectangle` geometry component centered on `(px, py)` in
+/// screen space, scaled by `zoom`. Rectangle has no pivot in its
+/// own component schema, so we center it on the entity's position —
+/// same convention the engine uses for unconfigured shape pivots.
+fn drawRectangle(dl: zgui.DrawList, rect: scene_io.Rectangle, px: f32, py: f32, zoom: f32) void {
+    const half_w = rect.width * zoom * 0.5;
+    const half_h = rect.height * zoom * 0.5;
+    const pmin: [2]f32 = .{ px - half_w, py - half_h };
+    const pmax: [2]f32 = .{ px + half_w, py + half_h };
+    // ImGui colors are 0xAABBGGRR. Build it from the u8 RGBA fields.
+    const col: u32 = (@as(u32, rect.a) << 24) |
+        (@as(u32, rect.b) << 16) |
+        (@as(u32, rect.g) << 8) |
+        @as(u32, rect.r);
+    if (rect.filled) {
+        dl.addRectFilled(.{ .pmin = pmin, .pmax = pmax, .col = col });
+    } else {
+        dl.addRect(.{ .pmin = pmin, .pmax = pmax, .col = col, .thickness = 1.5 });
+    }
 }
 
 /// Convert a pivot name (matching labelle-gfx pivot enums) to a

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -46,6 +46,21 @@ pub const Sprite = struct {
     has_z_index: bool = false,
 };
 
+/// Typed model of the `Rectangle` geometry component (issue #6).
+/// Shape on disk:
+/// `{ "width": N, "height": N, "color": { "r": .., "g": .., "b": .., "a": .. }, "filled": bool }`
+/// Color matches labelle-gfx's u8 RGBA convention so values flow
+/// straight through to the engine's renderer.
+pub const Rectangle = struct {
+    width: f32 = 0,
+    height: f32 = 0,
+    r: u8 = 255,
+    g: u8 = 255,
+    b: u8 = 255,
+    a: u8 = 255,
+    filled: bool = true,
+};
+
 pub const Entity = struct {
     prefab: ?[]const u8 = null,
     /// Parsed once on load; viewport reads it when drawing the entity
@@ -57,6 +72,9 @@ pub const Entity = struct {
     /// otherwise. Heap-allocated in the LoadedScene/LoadedPrefab
     /// arena so the inspector can edit the buffers in place.
     sprite: ?*Sprite = null,
+    /// Typed `Rectangle` geometry component (issue #6). Same
+    /// arena-ownership story as `sprite`.
+    rectangle: ?*Rectangle = null,
     /// Leading `//` comments captured from the source file, attached
     /// to the first entity that follows them — same rule we use for
     /// project.labelle pass-through. Lines keep their `//` markers and
@@ -190,12 +208,12 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
     const entity: Entity = .{
         .position = readPosition(parsed.value.components),
         .sprite = try readSprite(arena.allocator(), parsed.value.components),
+        .rectangle = try readRectangle(arena.allocator(), parsed.value.components),
     };
 
     // Re-use the entity-body scanner — walks `{ ... }`, finds the
-    // `components` key, captures every non-Position / non-Sprite
-    // entry as verbatim extras. Works the same for prefab body and
-    // child bodies.
+    // `components` key, captures every non-managed entry as verbatim
+    // extras. Works the same for prefab body and child bodies.
     const component_extras = try extractComponentExtras(arena.allocator(), raw);
 
     // Children: mutable so the editor can drag-to-move them. Each
@@ -209,6 +227,7 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
             .prefab = if (c.prefab) |p| try arena.allocator().dupe(u8, p) else null,
             .position = readPosition(c.components),
             .sprite = try readSprite(arena.allocator(), c.components),
+            .rectangle = try readRectangle(arena.allocator(), c.components),
         };
         if (i < child_comments.len) {
             buf.writeZeroed(&children[i].comment, child_comments[i]);
@@ -260,6 +279,11 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
         _ = try emitSprite(&w, sp.*);
         first = false;
     }
+    if (loaded.entity.rectangle) |re| {
+        if (!first) try w.writeAll(",");
+        _ = try emitRectangle(&w, re.*);
+        first = false;
+    }
     for (loaded.component_extras) |extra| {
         if (!first) try w.writeAll(",");
         try w.print(" \"{s}\": {s}", .{ extra.name, extra.value_text });
@@ -290,7 +314,10 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
                 loaded.children_extras[i]
             else
                 &[_]ComponentExtra{};
-            const has_components = child.position != null or child.sprite != null or cextras.len > 0;
+            const has_components = child.position != null or
+                child.sprite != null or
+                child.rectangle != null or
+                cextras.len > 0;
             if (has_components) {
                 if (!c_first) try w.writeAll(",");
                 try w.writeAll(" \"components\": {");
@@ -302,6 +329,11 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
                 if (child.sprite) |sp| {
                     if (!cc_first) try w.writeAll(",");
                     _ = try emitSprite(&w, sp.*);
+                    cc_first = false;
+                }
+                if (child.rectangle) |re| {
+                    if (!cc_first) try w.writeAll(",");
+                    _ = try emitRectangle(&w, re.*);
                     cc_first = false;
                 }
                 for (cextras) |extra| {
@@ -370,6 +402,7 @@ pub fn parseScene(allocator: std.mem.Allocator, raw: []const u8) !LoadedScene {
             .prefab = if (e.prefab) |p| try arena.allocator().dupe(u8, p) else null,
             .position = readPosition(e.components),
             .sprite = try readSprite(arena.allocator(), e.components),
+            .rectangle = try readRectangle(arena.allocator(), e.components),
         };
         // Comments are extracted on a best-effort basis: if the scanner
         // landed fewer entries than parser saw entities (recovery from
@@ -439,6 +472,37 @@ fn jsonNumberAsF32(v: ?std.json.Value) ?f32 {
     };
 }
 
+fn jsonNumberAsU8(v: ?std.json.Value) ?u8 {
+    const value = v orelse return null;
+    return switch (value) {
+        .integer => |i| if (i >= 0 and i <= 255) @intCast(i) else null,
+        .float => |f| if (f >= 0 and f <= 255) @intFromFloat(f) else null,
+        else => null,
+    };
+}
+
+fn readRectangle(arena: std.mem.Allocator, components: ?std.json.Value) !?*Rectangle {
+    const c = components orelse return null;
+    if (c != .object) return null;
+    const r_val = c.object.get("Rectangle") orelse return null;
+    if (r_val != .object) return null;
+
+    const out = try arena.create(Rectangle);
+    out.* = .{};
+    if (jsonNumberAsF32(r_val.object.get("width"))) |w| out.width = w;
+    if (jsonNumberAsF32(r_val.object.get("height"))) |h| out.height = h;
+    if (r_val.object.get("color")) |col| if (col == .object) {
+        if (jsonNumberAsU8(col.object.get("r"))) |x| out.r = x;
+        if (jsonNumberAsU8(col.object.get("g"))) |x| out.g = x;
+        if (jsonNumberAsU8(col.object.get("b"))) |x| out.b = x;
+        if (jsonNumberAsU8(col.object.get("a"))) |x| out.a = x;
+    };
+    if (r_val.object.get("filled")) |v| if (v == .bool) {
+        out.filled = v.bool;
+    };
+    return out;
+}
+
 /// Emit `s` as a JSON-escaped string literal (`"..."`) into `writer`.
 /// Handles the escapes the JSON spec requires for byte values < 0x20
 /// plus the two embeddable bytes (`"` and `\`); leaves the rest of
@@ -503,6 +567,23 @@ fn emitSprite(writer: anytype, sprite: Sprite) !bool {
         first = false;
     }
     if (first) try writer.writeAll(" ");
+    try writer.writeAll(" }");
+    return true;
+}
+
+/// Emit `"Rectangle": { ... }` into `writer` from the typed
+/// geometry fields. Same comma-management contract as `emitSprite`.
+/// The struct's defaults match the engine's defaults — width 0,
+/// height 0, white opaque, filled — so we still emit all fields
+/// every time. That keeps the file self-describing and lets the
+/// inspector show what was actually saved without inferring.
+fn emitRectangle(writer: anytype, rect: Rectangle) !bool {
+    try writer.writeAll(" \"Rectangle\": {");
+    try writer.print(" \"width\": {d}, \"height\": {d},", .{ rect.width, rect.height });
+    try writer.print(" \"color\": {{ \"r\": {d}, \"g\": {d}, \"b\": {d}, \"a\": {d} }},", .{
+        rect.r, rect.g, rect.b, rect.a,
+    });
+    try writer.print(" \"filled\": {s}", .{if (rect.filled) "true" else "false"});
     try writer.writeAll(" }");
     return true;
 }
@@ -864,7 +945,9 @@ fn extractComponentExtras(arena: std.mem.Allocator, entity_body: []const u8) ![]
         // Skip components the gui models structurally; their fields
         // are re-emitted by the writer from the typed Entity, so
         // capturing them as extras would round-trip them twice.
-        const is_managed = std.mem.eql(u8, key, "Position") or std.mem.eql(u8, key, "Sprite");
+        const is_managed = std.mem.eql(u8, key, "Position") or
+            std.mem.eql(u8, key, "Sprite") or
+            std.mem.eql(u8, key, "Rectangle");
         if (!is_managed) {
             try out.append(arena, .{
                 .name = try arena.dupe(u8, key),
@@ -1036,7 +1119,10 @@ pub fn renderSceneJsonc(allocator: std.mem.Allocator, loaded: LoadedScene) ![]u8
             loaded.extras.entity_components[i]
         else
             &[_]ComponentExtra{};
-        const has_components = e.position != null or e.sprite != null or extras.len > 0;
+        const has_components = e.position != null or
+            e.sprite != null or
+            e.rectangle != null or
+            extras.len > 0;
         if (has_components) {
             if (!first) try w.writeAll(",");
             try w.writeAll(" \"components\": {");
@@ -1048,6 +1134,11 @@ pub fn renderSceneJsonc(allocator: std.mem.Allocator, loaded: LoadedScene) ![]u8
             if (e.sprite) |sp| {
                 if (!c_first) try w.writeAll(",");
                 _ = try emitSprite(&w, sp.*);
+                c_first = false;
+            }
+            if (e.rectangle) |re| {
+                if (!c_first) try w.writeAll(",");
+                _ = try emitRectangle(&w, re.*);
                 c_first = false;
             }
             for (extras) |extra| {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -571,6 +571,99 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"z_index\": -5") != null);
     }
 
+    test "Rectangle round-trips with all fields through a prefab" {
+        // Geometry slice 1 (issue #6): a prefab carrying a Rectangle
+        // component must parse into the typed model with every field
+        // populated, and the writer must emit it back in the same
+        // shape — width/height as numbers, color as nested object,
+        // filled as bool.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "components": {
+            \\        "Rectangle": { "width": 32, "height": 18, "color": { "r": 200, "g": 50, "b": 25, "a": 240 }, "filled": false }
+            \\    }
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+
+        const rect = loaded.entity.rectangle orelse return error.MissingRectangle;
+        try expect.equal(rect.width, 32);
+        try expect.equal(rect.height, 18);
+        try expect.equal(rect.r, 200);
+        try expect.equal(rect.g, 50);
+        try expect.equal(rect.b, 25);
+        try expect.equal(rect.a, 240);
+        try expect.toBeFalse(rect.filled);
+
+        // Rectangle is managed → must NOT end up in component_extras.
+        try expect.equal(loaded.component_extras.len, 0);
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"Rectangle\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"width\": 32") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"filled\": false") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"r\": 200") != null);
+
+        // Re-parse the rendered output — same shape, same values.
+        var loaded2 = try scene_io.parsePrefab(allocator, text);
+        defer loaded2.deinit();
+        const rect2 = loaded2.entity.rectangle orelse return error.MissingRectangle;
+        try expect.equal(rect2.width, 32);
+        try expect.equal(rect2.b, 25);
+        try expect.toBeFalse(rect2.filled);
+    }
+
+    test "Rectangle alongside Sprite and Position on a scene entity" {
+        // Multiple managed components on the same entity must all
+        // round-trip; none of them should leak into component_extras.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "name": "x",
+            \\    "entities": [
+            \\        {
+            \\            "components": {
+            \\                "Position": { "x": 10, "y": 20 },
+            \\                "Sprite": { "sprite_name": "coin" },
+            \\                "Rectangle": { "width": 64, "height": 64, "color": { "r": 0, "g": 0, "b": 255, "a": 255 }, "filled": true }
+            \\            }
+            \\        }
+            \\    ]
+            \\}
+        ;
+        var loaded = try scene_io.parseScene(allocator, src);
+        defer loaded.deinit();
+
+        const e = &loaded.scene.entities[0];
+        try expect.toBeTrue(e.position != null);
+        try expect.toBeTrue(e.sprite != null);
+        try expect.toBeTrue(e.rectangle != null);
+        try expect.equal(loaded.extras.entity_components[0].len, 0);
+        try expect.equal(e.rectangle.?.b, 255);
+    }
+
+    test "edit Rectangle in memory; saved output reflects it" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "components": { "Rectangle": { "width": 0, "height": 0, "color": { "r": 0, "g": 0, "b": 0, "a": 0 }, "filled": true } } }
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        const rect = loaded.entity.rectangle orelse return error.MissingRectangle;
+        rect.width = 99;
+        rect.r = 128;
+        rect.filled = false;
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"width\": 99") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"r\": 128") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"filled\": false") != null);
+    }
+
     test "Sprite string fields are JSON-escaped on emit" {
         // Regression for gemini PR #32 review: sprite_name/pivot/layer
         // come from inspector text buffers and may contain `"` or `\`.


### PR DESCRIPTION
Slice 1 of #6 — first typed geometry component. Circle / Polygon follow in subsequent slices.

## Summary
- Typed `Rectangle` in `scene_io.zig` with full parse/write round-trip; managed alongside `Position` / `Sprite` so it doesn't double-emit via `component_extras`
- Disk schema matches labelle-gfx's `Color` convention (u8 RGBA, nested `color` object) so values flow straight to the engine renderer
- Inspector section: width/height inputs, RGBA color picker (u8 ↔ float conversion that round-trips stably), filled toggle
- Viewport draws the rectangle centered on the entity's position (filled or outline); render priority is now sprite > rectangle > colored-circle marker, so an entity with both Sprite and Rectangle still prefers the resolved sprite

## Disk shape
\`\`\`json
"Rectangle": {
  "width": 32,
  "height": 18,
  "color": { "r": 200, "g": 50, "b": 25, "a": 240 },
  "filled": true
}
\`\`\`

## Test plan
- [x] \`zig build\` clean
- [x] \`zig build test\` — 97/97 (3 new \`Rectangle\` round-trip regressions: standalone in a prefab, alongside Sprite+Position on a scene entity, in-memory edit reflected in saved output)
- [x] \`zig build gui-test\` — 6/6
- [x] \`zig build smoke\` — generate + build OK
- [ ] Live visual verification deferred to tomorrow per author

## Out of scope
- Circle (slice 2)
- Polygon (slice 3)
- Pivot for Rectangle (Rectangle is centered by convention; if/when needed, follow the Sprite pivot pattern)