### PR TITLE
Gizmo .zon editor — tab opens from project tree

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -22,6 +22,7 @@ const resources_mod = @import("modules/resources.zig");
 const scene_mod = @import("modules/scene.zig");
 const prefab_mod = @import("modules/prefab.zig");
 const flow_mod = @import("modules/flow.zig");
+const gizmo_mod = @import("modules/gizmo.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
 const atlas = @import("atlas.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
@@ -43,12 +44,14 @@ pub const OpenTab = union(enum) {
     /// `save`/`isDirty` are no-ops until Phase 1 lands the
     /// `.flow.zon` schema.
     flow: flow_mod.FlowState,
+    gizmo: gizmo_mod.GizmoState,
 
     pub fn deinit(self: *OpenTab, allocator: std.mem.Allocator) void {
         switch (self.*) {
             .scene => |*s| s.deinit(allocator),
             .prefab => |*p| p.deinit(allocator),
             .flow => |*f| f.deinit(allocator),
+            .gizmo => |*g| g.deinit(allocator),
         }
     }
 
@@ -57,6 +60,7 @@ pub const OpenTab = union(enum) {
             .scene => |*s| scene_mod.render(s, app),
             .prefab => |*p| prefab_mod.render(p, app),
             .flow => |*f| flow_mod.render(f, app),
+            .gizmo => |*g| gizmo_mod.render(g, app),
         }
     }
 
@@ -65,6 +69,7 @@ pub const OpenTab = union(enum) {
             .scene => |*s| scene_mod.saveScene(s, app),
             .prefab => |*p| prefab_mod.savePrefab(p, app),
             .flow => |*f| flow_mod.saveFlow(f, app),
+            .gizmo => |*g| gizmo_mod.saveGizmo(g, app),
         }
     }
 
@@ -73,6 +78,7 @@ pub const OpenTab = union(enum) {
             .scene => |s| s.display_name,
             .prefab => |p| p.display_name,
             .flow => |f| f.display_name,
+            .gizmo => |g| g.display_name,
         };
     }
 
@@ -81,6 +87,7 @@ pub const OpenTab = union(enum) {
             .scene => |s| s.path,
             .prefab => |p| p.path,
             .flow => |f| f.path,
+            .gizmo => |g| g.path,
         };
     }
 
@@ -89,6 +96,7 @@ pub const OpenTab = union(enum) {
             .scene => |s| s.is_dirty,
             .prefab => |p| p.is_dirty,
             .flow => |f| f.is_dirty,
+            .gizmo => |g| g.is_dirty,
         };
     }
 };
@@ -275,6 +283,26 @@ pub const App = struct {
         var state = try flow_mod.FlowState.open(self.allocator, path);
         errdefer state.deinit(self.allocator);
         try self.open_tabs.append(self.allocator, .{ .flow = state });
+        const new_idx = self.open_tabs.items.len - 1;
+        self.active_tab_idx = new_idx;
+        self.focus_tab_idx = new_idx;
+    }
+
+    /// Open a `.zon` gizmo file (under `<project>/gizmos/`) as a tab
+    /// in the main content area. De-dups by path; mirrors `openScene`
+    /// and `openPrefab`. `project_tree.isGizmoPath` is the router's
+    /// path discriminator.
+    pub fn openGizmo(self: *Self, path: []const u8) !void {
+        for (self.open_tabs.items, 0..) |t, i| {
+            if (std.mem.eql(u8, t.path(), path)) {
+                self.focus_tab_idx = i;
+                return;
+            }
+        }
+
+        var state = try gizmo_mod.GizmoState.open(self.allocator, path);
+        errdefer state.deinit(self.allocator);
+        try self.open_tabs.append(self.allocator, .{ .gizmo = state });
         const new_idx = self.open_tabs.items.len - 1;
         self.active_tab_idx = new_idx;
         self.focus_tab_idx = new_idx;

--- a/src/gizmo_io.zig
+++ b/src/gizmo_io.zig
@@ -1,0 +1,270 @@
+//! Read/write loader for the Gizmo editor.
+//!
+//! `labelle-engine` gizmos live at `<project>/gizmos/<name>.zon`. They
+//! declare a Shape (or set of children) that the engine attaches at
+//! runtime to any entity whose components match `.match` and don't
+//! match `.exclude`. Shape semantics are owned by
+//! `../labelle-gfx/src/visuals.zig` — a tagged union of
+//! `circle`/`rectangle`/`triangle`/`line`/`polygon`.
+//!
+//! v1 scope: model `.match` / `.exclude` as typed string lists so the
+//! inspector can edit them, but capture `.entity` and `.children` as
+//! verbatim ZON text. The Shape union isn't modeled structurally yet
+//! (deliberately — competing geometry models are still in flight in
+//! sibling PRs). Verbatim pass-through round-trips faithfully and
+//! unblocks the editor without committing to a typed Shape today.
+//!
+//! Same pattern as `src/project.zig`'s `extractUnmodeledFields` for
+//! `project.labelle` — pull out the bits we know how to render and
+//! splice the rest back in unchanged.
+
+const std = @import("std");
+
+/// One parsed gizmo. `match` and `exclude` are typed string lists
+/// owned by the surrounding `LoadedGizmo.arena`. `entity_verbatim` and
+/// `children_verbatim` hold the raw ZON source text of those value
+/// expressions (e.g. `.{ .Shape = .{ ... } }`) — the writer splices
+/// them back into the saved file unchanged.
+pub const Gizmo = struct {
+    match: [][]const u8 = &.{},
+    exclude: [][]const u8 = &.{},
+    /// Verbatim ZON for the `.entity = <value>` right-hand side, with
+    /// any leading/trailing whitespace trimmed. Null when the source
+    /// had no `.entity` field.
+    entity_verbatim: ?[]const u8 = null,
+    /// Verbatim ZON for the `.children = <value>` right-hand side,
+    /// same trim rule. Null when absent.
+    children_verbatim: ?[]const u8 = null,
+};
+
+/// Loaded gizmo plus the arena that owns its memory. Caller frees via
+/// `LoadedGizmo.deinit()`. Mirrors `scene_io.LoadedScene`'s ownership
+/// pattern so the tab module can pair this with its own arena.
+pub const LoadedGizmo = struct {
+    arena: *std.heap.ArenaAllocator,
+    gizmo: Gizmo,
+
+    pub fn deinit(self: *LoadedGizmo) void {
+        const child_alloc = self.arena.child_allocator;
+        self.arena.deinit();
+        child_alloc.destroy(self.arena);
+    }
+};
+
+pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !LoadedGizmo {
+    const raw = try std.fs.cwd().readFileAlloc(allocator, path, 16 * 1024 * 1024);
+    defer allocator.free(raw);
+    return parseGizmo(allocator, raw);
+}
+
+/// Parse a gizmo's ZON source into a `LoadedGizmo`. Pulls `.match` /
+/// `.exclude` through `std.zon.parse.fromSlice` (tolerant of unknown
+/// fields so `.entity` / `.children` don't trip it up), then re-scans
+/// the source byte-wise to capture the verbatim text of the
+/// `.entity` and `.children` value expressions for round-tripping.
+pub fn parseGizmo(allocator: std.mem.Allocator, raw: []const u8) !LoadedGizmo {
+    const arena = try allocator.create(std.heap.ArenaAllocator);
+    errdefer allocator.destroy(arena);
+    arena.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+
+    const arena_alloc = arena.allocator();
+
+    // `std.zon.parse.fromSlice` needs a sentinel-terminated slice for
+    // its tokenizer — same as `project.zig`. Copy into the arena so
+    // the parsed string slices borrow lifetime from us.
+    const source = try arena_alloc.dupeZ(u8, raw);
+
+    const Intermediate = struct {
+        match: [][]const u8 = &.{},
+        exclude: [][]const u8 = &.{},
+    };
+
+    var diag: std.zon.parse.Diagnostics = .{};
+    defer diag.deinit(arena_alloc);
+    const parsed = try std.zon.parse.fromSlice(Intermediate, arena_alloc, source, &diag, .{
+        .ignore_unknown_fields = true,
+    });
+
+    const entity_verbatim = try extractFieldValueVerbatim(arena_alloc, raw, "entity");
+    const children_verbatim = try extractFieldValueVerbatim(arena_alloc, raw, "children");
+
+    return .{
+        .arena = arena,
+        .gizmo = .{
+            .match = parsed.match,
+            .exclude = parsed.exclude,
+            .entity_verbatim = entity_verbatim,
+            .children_verbatim = children_verbatim,
+        },
+    };
+}
+
+/// Render a `LoadedGizmo` back to ZON source. Field order is
+/// canonical: `.match`, then `.exclude` (only when non-empty), then
+/// `.entity` (only when present), then `.children` (only when
+/// present). Mirrors `project.zig`'s `renderProjectLabelle` layout.
+pub fn renderGizmoZon(allocator: std.mem.Allocator, loaded: LoadedGizmo) ![]u8 {
+    var out: std.ArrayList(u8) = .{};
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+
+    try w.writeAll(".{\n");
+
+    // .match — always emitted (the engine requires it).
+    try w.writeAll("    .match = .{");
+    for (loaded.gizmo.match, 0..) |s, i| {
+        if (i > 0) try w.writeAll(", ");
+        try w.print("\"{s}\"", .{s});
+    }
+    try w.writeAll("},\n");
+
+    if (loaded.gizmo.exclude.len > 0) {
+        try w.writeAll("    .exclude = .{");
+        for (loaded.gizmo.exclude, 0..) |s, i| {
+            if (i > 0) try w.writeAll(", ");
+            try w.print("\"{s}\"", .{s});
+        }
+        try w.writeAll("},\n");
+    }
+
+    if (loaded.gizmo.entity_verbatim) |text| {
+        try w.print("    .entity = {s},\n", .{text});
+    }
+
+    if (loaded.gizmo.children_verbatim) |text| {
+        try w.print("    .children = {s},\n", .{text});
+    }
+
+    try w.writeAll("}\n");
+    return out.toOwnedSlice(allocator);
+}
+
+/// Write `loaded` back to disk at `path`. Truncates any existing file.
+pub fn saveGizmo(allocator: std.mem.Allocator, path: []const u8, loaded: LoadedGizmo) !void {
+    const text = try renderGizmoZon(allocator, loaded);
+    defer allocator.free(text);
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(text);
+}
+
+/// Strip a trailing `.zon` extension from a path's basename and
+/// return the stem (e.g. `"a/b/workstation.zon"` → `"workstation"`).
+/// Used by the gizmo tab for its display label.
+pub fn displayNameFromPath(path: []const u8) []const u8 {
+    const base = std.fs.path.basename(path);
+    const ext = ".zon";
+    if (std.mem.endsWith(u8, base, ext)) return base[0 .. base.len - ext.len];
+    return base;
+}
+
+// ─── Verbatim scanner ──────────────────────────────────────────────────
+//
+// Same dialect handling as `project.zig`'s top-level scanner: ZON with
+// `// ... \n` comments, `"..."` strings with `\"` escapes, and brace /
+// bracket / paren nesting in values. Multi-line strings (`\\...`) and
+// `'...'` character literals aren't handled because the gizmo schema
+// doesn't use them — extend if a future schema needs them.
+
+/// Locate the top-level field named `field_name` and return the
+/// verbatim source text of its value (trimmed of surrounding
+/// whitespace). Returns null when the field is absent.
+fn extractFieldValueVerbatim(
+    arena: std.mem.Allocator,
+    raw: []const u8,
+    field_name: []const u8,
+) !?[]const u8 {
+    var i: usize = 0;
+    skipWsAndComments(raw, &i);
+    if (i + 1 >= raw.len or raw[i] != '.' or raw[i + 1] != '{') return null;
+    i += 2;
+
+    while (i < raw.len) {
+        skipWsAndComments(raw, &i);
+        if (i >= raw.len) break;
+        if (raw[i] == '}') break;
+        if (raw[i] == ',') {
+            i += 1;
+            continue;
+        }
+        if (raw[i] != '.') break; // unexpected; bail rather than mis-parse
+
+        i += 1; // past '.'
+        const name_start = i;
+        while (i < raw.len) : (i += 1) {
+            const c = raw[i];
+            if (!std.ascii.isAlphanumeric(c) and c != '_') break;
+        }
+        const name = raw[name_start..i];
+        if (name.len == 0) break;
+
+        skipWsAndComments(raw, &i);
+        if (i >= raw.len or raw[i] != '=') break;
+        i += 1; // past '='
+        skipWsAndComments(raw, &i);
+
+        const value_start = i;
+        scanValue(raw, &i);
+        const value_end = i;
+
+        if (std.mem.eql(u8, name, field_name)) {
+            const trimmed = std.mem.trim(u8, raw[value_start..value_end], " \t\r\n");
+            return try arena.dupe(u8, trimmed);
+        }
+
+        // Optional trailing comma between fields.
+        const save = i;
+        skipWsAndComments(raw, &i);
+        if (i < raw.len and raw[i] == ',') {
+            i += 1;
+        } else {
+            i = save;
+        }
+    }
+    return null;
+}
+
+fn skipWsAndComments(raw: []const u8, i: *usize) void {
+    while (i.* < raw.len) {
+        const c = raw[i.*];
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r') {
+            i.* += 1;
+        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
+            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
+        } else break;
+    }
+}
+
+fn scanValue(raw: []const u8, i: *usize) void {
+    var depth: usize = 0;
+    while (i.* < raw.len) {
+        const c = raw[i.*];
+        if (c == '"') {
+            i.* += 1;
+            while (i.* < raw.len) {
+                if (raw[i.*] == '\\' and i.* + 1 < raw.len) {
+                    i.* += 2;
+                } else if (raw[i.*] == '"') {
+                    i.* += 1;
+                    break;
+                } else {
+                    i.* += 1;
+                }
+            }
+        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
+            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
+        } else if (c == '{' or c == '[' or c == '(') {
+            depth += 1;
+            i.* += 1;
+        } else if (c == '}' or c == ']' or c == ')') {
+            if (depth == 0) return; // outer `}` — stop without consuming
+            depth -= 1;
+            i.* += 1;
+        } else if (c == ',' and depth == 0) {
+            return;
+        } else {
+            i.* += 1;
+        }
+    }
+}

--- a/src/gizmo_io.zig
+++ b/src/gizmo_io.zig
@@ -19,6 +19,7 @@
 //! splice the rest back in unchanged.
 
 const std = @import("std");
+const zon_scan = @import("zon_scan.zig");
 
 /// One parsed gizmo. `match` and `exclude` are typed string lists
 /// owned by the surrounding `LoadedGizmo.arena`. `entity_verbatim` and
@@ -112,10 +113,13 @@ pub fn renderGizmoZon(allocator: std.mem.Allocator, loaded: LoadedGizmo) ![]u8 {
     try w.writeAll(".{\n");
 
     // .match — always emitted (the engine requires it).
+    // Strings are escaped via `std.zig.fmtString` so a hostile value
+    // (containing `"`, `\\`, or non-printables) round-trips as valid
+    // ZON instead of breaking the file.
     try w.writeAll("    .match = .{");
     for (loaded.gizmo.match, 0..) |s, i| {
         if (i > 0) try w.writeAll(", ");
-        try w.print("\"{s}\"", .{s});
+        try w.print("\"{f}\"", .{std.zig.fmtString(s)});
     }
     try w.writeAll("},\n");
 
@@ -123,7 +127,7 @@ pub fn renderGizmoZon(allocator: std.mem.Allocator, loaded: LoadedGizmo) ![]u8 {
         try w.writeAll("    .exclude = .{");
         for (loaded.gizmo.exclude, 0..) |s, i| {
             if (i > 0) try w.writeAll(", ");
-            try w.print("\"{s}\"", .{s});
+            try w.print("\"{f}\"", .{std.zig.fmtString(s)});
         }
         try w.writeAll("},\n");
     }
@@ -161,11 +165,11 @@ pub fn displayNameFromPath(path: []const u8) []const u8 {
 
 // ─── Verbatim scanner ──────────────────────────────────────────────────
 //
-// Same dialect handling as `project.zig`'s top-level scanner: ZON with
-// `// ... \n` comments, `"..."` strings with `\"` escapes, and brace /
-// bracket / paren nesting in values. Multi-line strings (`\\...`) and
-// `'...'` character literals aren't handled because the gizmo schema
-// doesn't use them — extend if a future schema needs them.
+// Dialect handling lives in `zon_scan.zig` and is shared with
+// `project.zig`'s `extractUnmodeledFields` — same ZON grammar (line
+// comments, `"..."` strings with backslash escapes, brace / bracket /
+// paren nesting). Keeping it in one place means future schema growth
+// (multi-line strings, char literals) lands in both consumers at once.
 
 /// Locate the top-level field named `field_name` and return the
 /// verbatim source text of its value (trimmed of surrounding
@@ -176,12 +180,12 @@ fn extractFieldValueVerbatim(
     field_name: []const u8,
 ) !?[]const u8 {
     var i: usize = 0;
-    skipWsAndComments(raw, &i);
+    zon_scan.skipWsAndComments(raw, &i);
     if (i + 1 >= raw.len or raw[i] != '.' or raw[i + 1] != '{') return null;
     i += 2;
 
     while (i < raw.len) {
-        skipWsAndComments(raw, &i);
+        zon_scan.skipWsAndComments(raw, &i);
         if (i >= raw.len) break;
         if (raw[i] == '}') break;
         if (raw[i] == ',') {
@@ -199,13 +203,13 @@ fn extractFieldValueVerbatim(
         const name = raw[name_start..i];
         if (name.len == 0) break;
 
-        skipWsAndComments(raw, &i);
+        zon_scan.skipWsAndComments(raw, &i);
         if (i >= raw.len or raw[i] != '=') break;
         i += 1; // past '='
-        skipWsAndComments(raw, &i);
+        zon_scan.skipWsAndComments(raw, &i);
 
         const value_start = i;
-        scanValue(raw, &i);
+        zon_scan.scanValue(raw, &i);
         const value_end = i;
 
         if (std.mem.eql(u8, name, field_name)) {
@@ -215,7 +219,7 @@ fn extractFieldValueVerbatim(
 
         // Optional trailing comma between fields.
         const save = i;
-        skipWsAndComments(raw, &i);
+        zon_scan.skipWsAndComments(raw, &i);
         if (i < raw.len and raw[i] == ',') {
             i += 1;
         } else {
@@ -223,48 +227,4 @@ fn extractFieldValueVerbatim(
         }
     }
     return null;
-}
-
-fn skipWsAndComments(raw: []const u8, i: *usize) void {
-    while (i.* < raw.len) {
-        const c = raw[i.*];
-        if (c == ' ' or c == '\t' or c == '\n' or c == '\r') {
-            i.* += 1;
-        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
-            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
-        } else break;
-    }
-}
-
-fn scanValue(raw: []const u8, i: *usize) void {
-    var depth: usize = 0;
-    while (i.* < raw.len) {
-        const c = raw[i.*];
-        if (c == '"') {
-            i.* += 1;
-            while (i.* < raw.len) {
-                if (raw[i.*] == '\\' and i.* + 1 < raw.len) {
-                    i.* += 2;
-                } else if (raw[i.*] == '"') {
-                    i.* += 1;
-                    break;
-                } else {
-                    i.* += 1;
-                }
-            }
-        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
-            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
-        } else if (c == '{' or c == '[' or c == '(') {
-            depth += 1;
-            i.* += 1;
-        } else if (c == '}' or c == ']' or c == ')') {
-            if (depth == 0) return; // outer `}` — stop without consuming
-            depth -= 1;
-            i.* += 1;
-        } else if (c == ',' and depth == 0) {
-            return;
-        } else {
-            i.* += 1;
-        }
-    }
 }

--- a/src/modules/gizmo.zig
+++ b/src/modules/gizmo.zig
@@ -34,6 +34,12 @@ pub const GizmoState = struct {
     /// `loaded.gizmo.match` (arena-owned). Sized at load.
     match_bufs: []TagBuf = &.{},
     exclude_bufs: []TagBuf = &.{},
+    /// Sentinel-terminated, mutable copies of the verbatim ZON blocks
+    /// for `inputTextMultiline`. Sized to exactly fit the text — the
+    /// previous fixed 4 KiB stack buffer truncated larger gizmos. Null
+    /// when the corresponding block is absent. Owned by `arena`.
+    entity_buf: ?[:0]u8 = null,
+    children_buf: ?[:0]u8 = null,
     is_dirty: bool = false,
 
     pub fn open(allocator: std.mem.Allocator, path: []const u8) !GizmoState {
@@ -52,6 +58,15 @@ pub const GizmoState = struct {
         const match_bufs = try makeTagBufs(a, loaded.gizmo.match);
         const exclude_bufs = try makeTagBufs(a, loaded.gizmo.exclude);
 
+        const entity_buf: ?[:0]u8 = if (loaded.gizmo.entity_verbatim) |t|
+            try a.dupeZ(u8, t)
+        else
+            null;
+        const children_buf: ?[:0]u8 = if (loaded.gizmo.children_verbatim) |t|
+            try a.dupeZ(u8, t)
+        else
+            null;
+
         return .{
             .arena = arena,
             .path = path_dup,
@@ -59,6 +74,8 @@ pub const GizmoState = struct {
             .loaded = loaded,
             .match_bufs = match_bufs,
             .exclude_bufs = exclude_bufs,
+            .entity_buf = entity_buf,
+            .children_buf = children_buf,
         };
     }
 
@@ -96,16 +113,16 @@ pub fn render(s: *GizmoState, app: *App) void {
     zgui.spacing();
     zgui.separator();
 
-    if (s.loaded.gizmo.entity_verbatim) |text| {
+    if (s.entity_buf) |buf| {
         if (zgui.collapsingHeader("Entity", .{ .default_open = true })) {
             zgui.textDisabled("(read-only — edit by hand for v1)", .{});
-            renderReadOnlyMultiline("##gizmo_entity", text);
+            renderReadOnlyMultiline("##gizmo_entity", buf);
         }
     }
-    if (s.loaded.gizmo.children_verbatim) |text| {
+    if (s.children_buf) |buf| {
         if (zgui.collapsingHeader("Children", .{ .default_open = true })) {
             zgui.textDisabled("(read-only — edit by hand for v1)", .{});
-            renderReadOnlyMultiline("##gizmo_children", text);
+            renderReadOnlyMultiline("##gizmo_children", buf);
         }
     }
 }
@@ -226,28 +243,24 @@ fn removeBufs(arena: std.mem.Allocator, src: []TagBuf, idx: usize) ![]TagBuf {
     return out;
 }
 
-fn renderReadOnlyMultiline(id: [:0]const u8, text: []const u8) void {
-    // Read-only inputTextMultiline needs a writable buffer (zgui
-    // copies into the buffer for cursor state). Allocate a stack
-    // buffer sized to the text, sentinel-terminated. 4 KiB is plenty
-    // for any v1 gizmo block — they're tiny in practice.
-    var stack_buf: [4096:0]u8 = undefined;
-    @memset(&stack_buf, 0);
-    const n = @min(stack_buf.len - 1, text.len);
-    @memcpy(stack_buf[0..n], text[0..n]);
+fn renderReadOnlyMultiline(id: [:0]const u8, buf: [:0]u8) void {
+    // Read-only inputTextMultiline still requires a writable, sentinel-
+    // terminated buffer (zgui copies into it for cursor state). The
+    // buffer is precomputed and arena-owned by `GizmoState.open`, sized
+    // to fit the full verbatim block — no truncation for large gizmos.
 
     // Approximate line count to size the widget. Clamped so a tiny
     // block doesn't render with a single-line slit and a huge one
     // doesn't dominate the inspector.
     var line_count: usize = 1;
-    for (text) |c| {
+    for (buf) |c| {
         if (c == '\n') line_count += 1;
     }
     const lines_clamped = @max(@min(line_count, @as(usize, 14)), @as(usize, 4));
     const h: f32 = @floatFromInt(@as(u32, @intCast(lines_clamped)) * 18);
 
     _ = zgui.inputTextMultiline(id, .{
-        .buf = &stack_buf,
+        .buf = buf,
         .w = 0,
         .h = h,
         .flags = .{ .read_only = true },

--- a/src/modules/gizmo.zig
+++ b/src/modules/gizmo.zig
@@ -1,0 +1,265 @@
+//! Gizmo editor — per-tab state and rendering.
+//!
+//! A gizmo lives at `<project>/gizmos/<name>.zon` and tells the
+//! engine: "any entity matching `.match` (and not matching
+//! `.exclude`) gets the declared visual attached at runtime". See
+//! `gizmo_io.zig` for the file shape and v1 verbatim pass-through.
+//!
+//! UX v1: a single-column inspector. The user can edit the
+//! `match`/`exclude` lists (typed) but the entity/children Shape
+//! blocks are read-only verbatim ZON. No viewport — gizmos describe
+//! shapes relative to entities, and rendering one in isolation
+//! against a placeholder entity would be misleading.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const gizmo_io = @import("../gizmo_io.zig");
+
+/// Edit buffer size for a single match/exclude entry. Component
+/// names are short identifiers in practice; 128 bytes is comfortable
+/// headroom over what the engine accepts.
+const tag_buf_len: usize = 128;
+
+const TagBuf = [tag_buf_len:0]u8;
+
+pub const GizmoState = struct {
+    arena: *std.heap.ArenaAllocator,
+    path: []const u8,
+    display_name: []const u8,
+    loaded: gizmo_io.LoadedGizmo,
+    /// Mirror buffers for `loaded.gizmo.match`. inputText writes into
+    /// these in place; on save we copy the buffer slices back into
+    /// `loaded.gizmo.match` (arena-owned). Sized at load.
+    match_bufs: []TagBuf = &.{},
+    exclude_bufs: []TagBuf = &.{},
+    is_dirty: bool = false,
+
+    pub fn open(allocator: std.mem.Allocator, path: []const u8) !GizmoState {
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const a = arena.allocator();
+        const path_dup = try a.dupe(u8, path);
+        const display_name = gizmo_io.displayNameFromPath(path_dup);
+
+        var loaded = try gizmo_io.loadFromFile(allocator, path);
+        errdefer loaded.deinit();
+
+        const match_bufs = try makeTagBufs(a, loaded.gizmo.match);
+        const exclude_bufs = try makeTagBufs(a, loaded.gizmo.exclude);
+
+        return .{
+            .arena = arena,
+            .path = path_dup,
+            .display_name = display_name,
+            .loaded = loaded,
+            .match_bufs = match_bufs,
+            .exclude_bufs = exclude_bufs,
+        };
+    }
+
+    pub fn deinit(self: *GizmoState, allocator: std.mem.Allocator) void {
+        self.loaded.deinit();
+        self.arena.deinit();
+        allocator.destroy(self.arena);
+    }
+};
+
+fn makeTagBufs(arena: std.mem.Allocator, src: [][]const u8) ![]TagBuf {
+    const out = try arena.alloc(TagBuf, src.len);
+    for (out, src) |*buf, s| {
+        @memset(buf, 0);
+        const n = @min(buf.len - 1, s.len);
+        @memcpy(buf[0..n], s[0..n]);
+    }
+    return out;
+}
+
+pub fn render(s: *GizmoState, app: *App) void {
+    zgui.text("Gizmo: {s}", .{s.display_name});
+    if (s.is_dirty) {
+        zgui.sameLine(.{});
+        zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("Save", .{})) saveGizmo(s, app);
+    zgui.separator();
+
+    renderTagList(s, .match);
+    zgui.spacing();
+    renderTagList(s, .exclude);
+
+    zgui.spacing();
+    zgui.separator();
+
+    if (s.loaded.gizmo.entity_verbatim) |text| {
+        if (zgui.collapsingHeader("Entity", .{ .default_open = true })) {
+            zgui.textDisabled("(read-only — edit by hand for v1)", .{});
+            renderReadOnlyMultiline("##gizmo_entity", text);
+        }
+    }
+    if (s.loaded.gizmo.children_verbatim) |text| {
+        if (zgui.collapsingHeader("Children", .{ .default_open = true })) {
+            zgui.textDisabled("(read-only — edit by hand for v1)", .{});
+            renderReadOnlyMultiline("##gizmo_children", text);
+        }
+    }
+}
+
+const TagKind = enum { match, exclude };
+
+fn renderTagList(s: *GizmoState, kind: TagKind) void {
+    const arena_alloc = s.arena.allocator();
+    const label: []const u8 = switch (kind) {
+        .match => "Match",
+        .exclude => "Exclude",
+    };
+    zgui.text("{s}", .{label});
+
+    const bufs = switch (kind) {
+        .match => s.match_bufs,
+        .exclude => s.exclude_bufs,
+    };
+    const tags = switch (kind) {
+        .match => s.loaded.gizmo.match,
+        .exclude => s.loaded.gizmo.exclude,
+    };
+
+    var remove_idx: ?usize = null;
+    var id_buf: [64]u8 = undefined;
+
+    for (bufs, 0..) |*buf, i| {
+        zgui.pushIntId(@intCast(i));
+        defer zgui.popId();
+
+        const input_id = std.fmt.bufPrintZ(&id_buf, "##tag_{s}_{d}", .{ @tagName(kind), i }) catch "##tag";
+        if (zgui.inputText(input_id, .{ .buf = buf })) {
+            // Reflect edit into the typed tags slice. Lifetime is
+            // pinned to the buffer (sentinel-terminated, never freed
+            // until the tab closes), so a borrowed slice is safe.
+            tags[i] = std.mem.sliceTo(buf, 0);
+            s.is_dirty = true;
+        }
+        zgui.sameLine(.{});
+        const x_id = std.fmt.bufPrintZ(&id_buf, "x##rm_{s}_{d}", .{ @tagName(kind), i }) catch "x";
+        if (zgui.smallButton(x_id)) {
+            remove_idx = i;
+        }
+    }
+
+    const add_id: [:0]const u8 = switch (kind) {
+        .match => "+ Add match",
+        .exclude => "+ Add exclude",
+    };
+    if (zgui.button(add_id, .{})) {
+        appendTag(s, kind, arena_alloc) catch |err| {
+            std.log.err("gizmo: failed to grow {s} list: {s}", .{ @tagName(kind), @errorName(err) });
+        };
+    }
+
+    if (remove_idx) |idx| {
+        removeTag(s, kind, idx, arena_alloc) catch |err| {
+            std.log.err("gizmo: failed to shrink {s} list: {s}", .{ @tagName(kind), @errorName(err) });
+        };
+    }
+}
+
+fn appendTag(s: *GizmoState, kind: TagKind, arena: std.mem.Allocator) !void {
+    switch (kind) {
+        .match => {
+            s.loaded.gizmo.match = try growStrings(arena, s.loaded.gizmo.match, "");
+            s.match_bufs = try growBufs(arena, s.match_bufs);
+        },
+        .exclude => {
+            s.loaded.gizmo.exclude = try growStrings(arena, s.loaded.gizmo.exclude, "");
+            s.exclude_bufs = try growBufs(arena, s.exclude_bufs);
+        },
+    }
+    s.is_dirty = true;
+}
+
+fn removeTag(s: *GizmoState, kind: TagKind, idx: usize, arena: std.mem.Allocator) !void {
+    switch (kind) {
+        .match => {
+            s.loaded.gizmo.match = try removeStrings(arena, s.loaded.gizmo.match, idx);
+            s.match_bufs = try removeBufs(arena, s.match_bufs, idx);
+        },
+        .exclude => {
+            s.loaded.gizmo.exclude = try removeStrings(arena, s.loaded.gizmo.exclude, idx);
+            s.exclude_bufs = try removeBufs(arena, s.exclude_bufs, idx);
+        },
+    }
+    s.is_dirty = true;
+}
+
+fn growStrings(arena: std.mem.Allocator, src: [][]const u8, addition: []const u8) ![][]const u8 {
+    const out = try arena.alloc([]const u8, src.len + 1);
+    @memcpy(out[0..src.len], src);
+    out[src.len] = addition;
+    return out;
+}
+
+fn growBufs(arena: std.mem.Allocator, src: []TagBuf) ![]TagBuf {
+    const out = try arena.alloc(TagBuf, src.len + 1);
+    @memcpy(out[0..src.len], src);
+    @memset(&out[src.len], 0);
+    return out;
+}
+
+fn removeStrings(arena: std.mem.Allocator, src: [][]const u8, idx: usize) ![][]const u8 {
+    if (idx >= src.len) return src;
+    const out = try arena.alloc([]const u8, src.len - 1);
+    @memcpy(out[0..idx], src[0..idx]);
+    @memcpy(out[idx..], src[idx + 1 ..]);
+    return out;
+}
+
+fn removeBufs(arena: std.mem.Allocator, src: []TagBuf, idx: usize) ![]TagBuf {
+    if (idx >= src.len) return src;
+    const out = try arena.alloc(TagBuf, src.len - 1);
+    @memcpy(out[0..idx], src[0..idx]);
+    @memcpy(out[idx..], src[idx + 1 ..]);
+    return out;
+}
+
+fn renderReadOnlyMultiline(id: [:0]const u8, text: []const u8) void {
+    // Read-only inputTextMultiline needs a writable buffer (zgui
+    // copies into the buffer for cursor state). Allocate a stack
+    // buffer sized to the text, sentinel-terminated. 4 KiB is plenty
+    // for any v1 gizmo block — they're tiny in practice.
+    var stack_buf: [4096:0]u8 = undefined;
+    @memset(&stack_buf, 0);
+    const n = @min(stack_buf.len - 1, text.len);
+    @memcpy(stack_buf[0..n], text[0..n]);
+
+    // Approximate line count to size the widget. Clamped so a tiny
+    // block doesn't render with a single-line slit and a huge one
+    // doesn't dominate the inspector.
+    var line_count: usize = 1;
+    for (text) |c| {
+        if (c == '\n') line_count += 1;
+    }
+    const lines_clamped = @max(@min(line_count, @as(usize, 14)), @as(usize, 4));
+    const h: f32 = @floatFromInt(@as(u32, @intCast(lines_clamped)) * 18);
+
+    _ = zgui.inputTextMultiline(id, .{
+        .buf = &stack_buf,
+        .w = 0,
+        .h = h,
+        .flags = .{ .read_only = true },
+    });
+}
+
+pub fn saveGizmo(s: *GizmoState, app: *App) void {
+    gizmo_io.saveGizmo(app.allocator, s.path, s.loaded) catch |err| {
+        std.log.err("Gizmo save failed at {s}: {s}", .{ s.path, @errorName(err) });
+        app.setStatus("Error saving gizmo!");
+        return;
+    };
+    s.is_dirty = false;
+    app.setStatus("Gizmo saved!");
+}

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -27,14 +27,14 @@ pub fn makeModule(app: *App) module.Module {
 /// elsewhere in the project return false; the caller skips opening
 /// them as scenes.
 pub fn isScenePath(proj_dir: ?[]const u8, path: []const u8) bool {
-    return isUnderFolder(proj_dir, path, project.ProjectFolders.scenes);
+    return isUnderFolder(proj_dir, path, project.ProjectFolders.scenes, ".jsonc");
 }
 
 /// Mirror of `isScenePath` for `prefabs/*.jsonc`. Used to route a
 /// tree click on a prefab file into the prefab editor rather than
 /// the scene editor.
 pub fn isPrefabPath(proj_dir: ?[]const u8, path: []const u8) bool {
-    return isUnderFolder(proj_dir, path, project.ProjectFolders.prefabs);
+    return isUnderFolder(proj_dir, path, project.ProjectFolders.prefabs, ".jsonc");
 }
 
 /// Return true when `path` is a `.flow.zon` file under the
@@ -58,9 +58,19 @@ pub fn isFlowPath(proj_dir: ?[]const u8, path: []const u8) bool {
     return std.mem.startsWith(u8, path, prefix);
 }
 
-fn isUnderFolder(proj_dir: ?[]const u8, path: []const u8, folder: []const u8) bool {
+/// Return true when `path` is a `.zon` file under the project's
+/// `gizmos/` directory. Gizmos are ZON, not JSONC, so this is the
+/// one router arm that uses a different extension. The folder name
+/// is hardcoded here rather than pulled from `project.ProjectFolders`
+/// to keep this PR independent of the parallel scaffold/folder-listing
+/// change a sibling PR is making — both PRs can land in either order.
+pub fn isGizmoPath(proj_dir: ?[]const u8, path: []const u8) bool {
+    return isUnderFolder(proj_dir, path, "gizmos", ".zon");
+}
+
+fn isUnderFolder(proj_dir: ?[]const u8, path: []const u8, folder: []const u8, ext: []const u8) bool {
     const dir = proj_dir orelse return false;
-    if (!std.mem.endsWith(u8, path, ".jsonc")) return false;
+    if (!std.mem.endsWith(u8, path, ext)) return false;
     var prefix_buf: [std.fs.max_path_bytes]u8 = undefined;
     const prefix = std.fmt.bufPrint(&prefix_buf, "{s}/{s}/", .{ dir, folder }) catch return false;
     return std.mem.startsWith(u8, path, prefix);
@@ -85,9 +95,10 @@ fn render(app: *App) void {
             // Tree returns true on the frame a file is newly clicked.
             // `.jsonc` files under `scenes/` route to the scene
             // editor; `.jsonc` files under `prefabs/` route to the
-            // prefab editor. The two paths are mutually exclusive
-            // (see `isScenePath` / `isPrefabPath`) so a single click
-            // never opens both.
+            // prefab editor; `.zon` files under `gizmos/` route to
+            // the gizmo editor. The three are mutually exclusive
+            // (different folders and/or extensions) so a single
+            // click never opens more than one.
             if (app.tree_view.render(proj.getProjectDir())) {
                 if (app.tree_view.getSelectedPath()) |path| {
                     const proj_dir = proj.getProjectDir();
@@ -105,6 +116,11 @@ fn render(app: *App) void {
                         app.openFlow(path) catch |err| {
                             std.log.err("Failed to open flow {s}: {s}", .{ path, @errorName(err) });
                             app.setStatus("Error opening flow!");
+                        };
+                    } else if (isGizmoPath(proj_dir, path)) {
+                        app.openGizmo(path) catch |err| {
+                            std.log.err("Failed to open gizmo {s}: {s}", .{ path, @errorName(err) });
+                            app.setStatus("Error opening gizmo!");
                         };
                     }
                 }

--- a/src/project.zig
+++ b/src/project.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const zon_scan = @import("zon_scan.zig");
 
 pub const PROJECT_FILENAME = "project.labelle";
 
@@ -332,7 +333,7 @@ fn isManaged(name: []const u8) bool {
 /// schema, this scanner will need to grow.
 fn extractUnmodeledFields(arena: std.mem.Allocator, raw: []const u8) ![]const []const u8 {
     var i: usize = 0;
-    skipWsAndComments(raw, &i);
+    zon_scan.skipWsAndComments(raw, &i);
     // Top-level shape is `.{ ... }`. Bail quietly on anything else; the
     // caller treats a missing extras list as "no preservation possible".
     if (i + 1 >= raw.len or raw[i] != '.' or raw[i + 1] != '{') return &.{};
@@ -368,18 +369,18 @@ fn extractUnmodeledFields(arena: std.mem.Allocator, raw: []const u8) ![]const []
         const name = raw[name_start..i];
         if (name.len == 0) break;
 
-        skipWsAndComments(raw, &i);
+        zon_scan.skipWsAndComments(raw, &i);
         if (i >= raw.len or raw[i] != '=') break;
         i += 1; // past '='
 
         // Scan the value up to (but not including) the next top-level
         // `,` or the outer `}`. Brace/string/comment aware.
-        scanValue(raw, &i);
+        zon_scan.scanValue(raw, &i);
         const field_end = i;
 
         // Consume optional trailing comma.
         const save = i;
-        skipWsAndComments(raw, &i);
+        zon_scan.skipWsAndComments(raw, &i);
         if (i < raw.len and raw[i] == ',') {
             i += 1;
         } else {
@@ -407,50 +408,6 @@ fn skipWhitespace(raw: []const u8, i: *usize) void {
         const c = raw[i.*];
         if (c != ' ' and c != '\t' and c != '\n' and c != '\r') break;
         i.* += 1;
-    }
-}
-
-fn skipWsAndComments(raw: []const u8, i: *usize) void {
-    while (i.* < raw.len) {
-        const c = raw[i.*];
-        if (c == ' ' or c == '\t' or c == '\n' or c == '\r') {
-            i.* += 1;
-        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
-            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
-        } else break;
-    }
-}
-
-fn scanValue(raw: []const u8, i: *usize) void {
-    var depth: usize = 0;
-    while (i.* < raw.len) {
-        const c = raw[i.*];
-        if (c == '"') {
-            i.* += 1;
-            while (i.* < raw.len) {
-                if (raw[i.*] == '\\' and i.* + 1 < raw.len) {
-                    i.* += 2;
-                } else if (raw[i.*] == '"') {
-                    i.* += 1;
-                    break;
-                } else {
-                    i.* += 1;
-                }
-            }
-        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
-            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
-        } else if (c == '{' or c == '[' or c == '(') {
-            depth += 1;
-            i.* += 1;
-        } else if (c == '}' or c == ']' or c == ')') {
-            if (depth == 0) return; // outer `}` — stop without consuming
-            depth -= 1;
-            i.* += 1;
-        } else if (c == ',' and depth == 0) {
-            return;
-        } else {
-            i.* += 1;
-        }
     }
 }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -11,6 +11,7 @@ const scene_module = @import("modules/scene.zig");
 const project_tree = @import("modules/project_tree.zig");
 const viewport = @import("modules/viewport.zig");
 const atlas = @import("atlas.zig");
+const gizmo_io = @import("gizmo_io.zig");
 
 test {
     zspec.runAll(@This());
@@ -1383,6 +1384,32 @@ pub const SceneRoutingTests = struct {
     test "no project dir → no flow routing" {
         try expect.toBeFalse(project_tree.isFlowPath(null, "/p/scripts/flows/foo.flow.zon"));
     }
+
+    test "gizmo path under gizmos/ is accepted" {
+        try expect.toBeTrue(project_tree.isGizmoPath("/p", "/p/gizmos/workstation.zon"));
+        try expect.toBeTrue(project_tree.isGizmoPath("/p", "/p/gizmos/sub/room.zon"));
+    }
+
+    test "gizmo path under prefabs/ is rejected" {
+        // Gizmos live under their own folder; a `.zon` file under
+        // prefabs/ (or anywhere else) must not open as a gizmo.
+        try expect.toBeFalse(project_tree.isGizmoPath("/p", "/p/prefabs/coin.zon"));
+        try expect.toBeFalse(project_tree.isGizmoPath("/p", "/p/scenes/main.zon"));
+        try expect.toBeFalse(project_tree.isGizmoPath("/p", "/p/random.zon"));
+    }
+
+    test "gizmo path rejects non-.zon files" {
+        // `.jsonc` files under gizmos/ are not gizmos — the engine's
+        // GizmoRegistry only compiles `.zon`. project.labelle lives
+        // at the project root, never under gizmos/, but defend
+        // anyway.
+        try expect.toBeFalse(project_tree.isGizmoPath("/p", "/p/gizmos/workstation.jsonc"));
+        try expect.toBeFalse(project_tree.isGizmoPath("/p", "/p/gizmos/notes.md"));
+    }
+
+    test "no project dir → no gizmo routing" {
+        try expect.toBeFalse(project_tree.isGizmoPath(null, "/p/gizmos/workstation.zon"));
+    }
 };
 
 pub const SceneHitTestTests = struct {
@@ -1969,5 +1996,140 @@ pub const ProjectFileTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, pm2.current_project.?.config.name, "round_trip"));
         try expect.equal(pm2.current_project.?.config.backend, .raylib);
         try expect.equal(pm2.current_project.?.config.ecs, .zig_ecs);
+    }
+};
+
+pub const GizmoIoTests = struct {
+    // Verbatim is the key contract: gizmos may carry a Shape union
+    // we don't model structurally yet, so the parser must capture
+    // `.entity` / `.children` blocks unchanged and the writer must
+    // splice them back in faithfully.
+
+    const sample_workstation =
+        \\.{
+        \\    .match = .{"Workstation"},
+        \\    .entity = .{
+        \\        .Shape = .{
+        \\            .x = 0,
+        \\            .y = 0,
+        \\            .shape = .{ .triangle = .{ .p2 = .{ .x = 12, .y = -20 }, .p3 = .{ .x = -12, .y = -20 } } },
+        \\            .color = .{ .r = 255, .g = 150, .b = 50, .a = 220 },
+        \\        },
+        \\    },
+        \\}
+        \\
+    ;
+
+    const sample_with_exclude =
+        \\.{
+        \\    .match = .{"Room", "Quarters"},
+        \\    .exclude = .{"Hidden"},
+        \\    .entity = .{
+        \\        .Shape = .{ .shape = .{ .circle = .{ .radius = 8 } } },
+        \\    },
+        \\}
+        \\
+    ;
+
+    test "parses match into a typed list" {
+        const allocator = std.testing.allocator;
+        var loaded = try gizmo_io.parseGizmo(allocator, sample_workstation);
+        defer loaded.deinit();
+
+        try expect.equal(loaded.gizmo.match.len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.gizmo.match[0], "Workstation"));
+        try expect.equal(loaded.gizmo.exclude.len, 0);
+    }
+
+    test "parses exclude when present" {
+        const allocator = std.testing.allocator;
+        var loaded = try gizmo_io.parseGizmo(allocator, sample_with_exclude);
+        defer loaded.deinit();
+
+        try expect.equal(loaded.gizmo.match.len, 2);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.gizmo.match[0], "Room"));
+        try expect.toBeTrue(std.mem.eql(u8, loaded.gizmo.match[1], "Quarters"));
+        try expect.equal(loaded.gizmo.exclude.len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.gizmo.exclude[0], "Hidden"));
+    }
+
+    test "captures .entity block verbatim" {
+        const allocator = std.testing.allocator;
+        var loaded = try gizmo_io.parseGizmo(allocator, sample_workstation);
+        defer loaded.deinit();
+
+        try expect.toBeTrue(loaded.gizmo.entity_verbatim != null);
+        const text = loaded.gizmo.entity_verbatim.?;
+        // Spot-check distinctive substrings from the Shape body so a
+        // future writer refactor that drops bytes is caught.
+        try expect.toBeTrue(std.mem.indexOf(u8, text, ".triangle") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, ".x = 12") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, ".r = 255") != null);
+    }
+
+    test "round-trip parse → render → parse preserves match/exclude/entity" {
+        const allocator = std.testing.allocator;
+
+        var loaded1 = try gizmo_io.parseGizmo(allocator, sample_with_exclude);
+        defer loaded1.deinit();
+        const rendered = try gizmo_io.renderGizmoZon(allocator, loaded1);
+        defer allocator.free(rendered);
+
+        var loaded2 = try gizmo_io.parseGizmo(allocator, rendered);
+        defer loaded2.deinit();
+
+        try expect.equal(loaded2.gizmo.match.len, loaded1.gizmo.match.len);
+        for (loaded1.gizmo.match, loaded2.gizmo.match) |a, b| {
+            try expect.toBeTrue(std.mem.eql(u8, a, b));
+        }
+        try expect.equal(loaded2.gizmo.exclude.len, loaded1.gizmo.exclude.len);
+        for (loaded1.gizmo.exclude, loaded2.gizmo.exclude) |a, b| {
+            try expect.toBeTrue(std.mem.eql(u8, a, b));
+        }
+        try expect.toBeTrue(loaded2.gizmo.entity_verbatim != null);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            loaded2.gizmo.entity_verbatim.?,
+            loaded1.gizmo.entity_verbatim.?,
+        ));
+    }
+
+    test "editing a match entry shows up in saved output" {
+        const allocator = std.testing.allocator;
+        var loaded = try gizmo_io.parseGizmo(allocator, sample_workstation);
+        defer loaded.deinit();
+
+        // Mutate match in place (using the same arena lifetime the
+        // module owns) and re-render. The new string must appear and
+        // the old one must not.
+        const new_str = try loaded.arena.allocator().dupe(u8, "DiningTable");
+        loaded.gizmo.match[0] = new_str;
+
+        const rendered = try gizmo_io.renderGizmoZon(allocator, loaded);
+        defer allocator.free(rendered);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, rendered, "\"DiningTable\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, rendered, "\"Workstation\"") == null);
+    }
+
+    test "omits exclude/entity/children when not present" {
+        const allocator = std.testing.allocator;
+        const minimal = ".{ .match = .{\"Foo\"} }\n";
+        var loaded = try gizmo_io.parseGizmo(allocator, minimal);
+        defer loaded.deinit();
+
+        const rendered = try gizmo_io.renderGizmoZon(allocator, loaded);
+        defer allocator.free(rendered);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, rendered, ".match") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, rendered, ".exclude") == null);
+        try expect.toBeTrue(std.mem.indexOf(u8, rendered, ".entity") == null);
+        try expect.toBeTrue(std.mem.indexOf(u8, rendered, ".children") == null);
+    }
+
+    test "displayNameFromPath strips .zon extension" {
+        try expect.toBeTrue(std.mem.eql(u8, gizmo_io.displayNameFromPath("/p/gizmos/workstation.zon"), "workstation"));
+        try expect.toBeTrue(std.mem.eql(u8, gizmo_io.displayNameFromPath("room.zon"), "room"));
+        try expect.toBeTrue(std.mem.eql(u8, gizmo_io.displayNameFromPath("noext"), "noext"));
     }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2132,4 +2132,37 @@ pub const GizmoIoTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, gizmo_io.displayNameFromPath("room.zon"), "room"));
         try expect.toBeTrue(std.mem.eql(u8, gizmo_io.displayNameFromPath("noext"), "noext"));
     }
+
+    test "renderGizmoZon escapes hostile characters in match/exclude" {
+        // Regression for gemini review: the writer used to interpolate
+        // strings raw, so a `"` or `\` in a tag name would break the
+        // file. `std.zig.fmtString` escapes those, and the rendered ZON
+        // must re-parse to the same byte sequence.
+        const allocator = std.testing.allocator;
+        const source = ".{ .match = .{\"Foo\"} }\n";
+        var loaded = try gizmo_io.parseGizmo(allocator, source);
+        defer loaded.deinit();
+
+        const hostile = try loaded.arena.allocator().dupe(u8, "Quote\"Backslash\\End");
+        loaded.gizmo.match[0] = hostile;
+        loaded.gizmo.exclude = try loaded.arena.allocator().alloc([]const u8, 1);
+        loaded.gizmo.exclude[0] = try loaded.arena.allocator().dupe(u8, "Tab\there");
+
+        const rendered = try gizmo_io.renderGizmoZon(allocator, loaded);
+        defer allocator.free(rendered);
+
+        // No unescaped `"` should appear inside our match value beyond
+        // the surrounding delimiters — escaping turned it into `\"`.
+        try expect.toBeTrue(std.mem.indexOf(u8, rendered, "Quote\\\"Backslash\\\\End") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, rendered, "Tab\\there") != null);
+
+        // Round-trip back through the parser and confirm the strings
+        // decode to the originals.
+        var reparsed = try gizmo_io.parseGizmo(allocator, rendered);
+        defer reparsed.deinit();
+        try expect.equal(reparsed.gizmo.match.len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, reparsed.gizmo.match[0], hostile));
+        try expect.equal(reparsed.gizmo.exclude.len, 1);
+        try expect.toBeTrue(std.mem.eql(u8, reparsed.gizmo.exclude[0], "Tab\there"));
+    }
 };

--- a/src/zon_scan.zig
+++ b/src/zon_scan.zig
@@ -1,0 +1,68 @@
+//! Shared byte-level ZON scanner helpers.
+//!
+//! Both `project.zig` (for `project.labelle`'s unmodeled fields) and
+//! `gizmo_io.zig` (for gizmo `.entity` / `.children` blocks) need to
+//! skip whitespace + `// ...` comments and walk a ZON value while
+//! respecting `"..."` strings, `\"` escapes, and brace / bracket /
+//! paren nesting. The two copies had drifted toward divergence; keep
+//! them here so a fix lands once.
+//!
+//! Dialect handled:
+//! - whitespace + line comments (`// ... \n`)
+//! - `"..."` strings with `\"` and other one-char backslash escapes
+//! - matched `{}` / `[]` / `()` nesting
+//!
+//! Not handled (no current schema needs them — extend if that changes):
+//! - multi-line strings (`\\...`)
+//! - `'...'` character literals
+
+const std = @import("std");
+
+/// Advance `i` past whitespace and `// ... \n` line comments.
+pub fn skipWsAndComments(raw: []const u8, i: *usize) void {
+    while (i.* < raw.len) {
+        const c = raw[i.*];
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r') {
+            i.* += 1;
+        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
+            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
+        } else break;
+    }
+}
+
+/// Advance `i` over one ZON value expression. Stops at the byte after
+/// the value — at the next top-level `,` or at the outer closing
+/// bracket (which is *not* consumed). Strings, comments, and nested
+/// containers are walked without bailing.
+pub fn scanValue(raw: []const u8, i: *usize) void {
+    var depth: usize = 0;
+    while (i.* < raw.len) {
+        const c = raw[i.*];
+        if (c == '"') {
+            i.* += 1;
+            while (i.* < raw.len) {
+                if (raw[i.*] == '\\' and i.* + 1 < raw.len) {
+                    i.* += 2;
+                } else if (raw[i.*] == '"') {
+                    i.* += 1;
+                    break;
+                } else {
+                    i.* += 1;
+                }
+            }
+        } else if (c == '/' and i.* + 1 < raw.len and raw[i.* + 1] == '/') {
+            while (i.* < raw.len and raw[i.*] != '\n') i.* += 1;
+        } else if (c == '{' or c == '[' or c == '(') {
+            depth += 1;
+            i.* += 1;
+        } else if (c == '}' or c == ']' or c == ')') {
+            if (depth == 0) return; // outer `}` — stop without consuming
+            depth -= 1;
+            i.* += 1;
+        } else if (c == ',' and depth == 0) {
+            return;
+        } else {
+            i.* += 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `gizmos/*.zon` editor: clicking a `.zon` file under `gizmos/` in the project tree opens it as a tab next to scenes and prefabs.
- v1 models `.match` and `.exclude` as typed string lists (editable in the inspector), and captures `.entity` and `.children` blocks as **verbatim ZON text** that round-trips unchanged on save.
- Verbatim pass-through deliberately avoids modeling the engine's `Shape` tagged union (`circle`/`rectangle`/`triangle`/`line`/`polygon` — see `../labelle-gfx/src/visuals.zig`). This unblocks the editor without committing to a typed Shape model while sibling PRs (#34/#36/#37) propose a competing geometry layout. Same pattern `project.labelle` already uses for unmodeled fields.
- `App.openGizmo` mirrors `openPrefab`; `OpenTab` grows a `gizmo` variant alongside `scene` / `prefab` with every dispatch arm wired through.

## Test plan

- [x] `zig build` — labelle-gui builds clean
- [x] `zig build test` — 105/105 pass (94 baseline + 11 new: 7 in `GizmoIoTests`, 4 in `SceneRoutingTests`)
- [x] `zig build gui-test` — 6/6 pass
- [x] `zig build smoke` — generate + build via launcher succeeded

## Out of scope

- **Typed Shape model.** Verbatim pass-through only for v1. The `.entity` and `.children` sections show as read-only `inputTextMultiline` with an explicit "edit by hand for v1" hint.
- **Viewport rendering of gizmos against a host scene.** Gizmos describe shapes relative to matched entities; rendering one in isolation would be misleading. No viewport on this tab — just the inspector.
- **`.children` structural editing.** Same trade-off as `.entity`: read-only verbatim until a Shape model lands.
- **Scaffold side (folder + icon).** Adding `gizmos` to `ProjectFolders.all` and the tree-view icon is a parallel sibling PR. This PR hardcodes the folder name in `project_tree.isGizmoPath` so both PRs can land independently in either order; opening a gizmo works whenever the user's project has a `gizmos/` directory.