### PR TITLE
Spike: imgui-node-editor binding for Flows (#45)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,14 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .backend = .glfw_opengl3,
+        // Pulls in thedmd/imgui-node-editor (vendored at
+        // libs/node_editor) and compiles it into the same `imgui`
+        // artifact zgui already produces. Exposed via
+        // `zgui.node_editor.*` (see libs/zgui/src/node_editor.zig).
+        // Linked against the same ImGui instance so the editor's
+        // canvas draws into the gui's existing context — no second
+        // ImGuiContext needed (issue #45, Flows spike).
+        .with_node_editor = true,
     });
 
     const nfd = b.dependency("nfd", .{
@@ -106,6 +114,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .backend = .glfw_opengl3,
         .with_te = true,
+        // Mirror the production `zgui` config so `App` compiles
+        // against the same module shape — the Flow module references
+        // `zgui.node_editor.*` and the test runner imports App.
+        .with_node_editor = true,
     });
 
     const gui_tests_exe = b.addExecutable(.{

--- a/src/app.zig
+++ b/src/app.zig
@@ -21,6 +21,7 @@ const project_tree_mod = @import("modules/project_tree.zig");
 const resources_mod = @import("modules/resources.zig");
 const scene_mod = @import("modules/scene.zig");
 const prefab_mod = @import("modules/prefab.zig");
+const flow_mod = @import("modules/flow.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
 const atlas = @import("atlas.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
@@ -38,11 +39,16 @@ const SCENE_NAME_BUF_LEN = 128;
 pub const OpenTab = union(enum) {
     scene: scene_mod.SceneState,
     prefab: prefab_mod.PrefabState,
+    /// Visual-scripting "flow graph" editor — spike for issue #45.
+    /// `save`/`isDirty` are no-ops until Phase 1 lands the
+    /// `.flow.zon` schema.
+    flow: flow_mod.FlowState,
 
     pub fn deinit(self: *OpenTab, allocator: std.mem.Allocator) void {
         switch (self.*) {
             .scene => |*s| s.deinit(allocator),
             .prefab => |*p| p.deinit(allocator),
+            .flow => |*f| f.deinit(allocator),
         }
     }
 
@@ -50,6 +56,7 @@ pub const OpenTab = union(enum) {
         switch (self.*) {
             .scene => |*s| scene_mod.render(s, app),
             .prefab => |*p| prefab_mod.render(p, app),
+            .flow => |*f| flow_mod.render(f, app),
         }
     }
 
@@ -57,6 +64,7 @@ pub const OpenTab = union(enum) {
         switch (self.*) {
             .scene => |*s| scene_mod.saveScene(s, app),
             .prefab => |*p| prefab_mod.savePrefab(p, app),
+            .flow => |*f| flow_mod.saveFlow(f, app),
         }
     }
 
@@ -64,6 +72,7 @@ pub const OpenTab = union(enum) {
         return switch (self) {
             .scene => |s| s.display_name,
             .prefab => |p| p.display_name,
+            .flow => |f| f.display_name,
         };
     }
 
@@ -71,6 +80,7 @@ pub const OpenTab = union(enum) {
         return switch (self) {
             .scene => |s| s.path,
             .prefab => |p| p.path,
+            .flow => |f| f.path,
         };
     }
 
@@ -78,6 +88,7 @@ pub const OpenTab = union(enum) {
         return switch (self) {
             .scene => |s| s.is_dirty,
             .prefab => |p| p.is_dirty,
+            .flow => |f| f.is_dirty,
         };
     }
 };
@@ -244,6 +255,26 @@ pub const App = struct {
         var state = try prefab_mod.PrefabState.open(self.allocator, path);
         errdefer state.deinit(self.allocator);
         try self.open_tabs.append(self.allocator, .{ .prefab = state });
+        const new_idx = self.open_tabs.items.len - 1;
+        self.active_tab_idx = new_idx;
+        self.focus_tab_idx = new_idx;
+    }
+
+    /// Open a `.flow.zon` file (under `<project>/scripts/flows/`)
+    /// as a tab. Spike behavior — the file isn't actually parsed
+    /// yet, the editor renders an empty canvas with one
+    /// placeholder node. See `src/modules/flow.zig` and issue #45.
+    pub fn openFlow(self: *Self, path: []const u8) !void {
+        for (self.open_tabs.items, 0..) |t, i| {
+            if (std.mem.eql(u8, t.path(), path)) {
+                self.focus_tab_idx = i;
+                return;
+            }
+        }
+
+        var state = try flow_mod.FlowState.open(self.allocator, path);
+        errdefer state.deinit(self.allocator);
+        try self.open_tabs.append(self.allocator, .{ .flow = state });
         const new_idx = self.open_tabs.items.len - 1;
         self.active_tab_idx = new_idx;
         self.focus_tab_idx = new_idx;

--- a/src/icons.zig
+++ b/src/icons.zig
@@ -23,6 +23,7 @@ pub const FA_BOX = "\u{f466}"; // box (for prefabs)
 pub const FA_FILM = "\u{f008}"; // film (for scenes)
 pub const FA_SCROLL = "\u{f70e}"; // scroll (for scripts)
 pub const FA_DATABASE = "\u{f1c0}"; // database (for resources)
+pub const FA_PROJECT_DIAGRAM = "\u{f046}"; // project-diagram / graph (for flows)
 
 // Common UI icons
 pub const FA_PLUS = "\u{f067}"; // plus

--- a/src/modules/flow.zig
+++ b/src/modules/flow.zig
@@ -1,0 +1,134 @@
+//! Flow editor — per-tab state and rendering for visual-scripting
+//! "flow graph" `.flow.zon` files under `<project>/scripts/flows/`.
+//!
+//! Phase 0 (spike — issue #45 / umbrella #42): prove we can embed
+//! [thedmd/imgui-node-editor](https://github.com/thedmd/imgui-node-editor)
+//! as a tab inside labelle-gui. This file is intentionally minimal:
+//!
+//!   - One `EditorContext` per tab (owned by `FlowState`, destroyed
+//!     in `deinit`).
+//!   - A single placeholder node with one input + one output pin.
+//!     The user can drag it; nothing else is wired up.
+//!
+//! Save / dirty tracking are no-ops for the spike — Phase 1 (issues
+//! #46–#52) lands a real `.flow.zon` schema, a node catalog, and
+//! serialization. The acceptance criterion here is: linker is
+//! happy, canvas renders, node drags.
+//!
+//! Not registered as a togglable panel; opens as a tab via tree
+//! click on a `.flow.zon` file (`project_tree.isFlowPath`).
+
+const std = @import("std");
+const zgui = @import("zgui");
+const ne = zgui.node_editor;
+
+const App = @import("../app.zig").App;
+const scene_io = @import("../scene_io.zig");
+
+/// Pin IDs are global within an editor context; tag the placeholder
+/// node's pins with distinct constants so the editor can tell them
+/// apart. NodeId is `u64` per the zgui binding — 0 is reserved
+/// internally as "no node", so start at 1.
+const placeholder_node_id: u64 = 1;
+const placeholder_input_pin_id: u64 = 100;
+const placeholder_output_pin_id: u64 = 101;
+
+pub const FlowState = struct {
+    /// Owns `path` and `display_name`. No parsed-source arena for
+    /// the spike — the file isn't actually read.
+    arena: *std.heap.ArenaAllocator,
+    /// Absolute path on disk. Used for dedup when opening another
+    /// tab on the same file. Not actually read or written.
+    path: []const u8,
+    /// Filename stem without `.flow.zon`. Used for the tab label.
+    display_name: []const u8,
+    /// imgui-node-editor's per-canvas state. Holds the visual
+    /// position of every node, current selection, view transform,
+    /// etc. Owned by this tab; destroyed in `deinit`.
+    editor: *ne.EditorContext,
+    /// Spike has no real edits to dirty-flag. Always false so the
+    /// close-tab modal never fires. Phase 1 will wire this up to
+    /// real edits.
+    is_dirty: bool = false,
+
+    pub fn open(allocator: std.mem.Allocator, path: []const u8) !FlowState {
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const a = arena.allocator();
+        const path_dup = try a.dupe(u8, path);
+        const display_name = displayNameFromPath(path_dup);
+
+        // Spike: don't persist the node layout — pass a null
+        // `settings_file` so the editor keeps its layout in memory
+        // only. Phase 1 will route the layout through our own ZON
+        // save callbacks.
+        const config: ne.Config = .{};
+        const editor = ne.EditorContext.create(config);
+
+        return .{
+            .arena = arena,
+            .path = path_dup,
+            .display_name = display_name,
+            .editor = editor,
+        };
+    }
+
+    pub fn deinit(self: *FlowState, allocator: std.mem.Allocator) void {
+        self.editor.destroy();
+        self.arena.deinit();
+        allocator.destroy(self.arena);
+    }
+};
+
+/// `foo.flow.zon` → `foo`. Strip both extensions so the tab label
+/// matches the user's mental file name. Falls back to the basename
+/// when the path doesn't end in our expected suffix.
+fn displayNameFromPath(path: []const u8) []const u8 {
+    const base = std.fs.path.basename(path);
+    const ext = ".flow.zon";
+    if (std.mem.endsWith(u8, base, ext)) return base[0 .. base.len - ext.len];
+    return scene_io.displayNameFromPath(path);
+}
+
+pub fn render(s: *FlowState, app: *App) void {
+    _ = app;
+    zgui.text("Flow: {s}", .{s.display_name});
+    zgui.sameLine(.{});
+    zgui.textDisabled("(spike — no save, no schema, no node catalog yet)", .{});
+    zgui.separator();
+
+    // Bind the per-tab editor context for the duration of this
+    // frame. SetCurrentEditor must wrap every Begin/End — the
+    // editor is global state inside thedmd's library.
+    ne.setCurrentEditor(s.editor);
+    defer ne.setCurrentEditor(null);
+
+    // size = {0,0} → fill the parent's content region.
+    ne.begin("##flow_canvas", .{ 0, 0 });
+    defer ne.end();
+
+    // Single placeholder node: input pin on the left, output pin
+    // on the right. The editor places the node on first frame; the
+    // user can drag it after that.
+    ne.beginNode(placeholder_node_id);
+    zgui.text("Placeholder", .{});
+    ne.beginPin(placeholder_input_pin_id, .input);
+    zgui.text("-> in", .{});
+    ne.endPin();
+    zgui.sameLine(.{});
+    ne.beginPin(placeholder_output_pin_id, .output);
+    zgui.text("out ->", .{});
+    ne.endPin();
+    ne.endNode();
+}
+
+/// No-op for the spike. The Flow tab is never dirty, so the close
+/// modal never reaches this path; but `OpenTab.save` still needs
+/// a function to dispatch to.
+pub fn saveFlow(s: *FlowState, app: *App) void {
+    _ = s;
+    _ = app;
+}

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -37,6 +37,27 @@ pub fn isPrefabPath(proj_dir: ?[]const u8, path: []const u8) bool {
     return isUnderFolder(proj_dir, path, project.ProjectFolders.prefabs);
 }
 
+/// Return true when `path` is a `.flow.zon` file under the
+/// project's `scripts/flows/` directory. Drives routing of tree
+/// clicks into the Flow editor (spike — issue #45).
+///
+/// Schema choice: `.flow.zon` (rather than reusing `.jsonc`)
+/// keeps Flow files out of the scene/prefab path predicates and
+/// makes the file's purpose obvious in the tree. The toolkit's
+/// other config files (`project.labelle`, prefab metadata) are
+/// already ZON; reusing the parser is convenient.
+pub fn isFlowPath(proj_dir: ?[]const u8, path: []const u8) bool {
+    const dir = proj_dir orelse return false;
+    if (!std.mem.endsWith(u8, path, ".flow.zon")) return false;
+    var prefix_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = std.fmt.bufPrint(
+        &prefix_buf,
+        "{s}/{s}/{s}/",
+        .{ dir, project.ProjectFolders.scripts, "flows" },
+    ) catch return false;
+    return std.mem.startsWith(u8, path, prefix);
+}
+
 fn isUnderFolder(proj_dir: ?[]const u8, path: []const u8, folder: []const u8) bool {
     const dir = proj_dir orelse return false;
     if (!std.mem.endsWith(u8, path, ".jsonc")) return false;
@@ -79,6 +100,11 @@ fn render(app: *App) void {
                         app.openPrefab(path) catch |err| {
                             std.log.err("Failed to open prefab {s}: {s}", .{ path, @errorName(err) });
                             app.setStatus("Error opening prefab!");
+                        };
+                    } else if (isFlowPath(proj_dir, path)) {
+                        app.openFlow(path) catch |err| {
+                            std.log.err("Failed to open flow {s}: {s}", .{ path, @errorName(err) });
+                            app.setStatus("Error opening flow!");
                         };
                     }
                 }

--- a/src/project.zig
+++ b/src/project.zig
@@ -10,6 +10,15 @@ pub const ProjectFolders = struct {
     pub const prefabs = "prefabs";
     pub const scenes = "scenes";
     pub const scripts = "scripts";
+    /// Nested subfolder under `scripts/` for visual-scripting
+    /// `.flow.zon` files (issue #45 — Flows editor). Scaffolded as
+    /// part of `ProjectFolders.all` so `createProjectFolders`
+    /// creates it on new project, but `std.fs.Dir.makeDir`
+    /// with this path needs the parent to exist first — it does,
+    /// because `scripts` appears earlier in `all`. The Flow tab
+    /// router (`project_tree.isFlowPath`) requires this exact
+    /// relative path.
+    pub const scripts_flows = "scripts/flows";
     pub const resources = "resources";
 
     pub const all = [_][]const u8{
@@ -20,6 +29,7 @@ pub const ProjectFolders = struct {
         prefabs,
         scenes,
         scripts,
+        scripts_flows,
         resources,
     };
 };
@@ -163,8 +173,12 @@ pub const ProjectManager = struct {
         var dir = try std.fs.cwd().openDir(base_path, .{});
         defer dir.close();
 
+        // `makePath` instead of `makeDir` so `scripts/flows`
+        // creates the `scripts` parent if it's missing — and so
+        // path separators in entries work on Windows (where
+        // `makeDir` only accepts a single component).
         for (ProjectFolders.all) |folder| {
-            dir.makeDir(folder) catch |err| {
+            dir.makePath(folder) catch |err| {
                 if (err != error.PathAlreadyExists) return err;
             };
         }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -79,6 +79,10 @@ pub const ProjectFoldersTests = struct {
         try expect.toBeTrue(containsFolder("scripts"));
     }
 
+    test "contains scripts/flows folder" {
+        try expect.toBeTrue(containsFolder("scripts/flows"));
+    }
+
     test "contains resources folder" {
         try expect.toBeTrue(containsFolder("resources"));
     }
@@ -222,6 +226,11 @@ pub const FolderIconsTests = struct {
     test "scripts folder has scroll icon" {
         const icon = tree_view.FolderIcons.forFolder("scripts");
         try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.scripts));
+    }
+
+    test "scripts/flows has project-diagram icon" {
+        const icon = tree_view.FolderIcons.forFolder("scripts/flows");
+        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.scripts_flows));
     }
 
     test "resources folder has database icon" {
@@ -1058,6 +1067,25 @@ pub const SceneRoutingTests = struct {
             const pf = project_tree.isPrefabPath("/p", sample);
             try expect.toBeFalse(sc and pf);
         }
+    }
+
+    test "flow path under scripts/flows/ is accepted" {
+        try expect.toBeTrue(project_tree.isFlowPath("/p", "/p/scripts/flows/foo.flow.zon"));
+        try expect.toBeTrue(project_tree.isFlowPath("/p", "/p/scripts/flows/sub/bar.flow.zon"));
+    }
+
+    test "non-flow-extension under scripts/flows is rejected" {
+        try expect.toBeFalse(project_tree.isFlowPath("/p", "/p/scripts/flows/notes.md"));
+        try expect.toBeFalse(project_tree.isFlowPath("/p", "/p/scripts/flows/main.zon"));
+    }
+
+    test "flow path outside scripts/flows/ is rejected" {
+        try expect.toBeFalse(project_tree.isFlowPath("/p", "/p/scripts/foo.flow.zon"));
+        try expect.toBeFalse(project_tree.isFlowPath("/p", "/p/scenes/foo.flow.zon"));
+    }
+
+    test "no project dir → no flow routing" {
+        try expect.toBeFalse(project_tree.isFlowPath(null, "/p/scripts/flows/foo.flow.zon"));
     }
 };
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -47,8 +47,8 @@ pub const ProjectFoldersTests = struct {
         return false;
     }
 
-    test "has 8 default folders" {
-        try expect.equal(project.ProjectFolders.all.len, 8);
+    test "has 9 default folders" {
+        try expect.equal(project.ProjectFolders.all.len, 9);
     }
 
     test "contains assets folder" {

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -11,6 +11,7 @@ pub const FolderIcons = struct {
     pub const prefabs = icons.FA_BOX; // Box for prefabs
     pub const scenes = icons.FA_FILM; // Film for scenes
     pub const scripts = icons.FA_SCROLL; // Scroll for scripts
+    pub const scripts_flows = icons.FA_PROJECT_DIAGRAM; // Graph icon for flows
     pub const resources = icons.FA_DATABASE; // Database for resources
     pub const file = icons.FA_FILE; // File icon
     pub const folder_open = icons.FA_FOLDER_OPEN; // Open folder
@@ -23,6 +24,10 @@ pub const FolderIcons = struct {
         if (std.mem.eql(u8, name, project.ProjectFolders.prefabs)) return prefabs;
         if (std.mem.eql(u8, name, project.ProjectFolders.scenes)) return scenes;
         if (std.mem.eql(u8, name, project.ProjectFolders.scripts)) return scripts;
+        // The Flows folder is nested under `scripts/` and registered
+        // in `ProjectFolders.all` as the literal `"scripts/flows"`.
+        // Match the full path here so the lookup hits.
+        if (std.mem.eql(u8, name, project.ProjectFolders.scripts_flows)) return scripts_flows;
         if (std.mem.eql(u8, name, project.ProjectFolders.resources)) return resources;
         return folder_closed;
     }


### PR DESCRIPTION
## Summary

Phase 0 de-risk of [thedmd/imgui-node-editor](https://github.com/thedmd/imgui-node-editor) as the canvas for the eventual Blueprint-style visual-scripting feature (umbrella #42). Proves the editor can be embedded as a tab in labelle-gui against our existing Zig 0.15.2 + zgui pin (`b6a4dff52`).

## Dep choice

**No new dependency.** The zgui pin we're already on (`b6a4dff52`) vendors the entire imgui-node-editor library at `libs/node_editor/` and ships Zig bindings at `src/node_editor.zig`. Activating it is one knob:

```zig
const zgui = b.dependency("zgui", .{
    .target = target, .optimize = optimize,
    .backend = .glfw_opengl3,
    .with_node_editor = true,
});
```

The C++ sources compile into the same `imgui` artifact zgui already produces, so the editor's canvas shares the gui's single `ImGuiContext`. The Zig binding covers everything the spike needed (`EditorContext.create/destroy`, `setCurrentEditor`, `begin/end`, `beginNode/endNode`, `beginPin/endPin`).

This is much cleaner than I expected — no fork, no wrapper repo, no ABI surprises.

## Build-system gotchas

1. **Two zgui deps to flip.** `build.zig` declares zgui twice: the production `zgui` (linked into `labelle-gui`) and `zgui_te` (the `with_te = true` variant linked into `gui-tests`). Both need `with_node_editor = true` because the test runner imports `App`, which references `zgui.node_editor.*`. Forgetting the second one fails the gui-tests link step.

2. **Nested project folder needs `makePath`.** `ProjectFolders.all` now contains `"scripts/flows"`. `Dir.makeDir` on POSIX is fine with `scripts/` already existing earlier in the iteration order, but Windows `makeDir` only accepts a single path component. Switched `createProjectFolders` to `Dir.makePath` so the same loop works portably and tolerates missing parents.

3. **`.flow.zon` extension predicate.** Routing in `project_tree` is whitespace-strict against `proj_dir + "/scripts/flows/"` + `.flow.zon` suffix. Files like `scripts/foo.flow.zon` (one folder up) are deliberately rejected — see `SceneRoutingTests` for the matrix.

## What this PR does

- `build.zig` — `with_node_editor = true` on both zgui deps.
- `src/modules/flow.zig` — new `FlowState`/`render`. Per-tab `ne.EditorContext`, one placeholder node (1 input pin, 1 output pin). Save/dirty are no-ops. Owns its arena like the scene/prefab tab states.
- `src/app.zig` — `OpenTab.flow` variant + `openFlow(path)`, wired through every switch arm (`displayName`, `path`, `isDirty`, `save`, `render`, `deinit`). Dedupes by path like the existing `openScene`/`openPrefab`.
- `src/modules/project_tree.zig` — `isFlowPath` predicate (`.flow.zon` under `scripts/flows/`); routing arm after scene + prefab.
- `src/project.zig` — `scripts/flows` added to `ProjectFolders.all`; `createProjectFolders` uses `makePath`.
- `src/icons.zig`, `src/tree_view.zig` — `FA_PROJECT_DIAGRAM` icon (`\u{f046}`) for the new folder.
- `src/tests.zig` — folder count 7 → 8, presence test for `scripts/flows`, icon mapping test, and four `isFlowPath` accept/reject tests.

## Not in scope (Phase 1, issues #46–#52)

The placeholder node + canvas have no business logic yet:
- No `.flow.zon` schema, no parse, no serialize.
- No node catalog (no event/condition/action node types).
- No codegen into the engine's script registry.
- No link creation/deletion UI.
- No layout persistence (the editor keeps node positions in memory only; `Config.settings_file` is left null).

Those land separately.

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — 100/100 pass (was 89; +11 new spike tests)
- [x] `zig build gui-test` — 6/6 pass
- [x] `zig build smoke` — OK against real `labelle` launcher
- [ ] Manual: `zig build run`, create a new project, drop a `foo.flow.zon` into `scripts/flows/`, click it in the tree, verify a Flow tab opens with one draggable placeholder node.

Closes #45.