### PR TITLE
Sprite pivot: dropdown instead of free-text

### DIFF
--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -14,6 +14,34 @@ const zgui = @import("zgui");
 const scene_io = @import("../scene_io.zig");
 const atlas = @import("../atlas.zig");
 
+/// Canonical Sprite.pivot values, matching the engine's pivot enum
+/// and the order in `modules/viewport.zig:pivotOffset`. Index 0
+/// (`center`) is the default when the buffer is empty or unknown.
+const pivot_names = [_][]const u8{
+    "center",
+    "bottom_center",
+    "top_center",
+    "bottom_left",
+    "bottom_right",
+    "top_left",
+    "top_right",
+    "left_center",
+    "right_center",
+};
+
+/// Zero-separated, zero-terminated form of `pivot_names` for
+/// `zgui.combo`'s `items_separated_by_zeros` argument.
+const pivot_items: [:0]const u8 =
+    "center\x00" ++
+    "bottom_center\x00" ++
+    "top_center\x00" ++
+    "bottom_left\x00" ++
+    "bottom_right\x00" ++
+    "top_left\x00" ++
+    "top_right\x00" ++
+    "left_center\x00" ++
+    "right_center\x00";
+
 /// Render the editable surface for one entity:
 ///
 /// - Heading: prefab name (plus optional `Entity #N` label for scene
@@ -65,7 +93,22 @@ pub fn renderEntity(
                     zgui.textColored(.{ 1.0, 0.5, 0.4, 1.0 }, "(missing)", .{});
                 }
             }
-            if (zgui.inputText("pivot", .{ .buf = &sprite.pivot })) is_dirty.* = true;
+            // Pivot is a closed enum on the engine side — let the
+            // user pick from the 9 valid names rather than free-type.
+            // Order matches `pivotOffset` in modules/viewport.zig.
+            const current_pivot = std.mem.sliceTo(&sprite.pivot, 0);
+            var pivot_idx: i32 = for (pivot_names, 0..) |n, i| {
+                if (std.mem.eql(u8, current_pivot, n)) break @intCast(i);
+            } else 0;
+            if (zgui.combo("pivot", .{
+                .current_item = &pivot_idx,
+                .items_separated_by_zeros = pivot_items,
+            })) {
+                const chosen = pivot_names[@intCast(pivot_idx)];
+                @memset(&sprite.pivot, 0);
+                @memcpy(sprite.pivot[0..chosen.len], chosen);
+                is_dirty.* = true;
+            }
             if (zgui.inputText("layer", .{ .buf = &sprite.layer })) is_dirty.* = true;
 
             // z_index is optional in the source; the checkbox toggles

--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -30,17 +30,15 @@ const pivot_names = [_][]const u8{
 };
 
 /// Zero-separated, zero-terminated form of `pivot_names` for
-/// `zgui.combo`'s `items_separated_by_zeros` argument.
-const pivot_items: [:0]const u8 =
-    "center\x00" ++
-    "bottom_center\x00" ++
-    "top_center\x00" ++
-    "bottom_left\x00" ++
-    "bottom_right\x00" ++
-    "top_left\x00" ++
-    "top_right\x00" ++
-    "left_center\x00" ++
-    "right_center\x00";
+/// `zgui.combo`'s `items_separated_by_zeros` argument. Built at
+/// comptime from `pivot_names` so the two lists can't drift.
+const pivot_items: [:0]const u8 = blk: {
+    var res: [:0]const u8 = "";
+    for (pivot_names) |name| {
+        res = res ++ name ++ "\x00";
+    }
+    break :blk res;
+};
 
 /// Render the editable surface for one entity:
 ///


### PR DESCRIPTION
## Summary

The Sprite `pivot` field in the inspector was a free-text input, but the engine treats it as a closed enum — only 9 names are valid and anything else is silently ignored. This swaps the input for a `zgui.combo` populated from the same canonical list used by `modules/viewport.zig:pivotOffset`, so typos are no longer possible and the valid set is discoverable.

Unknown / empty buffers default to "center" (index 0). On selection the buffer is zeroed and rewritten so the existing JSON round-trip continues to work without any changes to `scene_io`.

## Test plan

- [x] `zig build` clean
- [x] `zig build gui-test` — 6/6 passing
- [x] `zig build test` — 94/94 zspec tests passing
- [ ] Manual: open a scene/prefab where a sub-entity carries a `Sprite` with an existing pivot (e.g. `bottom_center`); confirm the dropdown shows that value selected on load, switch to another value, save, reload, and confirm the new value persists in the `.jsonc` file.