### PR TITLE
Scaffold + tree integration for gizmos/ folder

### DIFF
--- a/src/icons.zig
+++ b/src/icons.zig
@@ -18,11 +18,11 @@ pub const FA_FILE_CODE = "\u{f1c9}"; // file-code
 // Project folder icons
 pub const FA_CUBE = "\u{f1b2}"; // cube (for 3D components)
 pub const FA_WRENCH = "\u{f0ad}"; // wrench (for fixtures)
+pub const FA_BULLSEYE = "\u{f140}"; // bullseye/crosshair (for gizmos)
 pub const FA_BOX = "\u{f466}"; // box (for prefabs)
 pub const FA_FILM = "\u{f008}"; // film (for scenes)
 pub const FA_SCROLL = "\u{f70e}"; // scroll (for scripts)
 pub const FA_DATABASE = "\u{f1c0}"; // database (for resources)
-pub const FA_BULLSEYE = "\u{f140}"; // bullseye/crosshair (for gizmos)
 
 // Common UI icons
 pub const FA_PLUS = "\u{f067}"; // plus

--- a/src/icons.zig
+++ b/src/icons.zig
@@ -22,6 +22,7 @@ pub const FA_BOX = "\u{f466}"; // box (for prefabs)
 pub const FA_FILM = "\u{f008}"; // film (for scenes)
 pub const FA_SCROLL = "\u{f70e}"; // scroll (for scripts)
 pub const FA_DATABASE = "\u{f1c0}"; // database (for resources)
+pub const FA_BULLSEYE = "\u{f140}"; // bullseye/crosshair (for gizmos)
 
 // Common UI icons
 pub const FA_PLUS = "\u{f067}"; // plus

--- a/src/project.zig
+++ b/src/project.zig
@@ -6,6 +6,7 @@ pub const ProjectFolders = struct {
     pub const assets = "assets";
     pub const components = "components";
     pub const fixtures = "fixtures";
+    pub const gizmos = "gizmos";
     pub const prefabs = "prefabs";
     pub const scenes = "scenes";
     pub const scripts = "scripts";
@@ -15,6 +16,7 @@ pub const ProjectFolders = struct {
         assets,
         components,
         fixtures,
+        gizmos,
         prefabs,
         scenes,
         scripts,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -47,8 +47,8 @@ pub const ProjectFoldersTests = struct {
         return false;
     }
 
-    test "has 7 default folders" {
-        try expect.equal(project.ProjectFolders.all.len, 7);
+    test "has 8 default folders" {
+        try expect.equal(project.ProjectFolders.all.len, 8);
     }
 
     test "contains assets folder" {
@@ -61,6 +61,10 @@ pub const ProjectFoldersTests = struct {
 
     test "contains fixtures folder" {
         try expect.toBeTrue(containsFolder("fixtures"));
+    }
+
+    test "contains gizmos folder" {
+        try expect.toBeTrue(containsFolder("gizmos"));
     }
 
     test "contains prefabs folder" {
@@ -198,6 +202,11 @@ pub const FolderIconsTests = struct {
     test "fixtures folder has wrench icon" {
         const icon = tree_view.FolderIcons.forFolder("fixtures");
         try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.fixtures));
+    }
+
+    test "gizmos folder has bullseye icon" {
+        const icon = tree_view.FolderIcons.forFolder("gizmos");
+        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.gizmos));
     }
 
     test "prefabs folder has box icon" {

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -7,6 +7,7 @@ const icons = @import("icons.zig");
 pub const FolderIcons = struct {
     pub const components = icons.FA_CUBE; // 3D cube for components
     pub const fixtures = icons.FA_WRENCH; // Wrench for fixtures
+    pub const gizmos = icons.FA_BULLSEYE; // Bullseye for gizmos
     pub const prefabs = icons.FA_BOX; // Box for prefabs
     pub const scenes = icons.FA_FILM; // Film for scenes
     pub const scripts = icons.FA_SCROLL; // Scroll for scripts
@@ -18,6 +19,7 @@ pub const FolderIcons = struct {
     pub fn forFolder(name: []const u8) []const u8 {
         if (std.mem.eql(u8, name, project.ProjectFolders.components)) return components;
         if (std.mem.eql(u8, name, project.ProjectFolders.fixtures)) return fixtures;
+        if (std.mem.eql(u8, name, project.ProjectFolders.gizmos)) return gizmos;
         if (std.mem.eql(u8, name, project.ProjectFolders.prefabs)) return prefabs;
         if (std.mem.eql(u8, name, project.ProjectFolders.scenes)) return scenes;
         if (std.mem.eql(u8, name, project.ProjectFolders.scripts)) return scripts;


### PR DESCRIPTION
## Summary

- Adds `gizmos` to `ProjectFolders.all` so new projects scaffold a `gizmos/` directory alongside `scenes/`, `prefabs/`, `components/`, etc. Motivation: the assembler's plugin discovery list (`../labelle-assembler/src/plugin_manifest.zig:24` / `:318`) already treats `gizmos` as a top-level project directory, and the canonical reference project `../flying-platform-labelle/gizmos/` ships 10 `.zon` files there. Without scaffolding the gui silently omits the folder.
- Wires the tree view: new `FA_BULLSEYE` glyph in `icons.zig`, `FolderIcons.gizmos` mapping in `tree_view.zig`, plus the `forFolder("gizmos")` arm so the panel renders with a crosshair icon.
- Editor-side routing (open-as-tab) is intentionally **not** in this PR — a sibling PR owns `isGizmoPath` and `App.openGizmo`.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — 96 / 96 (94 baseline + 2 new: `has 8 default folders`, `contains gizmos folder`, `gizmos folder has bullseye icon`)
- [x] `zig build gui-test` — 6 / 6
- [x] `zig build smoke` — generate + build via launcher succeeded