### PR TITLE
Polygon geometry component (#6 slice 3)

### DIFF
--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -170,6 +170,77 @@ pub fn renderEntity(
         }
     }
 
+    if (entity.polygon) |poly| {
+        if (zgui.collapsingHeader("Polygon", .{ .default_open = true })) {
+            // Render the points as a numbered list. Each row carries
+            // two `inputFloat` widgets and a small `×` remove button.
+            // We walk by index because the remove path needs to
+            // shift the tail down (no realloc — fixed-cap inline
+            // buffer, see scene_io.Polygon).
+            var idx: u32 = 0;
+            // ImGui needs distinct IDs per row; push the index as a
+            // scope so the `x` / `y` / `×` labels can repeat.
+            while (idx < poly.point_count) {
+                zgui.pushIntId(@intCast(idx));
+                defer zgui.popId();
+
+                zgui.text("#{d}", .{idx});
+                zgui.sameLine(.{});
+                zgui.setNextItemWidth(80);
+                if (zgui.inputFloat("x", .{ .v = &poly.points[idx].x })) is_dirty.* = true;
+                zgui.sameLine(.{});
+                zgui.setNextItemWidth(80);
+                if (zgui.inputFloat("y", .{ .v = &poly.points[idx].y })) is_dirty.* = true;
+                zgui.sameLine(.{});
+
+                var removed = false;
+                if (zgui.smallButton("x##rm")) {
+                    // Shift the tail of the inline buffer down. Cheap:
+                    // the cap is small (64), and removal is rare.
+                    var k: u32 = idx;
+                    while (k + 1 < poly.point_count) : (k += 1) {
+                        poly.points[k] = poly.points[k + 1];
+                    }
+                    poly.point_count -= 1;
+                    poly.points[poly.point_count] = .{};
+                    is_dirty.* = true;
+                    removed = true;
+                }
+                if (!removed) idx += 1;
+            }
+
+            // Add-point button. Hidden when the buffer is at cap so
+            // the user can't drive past it silently.
+            if (poly.point_count < scene_io.polygon_max_points) {
+                if (zgui.button("+ Add point", .{})) {
+                    poly.points[poly.point_count] = .{};
+                    poly.point_count += 1;
+                    is_dirty.* = true;
+                }
+            } else {
+                zgui.textDisabled("(at cap: {d} points)", .{scene_io.polygon_max_points});
+            }
+
+            // Convert u8 RGBA to imgui's float color picker; same
+            // round-to-nearest reverse conversion as Sprite/Rectangle
+            // so the source round-trip is stable across saves.
+            var col4: [4]f32 = .{
+                @as(f32, @floatFromInt(poly.r)) / 255.0,
+                @as(f32, @floatFromInt(poly.g)) / 255.0,
+                @as(f32, @floatFromInt(poly.b)) / 255.0,
+                @as(f32, @floatFromInt(poly.a)) / 255.0,
+            };
+            if (zgui.colorEdit4("color", .{ .col = &col4 })) {
+                poly.r = @intFromFloat(@round(col4[0] * 255.0));
+                poly.g = @intFromFloat(@round(col4[1] * 255.0));
+                poly.b = @intFromFloat(@round(col4[2] * 255.0));
+                poly.a = @intFromFloat(@round(col4[3] * 255.0));
+                is_dirty.* = true;
+            }
+            if (zgui.checkbox("filled", .{ .v = &poly.filled })) is_dirty.* = true;
+        }
+    }
+
     if (zgui.collapsingHeader("Comment", .{})) {
         if (zgui.inputTextMultiline("##comment", .{
             .buf = &entity.comment,

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -28,6 +28,42 @@ pub const State = struct {
 /// Pixel radius around an entity marker that counts as a click.
 pub const hit_radius: f32 = 10.0;
 
+/// Which visual path `drawEntities` takes for one entity. Pulled out
+/// so the priority + unresolved-sprite logic is testable without an
+/// ImGui draw context.
+pub const RenderPath = enum {
+    /// Atlas-resolved sprite was drawn at the entity position.
+    sprite,
+    /// Sprite either wasn't declared or couldn't resolve; polygon
+    /// geometry drew instead.
+    polygon,
+    /// No drawable component resolved; the colored prefab-tinted
+    /// circle marker drew as a last resort.
+    marker,
+};
+
+/// What `drawEntities` should put on the canvas for one entity, given
+/// which components are present and whether the sprite atlas could
+/// resolve. `sprite_resolved` is true only when an atlas-backed quad
+/// will actually be drawn (atlas index present + name in atlas +
+/// non-empty name); see `drawSpriteIfResolved` for the runtime check.
+/// `overlay_question` mirrors the inline `?` overlay rule: any
+/// declared-but-unresolved sprite gets it, no matter which fallback
+/// drew the visual.
+pub fn planRender(has_sprite: bool, sprite_resolved: bool, has_polygon: bool) struct {
+    path: RenderPath,
+    overlay_question: bool,
+} {
+    if (has_sprite and sprite_resolved) {
+        return .{ .path = .sprite, .overlay_question = false };
+    }
+    const sprite_unresolved = has_sprite and !sprite_resolved;
+    if (has_polygon) {
+        return .{ .path = .polygon, .overlay_question = sprite_unresolved };
+    }
+    return .{ .path = .marker, .overlay_question = sprite_unresolved };
+}
+
 /// Render the viewport canvas for `entities` into the current
 /// imgui window. Caller is responsible for the surrounding container
 /// (e.g. a beginChild) and any controls bar.

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -145,9 +145,10 @@ fn drawEntities(
         const selected = state.selected_idx.* == i;
 
         // Render priority: sprite (when it resolves against the
-        // atlas) > rectangle geometry > circle geometry > colored-
-        // circle marker. A declared-but-unresolved sprite still gets
-        // a `?` overlay on whatever fallback it falls into.
+        // atlas) > rectangle geometry > circle geometry > polygon
+        // geometry > colored-circle marker. A declared-but-unresolved
+        // sprite still gets a `?` overlay on whatever fallback it
+        // falls into.
         const drew_sprite = drawSpriteIfResolved(dl, e, px, py, state.zoom.*, atlas_index);
         var drew_visual = drew_sprite;
         if (!drew_visual and e.rectangle != null) {
@@ -156,6 +157,10 @@ fn drawEntities(
         }
         if (!drew_visual and e.circle != null) {
             drawCircle(dl, e.circle.?.*, px, py, state.zoom.*);
+            drew_visual = true;
+        }
+        if (!drew_visual and e.polygon != null) {
+            drawPolygon(dl, e.polygon.?.*, px, py, state.zoom.*);
             drew_visual = true;
         }
         if (!drew_visual) {
@@ -295,6 +300,52 @@ fn drawCircle(dl: zgui.DrawList, circle: scene_io.Circle, px: f32, py: f32, zoom
             .r = r,
             .col = col,
             .num_segments = 32,
+            .thickness = 1.5,
+        });
+    }
+}
+
+/// Draw a `Polygon` geometry component anchored on `(px, py)` in
+/// screen space, scaled by `zoom`. Each point is world-space relative
+/// to the entity's position; the projection mirrors what `drawEntities`
+/// does for the entity marker itself (X scales linearly with zoom; Y
+/// is flipped because world +y is up and screen +y is down).
+///
+/// Filled rendering uses `addConvexPolyFilled` — **only correct for
+/// convex polygons**. Authors of non-convex shapes (L-shapes, stars,
+/// etc.) should set `filled: false`; the outline path uses a closed
+/// polyline which handles both convex and concave geometry. Two or
+/// fewer points fall back to an outline only because a filled poly
+/// would degenerate. Empty polygons render nothing at all.
+fn drawPolygon(dl: zgui.DrawList, poly: scene_io.Polygon, px: f32, py: f32, zoom: f32) void {
+    if (poly.point_count == 0) return;
+
+    // Project up to `polygon_max_points` points into a fixed-size
+    // stack buffer. Matches the source-of-truth cap on `Polygon`
+    // itself, so no allocator is needed.
+    var pts: [scene_io.polygon_max_points][2]f32 = undefined;
+    var i: u32 = 0;
+    while (i < poly.point_count) : (i += 1) {
+        pts[i][0] = px + poly.points[i].x * zoom;
+        pts[i][1] = py - poly.points[i].y * zoom;
+    }
+    const live = pts[0..poly.point_count];
+
+    // ImGui colors are 0xAABBGGRR. Build it from the u8 RGBA fields.
+    const col: u32 = (@as(u32, poly.a) << 24) |
+        (@as(u32, poly.b) << 16) |
+        (@as(u32, poly.g) << 8) |
+        @as(u32, poly.r);
+
+    if (poly.filled and poly.point_count >= 3) {
+        dl.addConvexPolyFilled(live, col);
+    } else {
+        // Closed polyline so the last segment connects back to the
+        // first vertex. For 1–2 points this still gives the user a
+        // visual cue (point or line) while they finish authoring.
+        dl.addPolyline(live, .{
+            .col = col,
+            .flags = .{ .closed = poly.point_count >= 3 },
             .thickness = 1.5,
         });
     }

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -105,10 +105,6 @@ pub const Polygon = struct {
     b: u8 = 255,
     a: u8 = 255,
     filled: bool = true,
-
-    pub fn livePoints(self: *const Polygon) []const Position {
-        return self.points[0..self.point_count];
-    }
 };
 
 pub const Entity = struct {

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -75,6 +75,42 @@ pub const Circle = struct {
     filled: bool = true,
 };
 
+/// Hard cap on how many points a single `Polygon` component can hold.
+/// We use a fixed-capacity inline array instead of an arena-grown slice
+/// so the inspector can add/remove points without re-allocating in the
+/// LoadedScene/LoadedPrefab arena. 64 is well above what any hand-
+/// authored geometry needs (real-world platformer collision polys top
+/// out around a dozen vertices); if a future use case wants more, bump
+/// the cap or migrate to an arena-realloc strategy.
+pub const polygon_max_points: u32 = 64;
+
+/// Typed model of the `Polygon` geometry component (issue #6, slice 3).
+/// Shape on disk:
+/// `{ "points": [ { "x": N, "y": N }, ... ], "color": { "r": .., "g": .., "b": .., "a": .. }, "filled": bool }`
+///
+/// Points are world-space offsets from the entity's `Position`. Color
+/// matches labelle-gfx's u8 RGBA convention so values flow straight
+/// through to the engine's renderer.
+///
+/// Storage: fixed-capacity inline buffer (`polygon_max_points`) with a
+/// `point_count` cursor. The inspector can add/remove points in place
+/// without touching the arena — same lifecycle story as `Sprite`'s
+/// inline char buffers. `points[0..point_count]` is the live slice;
+/// entries beyond `point_count` are undefined and must not be read.
+pub const Polygon = struct {
+    points: [polygon_max_points]Position = [_]Position{.{}} ** polygon_max_points,
+    point_count: u32 = 0,
+    r: u8 = 255,
+    g: u8 = 255,
+    b: u8 = 255,
+    a: u8 = 255,
+    filled: bool = true,
+
+    pub fn livePoints(self: *const Polygon) []const Position {
+        return self.points[0..self.point_count];
+    }
+};
+
 pub const Entity = struct {
     prefab: ?[]const u8 = null,
     /// Parsed once on load; viewport reads it when drawing the entity
@@ -92,6 +128,11 @@ pub const Entity = struct {
     /// Typed `Circle` geometry component (issue #6). Same
     /// arena-ownership story as `sprite`.
     circle: ?*Circle = null,
+    /// Typed `Polygon` geometry component (issue #6, slice 3). Same
+    /// arena-ownership story as `sprite`: the struct itself lives in
+    /// the arena, but its fixed-cap point buffer lives inline so
+    /// adding / removing points doesn't need a realloc.
+    polygon: ?*Polygon = null,
     /// Leading `//` comments captured from the source file, attached
     /// to the first entity that follows them — same rule we use for
     /// project.labelle pass-through. Lines keep their `//` markers and
@@ -227,6 +268,7 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
         .sprite = try readSprite(arena.allocator(), parsed.value.components),
         .rectangle = try readRectangle(arena.allocator(), parsed.value.components),
         .circle = try readCircle(arena.allocator(), parsed.value.components),
+        .polygon = try readPolygon(arena.allocator(), parsed.value.components),
     };
 
     // Re-use the entity-body scanner — walks `{ ... }`, finds the
@@ -247,6 +289,7 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
             .sprite = try readSprite(arena.allocator(), c.components),
             .rectangle = try readRectangle(arena.allocator(), c.components),
             .circle = try readCircle(arena.allocator(), c.components),
+            .polygon = try readPolygon(arena.allocator(), c.components),
         };
         if (i < child_comments.len) {
             buf.writeZeroed(&children[i].comment, child_comments[i]);
@@ -308,6 +351,11 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
         _ = try emitCircle(&w, ci.*);
         first = false;
     }
+    if (loaded.entity.polygon) |po| {
+        if (!first) try w.writeAll(",");
+        _ = try emitPolygon(&w, po.*);
+        first = false;
+    }
     for (loaded.component_extras) |extra| {
         if (!first) try w.writeAll(",");
         try w.print(" \"{s}\": {s}", .{ extra.name, extra.value_text });
@@ -342,6 +390,7 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
                 child.sprite != null or
                 child.rectangle != null or
                 child.circle != null or
+                child.polygon != null or
                 cextras.len > 0;
             if (has_components) {
                 if (!c_first) try w.writeAll(",");
@@ -364,6 +413,11 @@ pub fn renderPrefabJsonc(allocator: std.mem.Allocator, loaded: LoadedPrefab) ![]
                 if (child.circle) |ci| {
                     if (!cc_first) try w.writeAll(",");
                     _ = try emitCircle(&w, ci.*);
+                    cc_first = false;
+                }
+                if (child.polygon) |po| {
+                    if (!cc_first) try w.writeAll(",");
+                    _ = try emitPolygon(&w, po.*);
                     cc_first = false;
                 }
                 for (cextras) |extra| {
@@ -434,6 +488,7 @@ pub fn parseScene(allocator: std.mem.Allocator, raw: []const u8) !LoadedScene {
             .sprite = try readSprite(arena.allocator(), e.components),
             .rectangle = try readRectangle(arena.allocator(), e.components),
             .circle = try readCircle(arena.allocator(), e.components),
+            .polygon = try readPolygon(arena.allocator(), e.components),
         };
         // Comments are extracted on a best-effort basis: if the scanner
         // landed fewer entries than parser saw entities (recovery from
@@ -555,6 +610,43 @@ fn readCircle(arena: std.mem.Allocator, components: ?std.json.Value) !?*Circle {
     return out;
 }
 
+/// Read a `Polygon` component out of the parsed `components` object,
+/// allocating into `arena`. Returns null when the entity has no
+/// `Polygon` key. Points beyond `polygon_max_points` are dropped with
+/// no warning — the cap is documented on `Polygon` itself; in practice
+/// no hand-authored geometry hits it.
+fn readPolygon(arena: std.mem.Allocator, components: ?std.json.Value) !?*Polygon {
+    const c = components orelse return null;
+    if (c != .object) return null;
+    const p_val = c.object.get("Polygon") orelse return null;
+    if (p_val != .object) return null;
+
+    const out = try arena.create(Polygon);
+    out.* = .{};
+    if (p_val.object.get("points")) |pts| if (pts == .array) {
+        var n: u32 = 0;
+        for (pts.array.items) |item| {
+            if (n >= polygon_max_points) break;
+            if (item != .object) continue;
+            const x = jsonNumberAsF32(item.object.get("x")) orelse 0;
+            const y = jsonNumberAsF32(item.object.get("y")) orelse 0;
+            out.points[n] = .{ .x = x, .y = y };
+            n += 1;
+        }
+        out.point_count = n;
+    };
+    if (p_val.object.get("color")) |col| if (col == .object) {
+        if (jsonNumberAsU8(col.object.get("r"))) |x| out.r = x;
+        if (jsonNumberAsU8(col.object.get("g"))) |x| out.g = x;
+        if (jsonNumberAsU8(col.object.get("b"))) |x| out.b = x;
+        if (jsonNumberAsU8(col.object.get("a"))) |x| out.a = x;
+    };
+    if (p_val.object.get("filled")) |v| if (v == .bool) {
+        out.filled = v.bool;
+    };
+    return out;
+}
+
 /// Emit `s` as a JSON-escaped string literal (`"..."`) into `writer`.
 /// Handles the escapes the JSON spec requires for byte values < 0x20
 /// plus the two embeddable bytes (`"` and `\`); leaves the rest of
@@ -651,6 +743,32 @@ fn emitCircle(writer: anytype, circle: Circle) !bool {
         circle.r, circle.g, circle.b, circle.a,
     });
     try writer.print(" \"filled\": {s}", .{if (circle.filled) "true" else "false"});
+    try writer.writeAll(" }");
+    return true;
+}
+
+/// Emit `"Polygon": { ... }` into `writer` from the typed polygon
+/// fields. Same comma-management contract as `emitSprite`. We always
+/// emit `points`, `color`, and `filled` so the file is self-describing
+/// — an empty point list still renders `"points": []`, which makes
+/// the disk shape obvious and lets the inspector show what was saved
+/// without inferring defaults.
+fn emitPolygon(writer: anytype, poly: Polygon) !bool {
+    try writer.writeAll(" \"Polygon\": {");
+    try writer.writeAll(" \"points\": [");
+    var first_pt = true;
+    var i: u32 = 0;
+    while (i < poly.point_count) : (i += 1) {
+        if (!first_pt) try writer.writeAll(",");
+        try writer.print(" {{ \"x\": {d}, \"y\": {d} }}", .{ poly.points[i].x, poly.points[i].y });
+        first_pt = false;
+    }
+    if (poly.point_count == 0) try writer.writeAll(" ");
+    try writer.writeAll(" ],");
+    try writer.print(" \"color\": {{ \"r\": {d}, \"g\": {d}, \"b\": {d}, \"a\": {d} }},", .{
+        poly.r, poly.g, poly.b, poly.a,
+    });
+    try writer.print(" \"filled\": {s}", .{if (poly.filled) "true" else "false"});
     try writer.writeAll(" }");
     return true;
 }
@@ -1015,7 +1133,8 @@ fn extractComponentExtras(arena: std.mem.Allocator, entity_body: []const u8) ![]
         const is_managed = std.mem.eql(u8, key, "Position") or
             std.mem.eql(u8, key, "Sprite") or
             std.mem.eql(u8, key, "Rectangle") or
-            std.mem.eql(u8, key, "Circle");
+            std.mem.eql(u8, key, "Circle") or
+            std.mem.eql(u8, key, "Polygon");
         if (!is_managed) {
             try out.append(arena, .{
                 .name = try arena.dupe(u8, key),
@@ -1191,6 +1310,7 @@ pub fn renderSceneJsonc(allocator: std.mem.Allocator, loaded: LoadedScene) ![]u8
             e.sprite != null or
             e.rectangle != null or
             e.circle != null or
+            e.polygon != null or
             extras.len > 0;
         if (has_components) {
             if (!first) try w.writeAll(",");
@@ -1213,6 +1333,11 @@ pub fn renderSceneJsonc(allocator: std.mem.Allocator, loaded: LoadedScene) ![]u8
             if (e.circle) |ci| {
                 if (!c_first) try w.writeAll(",");
                 _ = try emitCircle(&w, ci.*);
+                c_first = false;
+            }
+            if (e.polygon) |po| {
+                if (!c_first) try w.writeAll(",");
+                _ = try emitPolygon(&w, po.*);
                 c_first = false;
             }
             for (extras) |extra| {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9,6 +9,7 @@ const new_scene = @import("dialogs/new_scene.zig");
 const scene_io = @import("scene_io.zig");
 const scene_module = @import("modules/scene.zig");
 const project_tree = @import("modules/project_tree.zig");
+const viewport = @import("modules/viewport.zig");
 const atlas = @import("atlas.zig");
 
 test {
@@ -1456,6 +1457,52 @@ pub const SceneHitTestTests = struct {
         );
         try expect.toBeTrue(hit != null);
         try expect.equal(hit.?, 1);
+    }
+};
+
+pub const ViewportRenderPlanTests = struct {
+    // Regression coverage for the render-priority + `?` overlay logic
+    // in `drawEntities`. PR #37 review (Cursor Bugbot) flagged that
+    // when a sprite was declared-but-unresolved AND a polygon was
+    // present, the polygon fallback used to suppress the `?` overlay.
+
+    test "resolved sprite wins; no question mark overlay" {
+        const plan = viewport.planRender(true, true, false);
+        try expect.equal(plan.path, .sprite);
+        try expect.toBeFalse(plan.overlay_question);
+    }
+
+    test "no sprite, polygon present → polygon path, no overlay" {
+        const plan = viewport.planRender(false, false, true);
+        try expect.equal(plan.path, .polygon);
+        try expect.toBeFalse(plan.overlay_question);
+    }
+
+    test "no components at all → marker path, no overlay" {
+        const plan = viewport.planRender(false, false, false);
+        try expect.equal(plan.path, .marker);
+        try expect.toBeFalse(plan.overlay_question);
+    }
+
+    test "unresolved sprite + no polygon → marker path with overlay" {
+        const plan = viewport.planRender(true, false, false);
+        try expect.equal(plan.path, .marker);
+        try expect.toBeTrue(plan.overlay_question);
+    }
+
+    test "unresolved sprite + polygon → polygon path STILL shows overlay" {
+        // The bug Cursor Bugbot caught: this case used to silently
+        // render the polygon with no `?` indicator that the sprite
+        // failed to resolve.
+        const plan = viewport.planRender(true, false, true);
+        try expect.equal(plan.path, .polygon);
+        try expect.toBeTrue(plan.overlay_question);
+    }
+
+    test "resolved sprite + polygon → sprite wins (polygon ignored)" {
+        const plan = viewport.planRender(true, true, true);
+        try expect.equal(plan.path, .sprite);
+        try expect.toBeFalse(plan.overlay_question);
     }
 };
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1103,6 +1103,116 @@ pub const SceneIoTests = struct {
         defer loaded.deinit();
         try expect.toBeTrue(loaded.scene.entities[0].position == null);
     }
+
+    test "Polygon round-trips with points + color + filled through a prefab" {
+        // Geometry slice 3 (issue #6): a prefab carrying a Polygon
+        // component must parse into the typed model with every field
+        // populated, and the writer must emit it back in the same
+        // shape — `points` as an array of `{x,y}` objects, color as a
+        // nested object, filled as bool. Polygon is managed so it
+        // must NOT leak into component_extras.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "components": {
+            \\        "Polygon": { "points": [ { "x": 0, "y": 0 }, { "x": 10, "y": 0 }, { "x": 5, "y": 8 } ], "color": { "r": 200, "g": 50, "b": 25, "a": 240 }, "filled": false }
+            \\    }
+            \\}
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+
+        const poly = loaded.entity.polygon orelse return error.MissingPolygon;
+        try expect.equal(poly.point_count, 3);
+        try expect.equal(poly.points[0].x, 0);
+        try expect.equal(poly.points[1].x, 10);
+        try expect.equal(poly.points[2].y, 8);
+        try expect.equal(poly.r, 200);
+        try expect.equal(poly.g, 50);
+        try expect.equal(poly.b, 25);
+        try expect.equal(poly.a, 240);
+        try expect.toBeFalse(poly.filled);
+
+        try expect.equal(loaded.component_extras.len, 0);
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"Polygon\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"points\":") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"x\": 10") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"filled\": false") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"r\": 200") != null);
+
+        // Re-parse the rendered output — same shape, same values.
+        var loaded2 = try scene_io.parsePrefab(allocator, text);
+        defer loaded2.deinit();
+        const poly2 = loaded2.entity.polygon orelse return error.MissingPolygon;
+        try expect.equal(poly2.point_count, 3);
+        try expect.equal(poly2.points[2].y, 8);
+        try expect.equal(poly2.b, 25);
+        try expect.toBeFalse(poly2.filled);
+    }
+
+    test "Polygon add + remove point survives a save / load round-trip" {
+        // The inspector's add-point / remove-point actions mutate the
+        // fixed-cap inline buffer in place. The saved output must
+        // reflect whatever the live slice (`points[0..point_count]`)
+        // contains at save time — not the original parsed source.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "components": { "Polygon": { "points": [ { "x": 0, "y": 0 }, { "x": 1, "y": 1 } ], "color": { "r": 0, "g": 0, "b": 0, "a": 255 }, "filled": true } } }
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        const poly = loaded.entity.polygon orelse return error.MissingPolygon;
+        try expect.equal(poly.point_count, 2);
+
+        // Add a point.
+        poly.points[poly.point_count] = .{ .x = 7, .y = 9 };
+        poly.point_count += 1;
+        try expect.equal(poly.point_count, 3);
+
+        // Remove the first point (shift tail down — same path the
+        // inspector takes when the user clicks `×` on row 0).
+        var k: u32 = 0;
+        while (k + 1 < poly.point_count) : (k += 1) {
+            poly.points[k] = poly.points[k + 1];
+        }
+        poly.point_count -= 1;
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        // Original `(0, 0)` first point must be gone; the appended
+        // `(7, 9)` must be present.
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"x\": 7") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"y\": 9") != null);
+
+        var loaded2 = try scene_io.parsePrefab(allocator, text);
+        defer loaded2.deinit();
+        const poly2 = loaded2.entity.polygon orelse return error.MissingPolygon;
+        try expect.equal(poly2.point_count, 2);
+        try expect.equal(poly2.points[0].x, 1);
+        try expect.equal(poly2.points[1].x, 7);
+    }
+
+    test "edit Polygon color in memory; saved output reflects it" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "components": { "Polygon": { "points": [], "color": { "r": 0, "g": 0, "b": 0, "a": 255 }, "filled": true } } }
+        ;
+        var loaded = try scene_io.parsePrefab(allocator, src);
+        defer loaded.deinit();
+        const poly = loaded.entity.polygon orelse return error.MissingPolygon;
+        poly.r = 128;
+        poly.g = 64;
+        poly.filled = false;
+
+        const text = try scene_io.renderPrefabJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"r\": 128") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"g\": 64") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"filled\": false") != null);
+    }
 };
 
 pub const AtlasJsonTests = struct {


### PR DESCRIPTION
Slice 3 of #6 — closes the geometry trilogy (Rectangle in #34, Circle in slice 2). The novel bit vs. the earlier slices is the dynamic point list.

## Summary
- Typed `Polygon` in `scene_io.zig` with full parse/write round-trip; managed alongside `Position` / `Sprite` so it doesn't double-emit via `component_extras`
- **Fixed-cap inline storage** (`polygon_max_points = 64`) — picked over arena-realloc per the task brief; lets the inspector add/remove points in place without touching the arena. Cap is well above what any hand-authored geometry needs; bump or migrate later if it ever bites
- Disk schema matches the rest of the geometry family for color (u8 RGBA, nested `color` object); points are an array of `{ x, y }` objects, world-space relative to the entity's `Position`
- Inspector section: per-point `#N`, `x`, `y` row with a small `×` remove button; `+ Add point` button (hidden + replaced with an `(at cap)` hint when full); RGBA color picker and `filled` toggle, same convention as Rectangle
- Viewport draws polygons via `addConvexPolyFilled` (filled) or a closed `addPolyline` (outline); render priority is now sprite (when it resolves) > polygon > colored-circle marker. 1–2 points render as a degenerate open polyline so the user gets visual feedback while authoring; ≥3 points enable the closed/filled paths

## Disk shape
```json
"Polygon": {
  "points": [ { "x": 0, "y": 0 }, { "x": 10, "y": 0 }, { "x": 5, "y": 8 } ],
  "color": { "r": 200, "g": 50, "b": 25, "a": 240 },
  "filled": false
}
```

## Convex-only limitation
`addConvexPolyFilled` is what ImGui exposes for the fast filled-path; it only renders correctly for convex polygons. Non-convex authors (L-shapes, stars, etc.) should set `"filled": false` — the outline (closed polyline) handles concave geometry just fine. Documented inline on `drawPolygon`.

## Test plan
- [x] `zig build` clean
- [x] `zig build test` — 97/97 (3 new `Polygon` regressions: full round-trip with points + color + filled, add/remove point survives save+load, color edit reflected in saved output)
- [x] `zig build gui-test` — 6/6
- [x] `zig build smoke` — generate + build OK

## Out of scope
- Closes the geometry trilogy for #6 (Rectangle in #34, Circle in slice 2)
- Non-convex filled rendering (would need `addConcavePolyFilled` + a per-polygon `convex` hint or auto-detection)
- Bumping the 64-point cap or migrating to arena-realloc — defer until a real-world poly hits the ceiling