### PR TITLE
Gizmo viewport overlay + show/hide toggle

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -240,7 +240,7 @@ pub const App = struct {
     /// Rebuild the gizmo overlay index by walking
     /// `<project_dir>/gizmos/`. Same generation-keyed invalidation
     /// rule the atlas index uses.
-    fn rebuildGizmoIndex(self: *Self) void {
+    pub fn rebuildGizmoIndex(self: *Self) void {
         if (self.gizmo_index) |*idx| {
             idx.deinit();
             self.gizmo_index = null;
@@ -252,13 +252,6 @@ pub const App = struct {
             dir,
             self.project_manager.generation,
         );
-    }
-
-    /// Refresh the per-project gizmo overlay index after an in-session
-    /// gizmo file edit/save so scene/prefab overlays update without
-    /// requiring a full project reload.
-    pub fn refreshGizmoIndex(self: *Self) void {
-        self.rebuildGizmoIndex();
     }
 
     // ─── Scene tabs ─────────────────────────────────────────────────────

--- a/src/app.zig
+++ b/src/app.zig
@@ -25,6 +25,7 @@ const flow_mod = @import("modules/flow.zig");
 const gizmo_mod = @import("modules/gizmo.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
 const atlas = @import("atlas.zig");
+const gizmos = @import("gizmos.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
 const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
 
@@ -151,6 +152,13 @@ pub const App = struct {
     /// + viewport consult it to validate `sprite_name` and draw the
     /// real pixels for entities with a Sprite component.
     atlas_index: ?atlas.Index = null,
+    /// Per-project gizmo overlay index. Built alongside `atlas_index`
+    /// on project new/load; viewport queries it when `show_gizmos`
+    /// is true to draw debug visualizations over matched entities.
+    gizmo_index: ?gizmos.Index = null,
+    /// User toggle for the gizmo overlay; on by default so the
+    /// overlay shows up immediately when a project with gizmos opens.
+    show_gizmos: bool = true,
 
     show_project_tree: bool = true,
 
@@ -190,6 +198,7 @@ pub const App = struct {
         self.closeAllTabs();
         self.open_tabs.deinit(self.allocator);
         if (self.atlas_index) |*idx| idx.deinit();
+        if (self.gizmo_index) |*idx| idx.deinit();
         self.project_manager.deinit();
         self.tree_view.deinit();
         self.compiler.deinit();
@@ -224,6 +233,23 @@ pub const App = struct {
             self.allocator,
             dir,
             resources.items,
+            self.project_manager.generation,
+        );
+    }
+
+    /// Rebuild the gizmo overlay index by walking
+    /// `<project_dir>/gizmos/`. Same generation-keyed invalidation
+    /// rule the atlas index uses.
+    fn rebuildGizmoIndex(self: *Self) void {
+        if (self.gizmo_index) |*idx| {
+            idx.deinit();
+            self.gizmo_index = null;
+        }
+        const proj = self.project_manager.current_project orelse return;
+        const dir = proj.dir orelse return;
+        self.gizmo_index = gizmos.Index.build(
+            self.allocator,
+            dir,
             self.project_manager.generation,
         );
     }
@@ -376,9 +402,11 @@ pub const App = struct {
             if (prev != gen) {
                 self.closeAllTabs();
                 self.rebuildAtlasIndex();
+                self.rebuildGizmoIndex();
             }
         } else {
             self.rebuildAtlasIndex();
+            self.rebuildGizmoIndex();
         }
         self.last_project_generation = gen;
 

--- a/src/app.zig
+++ b/src/app.zig
@@ -254,6 +254,13 @@ pub const App = struct {
         );
     }
 
+    /// Refresh the per-project gizmo overlay index after an in-session
+    /// gizmo file edit/save so scene/prefab overlays update without
+    /// requiring a full project reload.
+    pub fn refreshGizmoIndex(self: *Self) void {
+        self.rebuildGizmoIndex();
+    }
+
     // ─── Scene tabs ─────────────────────────────────────────────────────
 
     /// Open a `.jsonc` scene file (under `<project>/scenes/`) as a

--- a/src/gizmos.zig
+++ b/src/gizmos.zig
@@ -1,0 +1,281 @@
+//! Per-project gizmo index. On project open we walk `<project>/gizmos/*.zon`,
+//! parse each file's `.match` / `.exclude` predicates, and extract a typed
+//! `Shape` from the `.entity` block so the viewport can overlay debug
+//! visualizations on scene/prefab entities whose components match.
+//!
+//! Shape semantics mirror `../labelle-gfx/src/visuals.zig` — a tagged
+//! union of `circle`/`rectangle`/`triangle`/`line`/`polygon` (the
+//! engine's polygon is a regular n-gon, not an arbitrary point list).
+//!
+//! `gizmo_io.zig` continues to round-trip the gizmo file verbatim (with
+//! `entity_verbatim` preserving the source text); this module pulls the
+//! typed bits out for drawing without disrupting that round-trip.
+//!
+//! Like `src/atlas.zig`, the index is owned by `App` and keyed by
+//! `ProjectManager.generation` so project new/close/load invalidates it.
+//!
+//! Known v1 limitation: matching is against an entity's *direct*
+//! component name set. We don't follow `prefab:` references to gather
+//! the prefab's components, so an entity like `{ prefab: "workstation" }`
+//! that doesn't inline the `Workstation` component won't match a
+//! `.match = .{"Workstation"}` gizmo. The engine matches after prefab
+//! instantiation; we'd need a prefab index to do the same. Tracked for
+//! a follow-up.
+
+const std = @import("std");
+
+const gizmo_io = @import("gizmo_io.zig");
+const scene_io = @import("scene_io.zig");
+
+pub const FillMode = enum {
+    filled,
+    outline,
+};
+
+/// Shape primitives — mirrors `../labelle-gfx/src/visuals.zig:11`. Field
+/// names and defaults match so a future round-trip via the typed model
+/// will agree with what the engine ships.
+pub const Shape = union(enum) {
+    circle: Circle,
+    rectangle: Rectangle,
+    line: Line,
+    triangle: Triangle,
+    polygon: Polygon,
+
+    pub const Circle = struct {
+        radius: f32,
+        fill: FillMode = .filled,
+        thickness: f32 = 1.0,
+    };
+    pub const Rectangle = struct {
+        width: f32,
+        height: f32,
+        fill: FillMode = .filled,
+        thickness: f32 = 1.0,
+    };
+    pub const Line = struct {
+        end: Point = .{},
+        thickness: f32 = 1.0,
+    };
+    pub const Triangle = struct {
+        p2: Point = .{},
+        p3: Point = .{},
+        fill: FillMode = .filled,
+        thickness: f32 = 1.0,
+    };
+    pub const Polygon = struct {
+        sides: i32 = 3,
+        radius: f32 = 10,
+        fill: FillMode = .filled,
+        thickness: f32 = 1.0,
+    };
+};
+
+/// Engine uses `Position` for points inside Shape variants; mirror.
+pub const Point = struct {
+    x: f32 = 0,
+    y: f32 = 0,
+};
+
+pub const Color = struct {
+    r: u8 = 255,
+    g: u8 = 255,
+    b: u8 = 255,
+    a: u8 = 255,
+};
+
+/// One gizmo entry usable by the viewport. `match` / `exclude` are
+/// the predicates from the source file; `shape` is the typed render
+/// data extracted from `.entity.Shape.shape`. Color and offset come
+/// from `.entity.Shape.{color, x, y}` — both with engine defaults.
+pub const Entry = struct {
+    /// Source path. Useful for diagnostics; keys live in the index
+    /// arena.
+    source: []const u8,
+    match: []const []const u8,
+    exclude: []const []const u8,
+    shape: Shape,
+    color: Color = .{},
+    offset_x: f32 = 0,
+    offset_y: f32 = 0,
+};
+
+pub const Index = struct {
+    allocator: std.mem.Allocator,
+    entries: std.ArrayListUnmanaged(Entry) = .{},
+    /// `ProjectManager.generation` this index was built against. App
+    /// invalidates when the live generation changes.
+    generation: u64,
+    /// Per-entry arenas so each gizmo's string lifetimes are bounded
+    /// to its own slot — same shape `atlas.Index` uses.
+    arenas: std.ArrayListUnmanaged(*std.heap.ArenaAllocator) = .{},
+
+    pub fn deinit(self: *Index) void {
+        for (self.arenas.items) |a| {
+            a.deinit();
+            self.allocator.destroy(a);
+        }
+        self.arenas.deinit(self.allocator);
+        self.entries.deinit(self.allocator);
+    }
+
+    /// Walk `<project_dir>/gizmos/` and load every `.zon` file. Errors
+    /// on a single file are logged and skipped — same tolerance the
+    /// atlas loader uses for malformed entries.
+    pub fn build(
+        allocator: std.mem.Allocator,
+        project_dir: []const u8,
+        generation: u64,
+    ) Index {
+        var idx: Index = .{ .allocator = allocator, .generation = generation };
+
+        const gizmos_dir = std.fs.path.join(allocator, &.{ project_dir, "gizmos" }) catch return idx;
+        defer allocator.free(gizmos_dir);
+
+        var dir = std.fs.cwd().openDir(gizmos_dir, .{ .iterate = true }) catch return idx;
+        defer dir.close();
+
+        var it = dir.iterate();
+        while (it.next() catch null) |dirent| {
+            if (dirent.kind != .file) continue;
+            if (!std.mem.endsWith(u8, dirent.name, ".zon")) continue;
+
+            const full = std.fs.path.join(allocator, &.{ gizmos_dir, dirent.name }) catch continue;
+            defer allocator.free(full);
+
+            loadOne(allocator, &idx, full) catch |err| {
+                std.log.warn("Gizmo '{s}' failed to load: {s}", .{ full, @errorName(err) });
+                continue;
+            };
+        }
+        return idx;
+    }
+};
+
+fn loadOne(allocator: std.mem.Allocator, idx: *Index, path: []const u8) !void {
+    var loaded = try gizmo_io.loadFromFile(allocator, path);
+    errdefer loaded.deinit();
+
+    const entity_text = loaded.gizmo.entity_verbatim orelse {
+        // Gizmo with no `.entity` block — could still have `.children`,
+        // but we don't support multi-shape gizmos yet. Skip.
+        loaded.deinit();
+        return;
+    };
+
+    // Stand up a fresh arena to own the entry's typed data. We move
+    // the match/exclude lists across by deep-copying into this arena;
+    // then we can free the LoadedGizmo. This keeps the per-entry
+    // lifetime tidy independent of the source.
+    const arena = try allocator.create(std.heap.ArenaAllocator);
+    errdefer allocator.destroy(arena);
+    arena.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    const match_owned = try dupeStrings(a, loaded.gizmo.match);
+    const exclude_owned = try dupeStrings(a, loaded.gizmo.exclude);
+
+    const parsed = try parseEntityBlock(a, entity_text);
+    const source_owned = try a.dupe(u8, path);
+
+    loaded.deinit();
+
+    try idx.arenas.append(allocator, arena);
+    try idx.entries.append(allocator, .{
+        .source = source_owned,
+        .match = match_owned,
+        .exclude = exclude_owned,
+        .shape = parsed.shape,
+        .color = parsed.color,
+        .offset_x = parsed.offset_x,
+        .offset_y = parsed.offset_y,
+    });
+}
+
+fn dupeStrings(arena: std.mem.Allocator, src: [][]const u8) ![][]const u8 {
+    const out = try arena.alloc([]const u8, src.len);
+    for (src, 0..) |s, i| out[i] = try arena.dupe(u8, s);
+    return out;
+}
+
+const ParsedEntity = struct {
+    shape: Shape,
+    color: Color,
+    offset_x: f32,
+    offset_y: f32,
+};
+
+/// Parse the verbatim ZON text of `.entity` (e.g. `.{ .Shape = .{ ... } }`)
+/// into typed render data. The standard library's ZON parser handles
+/// tagged unions, structs, and primitive coercion; we just spell out
+/// the expected schema.
+fn parseEntityBlock(arena: std.mem.Allocator, verbatim: []const u8) !ParsedEntity {
+    // Note: `Color` and `Point` use field defaults so an absent field
+    // (or zero) parses cleanly. `Shape` is required.
+    const ShapeBlock = struct {
+        x: f32 = 0,
+        y: f32 = 0,
+        shape: Shape,
+        color: Color = .{},
+    };
+    const Entity = struct {
+        Shape: ShapeBlock,
+    };
+
+    const source = try arena.dupeZ(u8, verbatim);
+    var diag: std.zon.parse.Diagnostics = .{};
+    defer diag.deinit(arena);
+    const parsed = std.zon.parse.fromSlice(Entity, arena, source, &diag, .{
+        .ignore_unknown_fields = true,
+    }) catch return error.UnsupportedEntityShape;
+
+    return .{
+        .shape = parsed.Shape.shape,
+        .color = parsed.Shape.color,
+        .offset_x = parsed.Shape.x,
+        .offset_y = parsed.Shape.y,
+    };
+}
+
+// ─── Match logic ───────────────────────────────────────────────────────
+
+/// Build the set of component names present *directly* on an entity.
+/// `extras` are the unmodeled-component slice scenes/prefabs collect
+/// in parallel with their entity arrays; modeled component names
+/// (Position, Sprite) are inferred from the typed fields.
+///
+/// Caller owns the returned slice via `allocator` — it's a transient
+/// scratch list, typically discarded per entity per frame.
+pub fn entityComponentNames(
+    allocator: std.mem.Allocator,
+    entity: scene_io.Entity,
+    extras: []const scene_io.ComponentExtra,
+) ![]const []const u8 {
+    var names: std.ArrayListUnmanaged([]const u8) = .{};
+    errdefer names.deinit(allocator);
+    if (entity.position != null) try names.append(allocator, "Position");
+    if (entity.sprite != null) try names.append(allocator, "Sprite");
+    for (extras) |e| try names.append(allocator, e.name);
+    return names.toOwnedSlice(allocator);
+}
+
+/// Returns true when at least one `match` name is in `present` and
+/// no `exclude` name is. Empty `match` is treated as "matches
+/// everything" — the engine convention.
+pub fn entityMatches(
+    match: []const []const u8,
+    exclude: []const []const u8,
+    present: []const []const u8,
+) bool {
+    // Reject first if any exclude matches.
+    for (exclude) |x| if (contains(present, x)) return false;
+    if (match.len == 0) return true;
+    for (match) |m| if (contains(present, m)) return true;
+    return false;
+}
+
+fn contains(haystack: []const []const u8, needle: []const u8) bool {
+    for (haystack) |h| if (std.mem.eql(u8, h, needle)) return true;
+    return false;
+}

--- a/src/gizmos.zig
+++ b/src/gizmos.zig
@@ -25,7 +25,6 @@
 const std = @import("std");
 
 const gizmo_io = @import("gizmo_io.zig");
-const scene_io = @import("scene_io.zig");
 
 pub const FillMode = enum {
     filled,
@@ -154,19 +153,18 @@ pub const Index = struct {
 
 fn loadOne(allocator: std.mem.Allocator, idx: *Index, path: []const u8) !void {
     var loaded = try gizmo_io.loadFromFile(allocator, path);
-    errdefer loaded.deinit();
+    defer loaded.deinit();
 
     const entity_text = loaded.gizmo.entity_verbatim orelse {
         // Gizmo with no `.entity` block — could still have `.children`,
         // but we don't support multi-shape gizmos yet. Skip.
-        loaded.deinit();
         return;
     };
 
     // Stand up a fresh arena to own the entry's typed data. We move
     // the match/exclude lists across by deep-copying into this arena;
-    // then we can free the LoadedGizmo. This keeps the per-entry
-    // lifetime tidy independent of the source.
+    // then `loaded` can be freed by the defer above. This keeps the
+    // per-entry lifetime tidy independent of the source.
     const arena = try allocator.create(std.heap.ArenaAllocator);
     errdefer allocator.destroy(arena);
     arena.* = std.heap.ArenaAllocator.init(allocator);
@@ -179,10 +177,14 @@ fn loadOne(allocator: std.mem.Allocator, idx: *Index, path: []const u8) !void {
     const parsed = try parseEntityBlock(a, entity_text);
     const source_owned = try a.dupe(u8, path);
 
-    loaded.deinit();
-
-    try idx.arenas.append(allocator, arena);
-    try idx.entries.append(allocator, .{
+    // Reserve both list slots up front so the two appends below are
+    // infallible — otherwise an OOM between the two would leave the
+    // arena tracked in `idx.arenas` while also being freed by the
+    // arena errdefers above (dangling pointer on next `Index.deinit`).
+    try idx.arenas.ensureUnusedCapacity(allocator, 1);
+    try idx.entries.ensureUnusedCapacity(allocator, 1);
+    idx.arenas.appendAssumeCapacity(arena);
+    idx.entries.appendAssumeCapacity(.{
         .source = source_owned,
         .match = match_owned,
         .exclude = exclude_owned,
@@ -239,26 +241,6 @@ fn parseEntityBlock(arena: std.mem.Allocator, verbatim: []const u8) !ParsedEntit
 }
 
 // ─── Match logic ───────────────────────────────────────────────────────
-
-/// Build the set of component names present *directly* on an entity.
-/// `extras` are the unmodeled-component slice scenes/prefabs collect
-/// in parallel with their entity arrays; modeled component names
-/// (Position, Sprite) are inferred from the typed fields.
-///
-/// Caller owns the returned slice via `allocator` — it's a transient
-/// scratch list, typically discarded per entity per frame.
-pub fn entityComponentNames(
-    allocator: std.mem.Allocator,
-    entity: scene_io.Entity,
-    extras: []const scene_io.ComponentExtra,
-) ![]const []const u8 {
-    var names: std.ArrayListUnmanaged([]const u8) = .{};
-    errdefer names.deinit(allocator);
-    if (entity.position != null) try names.append(allocator, "Position");
-    if (entity.sprite != null) try names.append(allocator, "Sprite");
-    for (extras) |e| try names.append(allocator, e.name);
-    return names.toOwnedSlice(allocator);
-}
 
 /// Returns true when at least one `match` name is in `present` and
 /// no `exclude` name is. Empty `match` is treated as "matches

--- a/src/modules/gizmo.zig
+++ b/src/modules/gizmo.zig
@@ -274,6 +274,6 @@ pub fn saveGizmo(s: *GizmoState, app: *App) void {
         return;
     };
     s.is_dirty = false;
-    app.refreshGizmoIndex();
+    app.rebuildGizmoIndex();
     app.setStatus("Gizmo saved!");
 }

--- a/src/modules/gizmo.zig
+++ b/src/modules/gizmo.zig
@@ -274,5 +274,6 @@ pub fn saveGizmo(s: *GizmoState, app: *App) void {
         return;
     };
     s.is_dirty = false;
+    app.refreshGizmoIndex();
     app.setStatus("Gizmo saved!");
 }

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -86,6 +86,8 @@ pub fn render(s: *PrefabState, app: *App) void {
     zgui.sameLine(.{});
     zgui.text("zoom: {d:.2}x", .{s.zoom});
     zgui.sameLine(.{});
+    _ = zgui.checkbox("gizmos", .{ .v = &app.show_gizmos });
+    zgui.sameLine(.{});
     if (zgui.button("Save", .{})) savePrefab(s, app);
     zgui.separator();
 
@@ -94,15 +96,23 @@ pub fn render(s: *PrefabState, app: *App) void {
     const viewport_w = @max(120.0, total_w - inspector_w - split_gap);
 
     const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
+    const gizmo_index_ptr: ?*const @import("../gizmos.zig").Index = if (app.gizmo_index) |*ix| ix else null;
 
     if (zgui.beginChild("##prefab_viewport_col", .{ .w = viewport_w, .h = 0 })) {
-        viewport.render(.{
-            .pan = &s.pan,
-            .zoom = &s.zoom,
-            .selected_idx = &s.selected_child_idx,
-            .is_dirty = &s.is_dirty,
-            .drag_armed = &s.drag_armed,
-        }, s.loaded.children, atlas_index_ptr);
+        viewport.render(
+            .{
+                .pan = &s.pan,
+                .zoom = &s.zoom,
+                .selected_idx = &s.selected_child_idx,
+                .is_dirty = &s.is_dirty,
+                .drag_armed = &s.drag_armed,
+            },
+            s.loaded.children,
+            s.loaded.children_extras,
+            atlas_index_ptr,
+            gizmo_index_ptr,
+            app.show_gizmos,
+        );
     }
     zgui.endChild();
     zgui.sameLine(.{});

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -110,6 +110,8 @@ pub fn render(s: *SceneState, app: *App) void {
     zgui.sameLine(.{});
     zgui.text("zoom: {d:.2}x", .{s.zoom});
     zgui.sameLine(.{});
+    _ = zgui.checkbox("gizmos", .{ .v = &app.show_gizmos });
+    zgui.sameLine(.{});
     if (zgui.button("Save", .{})) saveScene(s, app);
     zgui.separator();
 
@@ -118,9 +120,10 @@ pub fn render(s: *SceneState, app: *App) void {
     const viewport_w = @max(120.0, total_w - inspector_w - split_gap);
 
     const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
+    const gizmo_index_ptr: ?*const @import("../gizmos.zig").Index = if (app.gizmo_index) |*ix| ix else null;
 
     if (zgui.beginChild("##viewport_col", .{ .w = viewport_w, .h = 0 })) {
-        renderViewport(s, atlas_index_ptr);
+        renderViewport(s, atlas_index_ptr, gizmo_index_ptr, app.show_gizmos);
     }
     zgui.endChild();
     zgui.sameLine(.{});
@@ -169,14 +172,26 @@ fn renderInspector(s: *SceneState, atlas_index: ?*const @import("../atlas.zig").
     inspector.renderEntity(entity, extras, &s.is_dirty, idx, atlas_index);
 }
 
-fn renderViewport(s: *SceneState, atlas_index: ?*const @import("../atlas.zig").Index) void {
-    viewport.render(.{
-        .pan = &s.pan,
-        .zoom = &s.zoom,
-        .selected_idx = &s.selected_index,
-        .is_dirty = &s.is_dirty,
-        .drag_armed = &s.drag_armed,
-    }, s.loaded.scene.entities, atlas_index);
+fn renderViewport(
+    s: *SceneState,
+    atlas_index: ?*const @import("../atlas.zig").Index,
+    gizmo_index: ?*const @import("../gizmos.zig").Index,
+    show_gizmos: bool,
+) void {
+    viewport.render(
+        .{
+            .pan = &s.pan,
+            .zoom = &s.zoom,
+            .selected_idx = &s.selected_index,
+            .is_dirty = &s.is_dirty,
+            .drag_armed = &s.drag_armed,
+        },
+        s.loaded.scene.entities,
+        s.loaded.extras.entity_components,
+        atlas_index,
+        gizmo_index,
+        show_gizmos,
+    );
 }
 
 /// Re-exported so existing zspec tests (and any other caller of

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -13,6 +13,7 @@ const zgui = @import("zgui");
 
 const scene_io = @import("../scene_io.zig");
 const atlas = @import("../atlas.zig");
+const gizmos = @import("../gizmos.zig");
 
 pub const min_h: f32 = 240;
 
@@ -67,7 +68,17 @@ pub fn planRender(has_sprite: bool, sprite_resolved: bool, has_polygon: bool) st
 /// Render the viewport canvas for `entities` into the current
 /// imgui window. Caller is responsible for the surrounding container
 /// (e.g. a beginChild) and any controls bar.
-pub fn render(state: State, entities: []scene_io.Entity, atlas_index: ?*const atlas.Index) void {
+pub fn render(
+    state: State,
+    entities: []scene_io.Entity,
+    /// Parallel to `entities`: the unmodeled-component list per entity.
+    /// Pass an empty slice when the caller doesn't track them
+    /// (gizmo matching against unmodeled components is skipped).
+    entity_extras: []const []const scene_io.ComponentExtra,
+    atlas_index: ?*const atlas.Index,
+    gizmo_index: ?*const gizmos.Index,
+    show_gizmos: bool,
+) void {
     const avail = zgui.getContentRegionAvail();
     const canvas_h = @max(min_h, avail[1]);
     if (!zgui.beginChild("##canvas", .{
@@ -94,6 +105,9 @@ pub fn render(state: State, entities: []scene_io.Entity, atlas_index: ?*const at
 
     drawGrid(dl, canvas_min, canvas_max, state.pan.*, state.zoom.*);
     drawEntities(dl, canvas_min, state, entities, atlas_index);
+    if (show_gizmos) if (gizmo_index) |gi| {
+        drawGizmoOverlay(dl, canvas_min, state, entities, entity_extras, gi);
+    };
 
     _ = zgui.invisibleButton("##canvas_drag", .{ .w = canvas_size[0], .h = canvas_size[1], .flags = .{} });
 
@@ -428,6 +442,119 @@ pub fn hitTestEntity(
         }
     }
     return best;
+}
+
+/// Walk every entity, check every gizmo's predicates, draw the gizmo's
+/// Shape on each match. Uses a tiny per-entity scratch list for the
+/// component-name set; the cost is O(entities × gizmos × names) but
+/// the constants are small (real projects have <50 gizmos).
+fn drawGizmoOverlay(
+    dl: zgui.DrawList,
+    cmin: [2]f32,
+    state: State,
+    entities: []scene_io.Entity,
+    entity_extras: []const []const scene_io.ComponentExtra,
+    index: *const gizmos.Index,
+) void {
+    if (index.entries.items.len == 0) return;
+
+    var name_buf: [32][]const u8 = undefined;
+    for (entities, 0..) |e, i| {
+        const pos = e.position orelse continue;
+
+        // Build the entity's direct component name set into a stack
+        // buffer — most entities have <8 components so 32 is plenty.
+        var n: usize = 0;
+        if (e.position != null and n < name_buf.len) {
+            name_buf[n] = "Position";
+            n += 1;
+        }
+        if (e.sprite != null and n < name_buf.len) {
+            name_buf[n] = "Sprite";
+            n += 1;
+        }
+        if (i < entity_extras.len) {
+            for (entity_extras[i]) |ex| {
+                if (n >= name_buf.len) break;
+                name_buf[n] = ex.name;
+                n += 1;
+            }
+        }
+        const names: []const []const u8 = name_buf[0..n];
+
+        for (index.entries.items) |entry| {
+            if (!gizmos.entityMatches(entry.match, entry.exclude, names)) continue;
+            const px = cmin[0] + state.pan[0] + (pos.x + entry.offset_x) * state.zoom.*;
+            // World +y is up; screen +y is down. Subtract for both
+            // the entity's y and the gizmo offset's y.
+            const py = cmin[1] + state.pan[1] - (pos.y + entry.offset_y) * state.zoom.*;
+            drawShape(dl, entry.shape, entry.color, px, py, state.zoom.*);
+        }
+    }
+}
+
+fn drawShape(dl: zgui.DrawList, shape: gizmos.Shape, color: gizmos.Color, px: f32, py: f32, zoom: f32) void {
+    const col: u32 = (@as(u32, color.a) << 24) |
+        (@as(u32, color.b) << 16) |
+        (@as(u32, color.g) << 8) |
+        @as(u32, color.r);
+    switch (shape) {
+        .circle => |c| {
+            const r = c.radius * zoom;
+            if (c.fill == .filled) {
+                dl.addCircleFilled(.{ .p = .{ px, py }, .r = r, .col = col, .num_segments = 32 });
+            } else {
+                dl.addCircle(.{ .p = .{ px, py }, .r = r, .col = col, .num_segments = 32, .thickness = c.thickness });
+            }
+        },
+        .rectangle => |r| {
+            const half_w = r.width * zoom * 0.5;
+            const half_h = r.height * zoom * 0.5;
+            const pmin: [2]f32 = .{ px - half_w, py - half_h };
+            const pmax: [2]f32 = .{ px + half_w, py + half_h };
+            if (r.fill == .filled) {
+                dl.addRectFilled(.{ .pmin = pmin, .pmax = pmax, .col = col });
+            } else {
+                dl.addRect(.{ .pmin = pmin, .pmax = pmax, .col = col, .thickness = r.thickness });
+            }
+        },
+        .line => |l| {
+            dl.addLine(.{
+                .p1 = .{ px, py },
+                .p2 = .{ px + l.end.x * zoom, py - l.end.y * zoom },
+                .col = col,
+                .thickness = l.thickness,
+            });
+        },
+        .triangle => |t| {
+            const p1: [2]f32 = .{ px, py };
+            const p2: [2]f32 = .{ px + t.p2.x * zoom, py - t.p2.y * zoom };
+            const p3: [2]f32 = .{ px + t.p3.x * zoom, py - t.p3.y * zoom };
+            if (t.fill == .filled) {
+                dl.addTriangleFilled(.{ .p1 = p1, .p2 = p2, .p3 = p3, .col = col });
+            } else {
+                dl.addTriangle(.{ .p1 = p1, .p2 = p2, .p3 = p3, .col = col, .thickness = t.thickness });
+            }
+        },
+        .polygon => |p| {
+            // Regular n-gon: compute vertices on a circle of `radius`
+            // around the entity, then either filled-fan or outline.
+            const sides = std.math.clamp(p.sides, 3, 64);
+            var pts: [64][2]f32 = undefined;
+            var k: usize = 0;
+            while (k < sides) : (k += 1) {
+                const t: f32 = @as(f32, @floatFromInt(k)) / @as(f32, @floatFromInt(sides));
+                const angle = t * std.math.tau;
+                pts[k] = .{ px + @cos(angle) * p.radius * zoom, py - @sin(angle) * p.radius * zoom };
+            }
+            const slice = pts[0..@intCast(sides)];
+            if (p.fill == .filled) {
+                dl.addConvexPolyFilled(slice, col);
+            } else {
+                dl.addPolyline(slice, .{ .col = col, .flags = .{ .closed = true }, .thickness = p.thickness });
+            }
+        },
+    }
 }
 
 fn colorForPrefab(prefab: ?[]const u8) u32 {

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -464,8 +464,10 @@ fn drawGizmoOverlay(
 
         // Build the entity's direct component name set into a stack
         // buffer — most entities have <8 components so 32 is plenty.
+        // `pos` is non-null here (orelse-continue above), so Position
+        // is always present.
         var n: usize = 0;
-        if (e.position != null and n < name_buf.len) {
+        if (n < name_buf.len) {
             name_buf[n] = "Position";
             n += 1;
         }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -12,6 +12,7 @@ const project_tree = @import("modules/project_tree.zig");
 const viewport = @import("modules/viewport.zig");
 const atlas = @import("atlas.zig");
 const gizmo_io = @import("gizmo_io.zig");
+const gizmos = @import("gizmos.zig");
 
 test {
     zspec.runAll(@This());
@@ -2164,5 +2165,37 @@ pub const GizmoIoTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, reparsed.gizmo.match[0], hostile));
         try expect.equal(reparsed.gizmo.exclude.len, 1);
         try expect.toBeTrue(std.mem.eql(u8, reparsed.gizmo.exclude[0], "Tab\there"));
+    }
+};
+
+pub const GizmoMatchTests = struct {
+    test "match accepts an entity whose components include a match name" {
+        const present = [_][]const u8{ "Position", "Workstation" };
+        const m = [_][]const u8{"Workstation"};
+        const x: [0][]const u8 = .{};
+        try expect.toBeTrue(gizmos.entityMatches(&m, &x, &present));
+    }
+
+    test "match rejects when none of the match names are present" {
+        const present = [_][]const u8{ "Position", "Sprite" };
+        const m = [_][]const u8{"Workstation"};
+        const x: [0][]const u8 = .{};
+        try expect.toBeFalse(gizmos.entityMatches(&m, &x, &present));
+    }
+
+    test "exclude vetoes an otherwise-matching entity" {
+        const present = [_][]const u8{ "Item", "Stored" };
+        const m = [_][]const u8{"Item"};
+        const x = [_][]const u8{"Stored"};
+        try expect.toBeFalse(gizmos.entityMatches(&m, &x, &present));
+    }
+
+    test "empty match matches every non-excluded entity" {
+        // Mirrors the engine convention: an absent `.match` field is
+        // treated as a catch-all.
+        const present = [_][]const u8{ "Position", "Sprite" };
+        const m: [0][]const u8 = .{};
+        const x: [0][]const u8 = .{};
+        try expect.toBeTrue(gizmos.entityMatches(&m, &x, &present));
     }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2199,3 +2199,54 @@ pub const GizmoMatchTests = struct {
         try expect.toBeTrue(gizmos.entityMatches(&m, &x, &present));
     }
 };
+
+pub const GizmosIndexTests = struct {
+    test "build against a missing gizmos/ dir returns an empty index" {
+        // Regression: the loader has to tolerate projects without a
+        // gizmos/ subtree (the common case). `Index.deinit` must be
+        // safe on the resulting empty struct.
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+        defer std.testing.allocator.free(dir_path);
+
+        var idx = gizmos.Index.build(std.testing.allocator, dir_path, 1);
+        defer idx.deinit();
+        try expect.toBeEmpty(idx.entries.items);
+        try expect.toBeEmpty(idx.arenas.items);
+        try expect.equal(idx.generation, @as(u64, 1));
+    }
+
+    test "deinit frees per-entry arenas without double-free" {
+        // Regression for PR #41 review: prior to the fix, an OOM
+        // between `arenas.append` and `entries.append` left a dangling
+        // arena pointer; the errdefer for the loop arena and the
+        // index's own deinit would each free it. We can't easily
+        // force an OOM here, but we can stand up an Index manually
+        // with one valid arena+entry and prove deinit walks the
+        // arena list and frees cleanly.
+        var idx: gizmos.Index = .{
+            .allocator = std.testing.allocator,
+            .generation = 7,
+        };
+        const arena = try std.testing.allocator.create(std.heap.ArenaAllocator);
+        arena.* = std.heap.ArenaAllocator.init(std.testing.allocator);
+        const a = arena.allocator();
+
+        const match_one = try a.alloc([]const u8, 1);
+        match_one[0] = try a.dupe(u8, "Workstation");
+        const empty: [][]const u8 = &.{};
+        const source_owned = try a.dupe(u8, "/dev/null/test.zon");
+
+        try idx.arenas.append(std.testing.allocator, arena);
+        try idx.entries.append(std.testing.allocator, .{
+            .source = source_owned,
+            .match = match_one,
+            .exclude = empty,
+            .shape = .{ .circle = .{ .radius = 8 } },
+        });
+        idx.deinit();
+        // Reaching here without leaks (std.testing.allocator is the
+        // GPA) is the assertion.
+    }
+};


### PR DESCRIPTION
Stacked on **#40** (gizmo .zon editor). Loads every `<project>/gizmos/*.zon` on project open, parses the typed `Shape` out of each gizmo's `.entity` block, and overlays the shape on any scene/prefab entity whose direct components satisfy the gizmo's `.match` / `.exclude` predicates.

## Summary
- New `src/gizmos.zig` — per-project `Index` (built alongside `atlas_index`, keyed by `ProjectManager.generation`), typed `Shape` union mirroring `../labelle-gfx/src/visuals.zig` (circle / rectangle / line / triangle / polygon), and an `entityMatches` predicate
- `App.gizmo_index: ?gizmos.Index` + `App.show_gizmos: bool = true`, rebuilt on the generation-change path next to the atlas rebuild
- `viewport.render` extended with the per-entity extras slice + the gizmo index + a `show_gizmos` flag; new `drawGizmoOverlay` + `drawShape` helpers handle all five variants (filled or outlined, regular n-gon for polygon)
- Scene and prefab modules each add a **`gizmos` checkbox** to the controls bar bound to `app.show_gizmos`
- 4 zspec regressions for `entityMatches` (positive, negative, exclude-veto, empty-match catch-all)

## Test plan
- [x] `zig build` clean
- [x] `zig build test` — 109/109 (105 baseline + 4 new `GizmoMatchTests`)
- [x] `zig build gui-test` — 6/6
- [x] `zig build smoke` — OK
- [ ] Live verification deferred — open flying-platform in the gui and confirm Workstation entities show a triangle, Room shows an outlined rectangle, MovementNode shows a circle

## Known v1 limitation
Matching checks an entity's *direct* component name set (typed Position/Sprite fields + the source's unmodeled extras). Doesn't follow `prefab:` references, so a scene entity like `{ prefab: "workstation" }` with no inlined components won't match a `.match = .{"Workstation"}` gizmo. Engine matches after prefab instantiation; closing this requires a prefab index. Documented in `src/gizmos.zig` header.

## Stack
Targets `worktree-agent-a99dd25cdf278eebc` (the head branch of PR #40) since the typed parser builds on the `entity_verbatim` field added there. Will rebase to `main` after #40 lands.