### PR TITLE
Circle geometry component (#6 slice 2)

### DIFF
--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -149,6 +149,27 @@ pub fn renderEntity(
         }
     }
 
+    if (entity.circle) |circle| {
+        if (zgui.collapsingHeader("Circle", .{ .default_open = true })) {
+            if (zgui.inputFloat("radius", .{ .v = &circle.radius })) is_dirty.* = true;
+
+            var col4: [4]f32 = .{
+                @as(f32, @floatFromInt(circle.r)) / 255.0,
+                @as(f32, @floatFromInt(circle.g)) / 255.0,
+                @as(f32, @floatFromInt(circle.b)) / 255.0,
+                @as(f32, @floatFromInt(circle.a)) / 255.0,
+            };
+            if (zgui.colorEdit4("color", .{ .col = &col4 })) {
+                circle.r = @intFromFloat(@round(col4[0] * 255.0));
+                circle.g = @intFromFloat(@round(col4[1] * 255.0));
+                circle.b = @intFromFloat(@round(col4[2] * 255.0));
+                circle.a = @intFromFloat(@round(col4[3] * 255.0));
+                is_dirty.* = true;
+            }
+            if (zgui.checkbox("filled", .{ .v = &circle.filled })) is_dirty.* = true;
+        }
+    }
+
     if (zgui.collapsingHeader("Comment", .{})) {
         if (zgui.inputTextMultiline("##comment", .{
             .buf = &entity.comment,

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -145,13 +145,17 @@ fn drawEntities(
         const selected = state.selected_idx.* == i;
 
         // Render priority: sprite (when it resolves against the
-        // atlas) > rectangle geometry > colored-circle marker.
-        // A declared-but-unresolved sprite still gets a `?` overlay
-        // on whatever fallback it falls into.
+        // atlas) > rectangle geometry > circle geometry > colored-
+        // circle marker. A declared-but-unresolved sprite still gets
+        // a `?` overlay on whatever fallback it falls into.
         const drew_sprite = drawSpriteIfResolved(dl, e, px, py, state.zoom.*, atlas_index);
         var drew_visual = drew_sprite;
         if (!drew_visual and e.rectangle != null) {
             drawRectangle(dl, e.rectangle.?.*, px, py, state.zoom.*);
+            drew_visual = true;
+        }
+        if (!drew_visual and e.circle != null) {
+            drawCircle(dl, e.circle.?.*, px, py, state.zoom.*);
             drew_visual = true;
         }
         if (!drew_visual) {
@@ -264,6 +268,35 @@ fn drawRectangle(dl: zgui.DrawList, rect: scene_io.Rectangle, px: f32, py: f32, 
         dl.addRectFilled(.{ .pmin = pmin, .pmax = pmax, .col = col });
     } else {
         dl.addRect(.{ .pmin = pmin, .pmax = pmax, .col = col, .thickness = 1.5 });
+    }
+}
+
+/// Draw a `Circle` geometry component centered on `(px, py)` in
+/// screen space, scaled by `zoom`. Circle's pivot is implicitly its
+/// center — same convention the engine uses for unconfigured shape
+/// pivots.
+fn drawCircle(dl: zgui.DrawList, circle: scene_io.Circle, px: f32, py: f32, zoom: f32) void {
+    const r = circle.radius * zoom;
+    // ImGui colors are 0xAABBGGRR. Build it from the u8 RGBA fields.
+    const col: u32 = (@as(u32, circle.a) << 24) |
+        (@as(u32, circle.b) << 16) |
+        (@as(u32, circle.g) << 8) |
+        @as(u32, circle.r);
+    if (circle.filled) {
+        dl.addCircleFilled(.{
+            .p = .{ px, py },
+            .r = r,
+            .col = col,
+            .num_segments = 32,
+        });
+    } else {
+        dl.addCircle(.{
+            .p = .{ px, py },
+            .r = r,
+            .col = col,
+            .num_segments = 32,
+            .thickness = 1.5,
+        });
     }
 }
 

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -61,6 +61,20 @@ pub const Rectangle = struct {
     filled: bool = true,
 };
 
+/// Typed model of the `Circle` geometry component (issue #6, slice 2).
+/// Shape on disk:
+/// `{ "radius": N, "color": { "r": .., "g": .., "b": .., "a": .. }, "filled": bool }`
+/// Color matches labelle-gfx's u8 RGBA convention so values flow
+/// straight through to the engine's renderer.
+pub const Circle = struct {
+    radius: f32 = 0,
+    r: u8 = 255,
+    g: u8 = 255,
+    b: u8 = 255,
+    a: u8 = 255,
+    filled: bool = true,
+};
+
 pub const Entity = struct {
     prefab: ?[]const u8 = null,
     /// Parsed once on load; viewport reads it when drawing the entity
@@ -75,6 +89,9 @@ pub const Entity = struct {
     /// Typed `Rectangle` geometry component (issue #6). Same
     /// arena-ownership story as `sprite`.
     rectangle: ?*Rectangle = null,
+    /// Typed `Circle` geometry component (issue #6). Same
+    /// arena-ownership story as `sprite`.
+    circle: ?*Circle = null,
     /// Leading `//` comments captured from the source file, attached
     /// to the first entity that follows them — same rule we use for
     /// project.labelle pass-through. Lines keep their `//` markers and
@@ -209,6 +226,7 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
         .position = readPosition(parsed.value.components),
         .sprite = try readSprite(arena.allocator(), parsed.value.components),
         .rectangle = try readRectangle(arena.allocator(), parsed.value.components),
+        .circle = try readCircle(arena.allocator(), parsed.value.components),
     };
 
     // Re-use the entity-body scanner — walks `{ ... }`, finds the
@@ -228,6 +246,7 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
             .position = readPosition(c.components),
             .sprite = try readSprite(arena.allocator(), c.components),
             .rectangle = try readRectangle(arena.allocator(), c.components),
+            .circle = try readCircle(arena.allocator(), c.components),
         };
         if (i < child_comments.len) {
             buf.writeZeroed(&children[i].comment, child_comments[i]);
@@ -284,6 +303,11 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
         _ = try emitRectangle(&w, re.*);
         first = false;
     }
+    if (loaded.entity.circle) |ci| {
+        if (!first) try w.writeAll(",");
+        _ = try emitCircle(&w, ci.*);
+        first = false;
+    }
     for (loaded.component_extras) |extra| {
         if (!first) try w.writeAll(",");
         try w.print(" \"{s}\": {s}", .{ extra.name, extra.value_text });
@@ -317,6 +341,7 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
             const has_components = child.position != null or
                 child.sprite != null or
                 child.rectangle != null or
+                child.circle != null or
                 cextras.len > 0;
             if (has_components) {
                 if (!c_first) try w.writeAll(",");
@@ -334,6 +359,11 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
                 if (child.rectangle) |re| {
                     if (!cc_first) try w.writeAll(",");
                     _ = try emitRectangle(&w, re.*);
+                    cc_first = false;
+                }
+                if (child.circle) |ci| {
+                    if (!cc_first) try w.writeAll(",");
+                    _ = try emitCircle(&w, ci.*);
                     cc_first = false;
                 }
                 for (cextras) |extra| {
@@ -403,6 +433,7 @@ pub fn parseScene(allocator: std.mem.Allocator, raw: []const u8) !LoadedScene {
             .position = readPosition(e.components),
             .sprite = try readSprite(arena.allocator(), e.components),
             .rectangle = try readRectangle(arena.allocator(), e.components),
+            .circle = try readCircle(arena.allocator(), e.components),
         };
         // Comments are extracted on a best-effort basis: if the scanner
         // landed fewer entries than parser saw entities (recovery from
@@ -503,6 +534,27 @@ fn readRectangle(arena: std.mem.Allocator, components: ?std.json.Value) !?*Recta
     return out;
 }
 
+fn readCircle(arena: std.mem.Allocator, components: ?std.json.Value) !?*Circle {
+    const c = components orelse return null;
+    if (c != .object) return null;
+    const c_val = c.object.get("Circle") orelse return null;
+    if (c_val != .object) return null;
+
+    const out = try arena.create(Circle);
+    out.* = .{};
+    if (jsonNumberAsF32(c_val.object.get("radius"))) |rv| out.radius = rv;
+    if (c_val.object.get("color")) |col| if (col == .object) {
+        if (jsonNumberAsU8(col.object.get("r"))) |x| out.r = x;
+        if (jsonNumberAsU8(col.object.get("g"))) |x| out.g = x;
+        if (jsonNumberAsU8(col.object.get("b"))) |x| out.b = x;
+        if (jsonNumberAsU8(col.object.get("a"))) |x| out.a = x;
+    };
+    if (c_val.object.get("filled")) |v| if (v == .bool) {
+        out.filled = v.bool;
+    };
+    return out;
+}
+
 /// Emit `s` as a JSON-escaped string literal (`"..."`) into `writer`.
 /// Handles the escapes the JSON spec requires for byte values < 0x20
 /// plus the two embeddable bytes (`"` and `\`); leaves the rest of
@@ -584,6 +636,21 @@ fn emitRectangle(writer: anytype, rect: Rectangle) !bool {
         rect.r, rect.g, rect.b, rect.a,
     });
     try writer.print(" \"filled\": {s}", .{if (rect.filled) "true" else "false"});
+    try writer.writeAll(" }");
+    return true;
+}
+
+/// Emit `"Circle": { ... }` into `writer` from the typed geometry
+/// fields. Same comma-management contract as `emitSprite`. All
+/// fields are always emitted so the file is self-describing and
+/// the inspector shows what was actually saved without inferring.
+fn emitCircle(writer: anytype, circle: Circle) !bool {
+    try writer.writeAll(" \"Circle\": {");
+    try writer.print(" \"radius\": {d},", .{circle.radius});
+    try writer.print(" \"color\": {{ \"r\": {d}, \"g\": {d}, \"b\": {d}, \"a\": {d} }},", .{
+        circle.r, circle.g, circle.b, circle.a,
+    });
+    try writer.print(" \"filled\": {s}", .{if (circle.filled) "true" else "false"});
     try writer.writeAll(" }");
     return true;
 }
@@ -947,7 +1014,8 @@ fn extractComponentExtras(arena: std.mem.Allocator, entity_body: []const u8) ![]
         // capturing them as extras would round-trip them twice.
         const is_managed = std.mem.eql(u8, key, "Position") or
             std.mem.eql(u8, key, "Sprite") or
-            std.mem.eql(u8, key, "Rectangle");
+            std.mem.eql(u8, key, "Rectangle") or
+            std.mem.eql(u8, key, "Circle");
         if (!is_managed) {
             try out.append(arena, .{
                 .name = try arena.dupe(u8, key),
@@ -1122,6 +1190,7 @@ pub fn renderSceneJsonc(allocator: std.mem.Allocator, loaded: LoadedScene) ![]u8
         const has_components = e.position != null or
             e.sprite != null or
             e.rectangle != null or
+            e.circle != null or
             extras.len > 0;
         if (has_components) {
             if (!first) try w.writeAll(",");
@@ -1139,6 +1208,11 @@ pub fn renderSceneJsonc(allocator: std.mem.Allocator, loaded: LoadedScene) ![]u8
             if (e.rectangle) |re| {
                 if (!c_first) try w.writeAll(",");
                 _ = try emitRectangle(&w, re.*);
+                c_first = false;
+            }
+            if (e.circle) |ci| {
+                if (!c_first) try w.writeAll(",");
+                _ = try emitCircle(&w, ci.*);
                 c_first = false;
             }
             for (extras) |extra| {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -673,6 +673,98 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"filled\": false") != null);
     }
 
+    test "Circle round-trips with all fields through a prefab" {
+        // Geometry slice 2 (issue #6): a prefab carrying a Circle
+        // component must parse into the typed model with every field
+        // populated, and the writer must emit it back in the same
+        // shape — radius as number, color as nested object, filled
+        // as bool.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "components": {
+            \\        "Circle": { "radius": 24, "color": { "r": 200, "g": 50, "b": 25, "a": 240 }, "filled": false }
+            \\    }
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+
+        const circle = loaded.entity.circle orelse return error.MissingCircle;
+        try expect.equal(circle.radius, 24);
+        try expect.equal(circle.r, 200);
+        try expect.equal(circle.g, 50);
+        try expect.equal(circle.b, 25);
+        try expect.equal(circle.a, 240);
+        try expect.toBeFalse(circle.filled);
+
+        // Circle is managed → must NOT end up in component_extras.
+        try expect.equal(loaded.component_extras.len, 0);
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"Circle\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"radius\": 24") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"filled\": false") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"r\": 200") != null);
+
+        // Re-parse the rendered output — same shape, same values.
+        var loaded2 = try scene_io.parsePrefab(allocator, text);
+        defer loaded2.deinit();
+        const circle2 = loaded2.entity.circle orelse return error.MissingCircle;
+        try expect.equal(circle2.radius, 24);
+        try expect.equal(circle2.b, 25);
+        try expect.toBeFalse(circle2.filled);
+    }
+
+    test "Circle alongside Sprite and Position on a scene entity" {
+        // Multiple managed components on the same entity must all
+        // round-trip; none of them should leak into component_extras.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "name": "x",
+            \\    "entities": [
+            \\        {
+            \\            "components": {
+            \\                "Position": { "x": 10, "y": 20 },
+            \\                "Sprite": { "sprite_name": "coin" },
+            \\                "Circle": { "radius": 12, "color": { "r": 0, "g": 0, "b": 255, "a": 255 }, "filled": true }
+            \\            }
+            \\        }
+            \\    ]
+            \\}
+        ;
+        var loaded = try scene_io.parseScene(allocator, src);
+        defer loaded.deinit();
+
+        const e = &loaded.scene.entities[0];
+        try expect.toBeTrue(e.position != null);
+        try expect.toBeTrue(e.sprite != null);
+        try expect.toBeTrue(e.circle != null);
+        try expect.equal(loaded.extras.entity_components[0].len, 0);
+        try expect.equal(e.circle.?.b, 255);
+    }
+
+    test "edit Circle in memory; saved output reflects it" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "components": { "Circle": { "radius": 0, "color": { "r": 0, "g": 0, "b": 0, "a": 0 }, "filled": true } } }
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        const circle = loaded.entity.circle orelse return error.MissingCircle;
+        circle.radius = 99;
+        circle.r = 128;
+        circle.filled = false;
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"radius\": 99") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"r\": 128") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"filled\": false") != null);
+    }
+
     test "Sprite string fields are JSON-escaped on emit" {
         // Regression for gemini PR #32 review: sprite_name/pivot/layer
         // come from inspector text buffers and may contain `"` or `\`.


### PR DESCRIPTION
## Summary

- Adds a typed `Circle` geometry component to the scene/prefab editor,
  mirroring the Rectangle slice in #34.
- Disk shape (always-emitted fields):
```json
"Circle": {
  "radius": 24,
  "color": { "r": 200, "g": 50, "b": 25, "a": 240 },
  "filled": false
}
```
- Inspector gets a "Circle" collapsing header (radius `inputFloat`,
  `colorEdit4` with u8 ↔ float conversion, `filled` checkbox).
- Viewport renders Circle between sprite (when atlas-resolved) and the
  colored-marker fallback, using `addCircleFilled` / `addCircle` with
  32 segments.
- `Circle` is marked managed in `extractComponentExtras` so it never
  double-emits through the verbatim extras path.

## Test plan

- [x] `zig build` — clean.
- [x] `zig build test` — all passing (94 prior + 3 new Circle
  regressions = 97). New tests cover:
  - Circle round-trips through a prefab with every field populated.
  - Circle alongside Sprite + Position on a scene entity (none leak
    into `component_extras`).
  - In-memory edit to a Circle is reflected in the saved output.
- [x] `zig build gui-test` — 6/6.
- [x] `zig build smoke` — generate + build via launcher OK.

## Out of scope

- Polygon is the next slice (slice 3) and is being implemented in a
  sibling PR; conflicts with this one (if any) will be rebased after
  the first lands.
- Rectangle is in #34; this PR is stacked behind it conceptually but
  is branched off `main`, so whichever lands first wins.