### PR TITLE
Preview mode Phase 1: Run preview button + TCP listener + heartbeat surface

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -13,12 +13,14 @@ const nfd = @import("nfd");
 const project = @import("project.zig");
 const tree_view = @import("tree_view.zig");
 const compiler = @import("compiler.zig");
+const preview = @import("preview.zig");
 const config = @import("config.zig");
 const module = @import("module.zig");
 const compiler_output = @import("modules/compiler_output.zig");
 const project_settings_mod = @import("modules/project_settings.zig");
 const project_tree_mod = @import("modules/project_tree.zig");
 const resources_mod = @import("modules/resources.zig");
+const preview_mod = @import("modules/preview.zig");
 const scene_mod = @import("modules/scene.zig");
 const prefab_mod = @import("modules/prefab.zig");
 const flow_mod = @import("modules/flow.zig");
@@ -109,6 +111,10 @@ pub const App = struct {
     project_manager: project.ProjectManager,
     tree_view: tree_view.TreeView,
     compiler: compiler.Compiler,
+    /// Preview-mode session (issue #61). Lifetime spans the App; `start`/
+    /// `stop` drive transitions, `poll` is ticked every frame. The
+    /// `preview` panel module reads its state for the status line.
+    preview: preview.PreviewSession,
 
     status_message: [STATUS_BUF_LEN]u8 = [_]u8{0} ** STATUS_BUF_LEN,
     status_timer: f32 = 0,
@@ -123,6 +129,11 @@ pub const App = struct {
 
     show_resources: bool = false,
     resources_editor: resources_mod.ResourcesEditor = .{},
+
+    /// Toggled by the View menu and the Build menu's "Run preview"
+    /// action. The Preview panel reads this via its `Module.is_open`
+    /// pointer; clicking Run preview also force-opens it.
+    show_preview: bool = false,
 
     /// Open editor tabs — scenes and prefabs share this list as
     /// `OpenTab` variants. Populated when the user clicks an
@@ -168,7 +179,7 @@ pub const App = struct {
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [4]module.Module = undefined,
+    modules: [5]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -183,12 +194,14 @@ pub const App = struct {
             .project_manager = project.ProjectManager.init(allocator),
             .tree_view = tree_view.TreeView.init(allocator),
             .compiler = compiler.Compiler.init(allocator),
+            .preview = preview.PreviewSession.init(allocator),
         };
 
         app.modules[0] = project_tree_mod.makeModule(app);
         app.modules[1] = compiler_output.makeModule(app);
         app.modules[2] = project_settings_mod.makeModule(app);
         app.modules[3] = resources_mod.makeModule(app);
+        app.modules[4] = preview_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
 
         return app;
@@ -202,6 +215,7 @@ pub const App = struct {
         self.project_manager.deinit();
         self.tree_view.deinit();
         self.compiler.deinit();
+        self.preview.deinit();
         self.allocator.destroy(self);
     }
 
@@ -412,6 +426,7 @@ pub const App = struct {
 
         self.renderMenuBar();
         self.pollCompiler();
+        self.preview.poll();
         self.renderMainContent();
         self.registry.renderAllPanels(self);
         self.renderStatusBar();
@@ -472,6 +487,13 @@ pub const App = struct {
         zgui.separator();
         if (zgui.menuItem("Build", .{ .enabled = can_build })) self.startBuildOrRun(.build);
         if (zgui.menuItem("Run", .{ .enabled = can_build })) self.startBuildOrRun(.run);
+        zgui.separator();
+        // Preview mode (#61). Disabled while an existing preview session
+        // is alive — the session is single-instance (multi-session is
+        // punted in the #59 umbrella).
+        const preview_active = self.preview.isActive();
+        if (zgui.menuItem("Run preview", .{ .enabled = can_build and !preview_active })) self.startPreview();
+        if (zgui.menuItem("Stop preview", .{ .enabled = preview_active })) self.stopPreview();
     }
 
     fn renderHelpMenu(_: *Self) void {
@@ -580,6 +602,31 @@ pub const App = struct {
             self.setStatus(if (result.success) "Build successful!" else "Build failed!");
             self.compiler_output_scroll_to_bottom = true;
         }
+    }
+
+    /// Spawn a preview-mode child process and surface the Preview
+    /// panel. Mirrors `startBuildOrRun` shape: sync project files,
+    /// hand off to the session, surface a status message. The session
+    /// drives state from there via `poll()`.
+    pub fn startPreview(self: *Self) void {
+        const proj = self.project_manager.current_project orelse return;
+        self.compiler.syncProjectFiles(&self.project_manager) catch |err| {
+            std.log.err("Error syncing project files: {}", .{err});
+            self.setStatus("Error syncing project files!");
+            return;
+        };
+        self.preview.start(proj) catch |err| {
+            std.log.err("Error starting preview: {}", .{err});
+            self.setStatus("Error starting preview!");
+            return;
+        };
+        self.setStatus("Preview starting...");
+        self.show_preview = true;
+    }
+
+    pub fn stopPreview(self: *Self) void {
+        self.preview.stop();
+        self.setStatus("Preview stopped.");
     }
 
     // ─── Panels ─────────────────────────────────────────────────────────

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -311,6 +311,44 @@ pub fn main() !void {
         }
     });
 
+    // Preview panel — toggle from View menu and drive the Stop button
+    // path. We deliberately don't drive Run preview here because that
+    // would spawn the real `labelle` launcher (sibling repos #94/#193
+    // haven't landed --preview-mode yet). Hand-injecting a state via
+    // the public API keeps this test hermetic — same pattern the
+    // scene/prefab tests use to avoid touching nfd.
+    _ = engine.registerTest("phase3", "preview_panel_toggle_and_stop", @src(), struct {
+        fn gui(_: *zgui.te.TestContext) !void {
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            // Sanity: panel starts closed.
+            _ = zgui.te.check(@src(), .{}, !a.show_preview, "Preview panel starts closed");
+
+            // View menu toggle.
+            ctx.menuAction(.click, "View/Preview");
+            _ = zgui.te.check(@src(), .{}, a.show_preview, "View/Preview opens panel");
+
+            // From idle, isActive must be false and Stop is a no-op
+            // (state stays at .stopped after a stop call).
+            _ = zgui.te.check(@src(), .{}, !a.preview.isActive(), "preview starts inactive");
+
+            // Drive the Stop path through the App method — exercises
+            // the same code the panel button hits.
+            a.stopPreview();
+            _ = zgui.te.check(@src(), .{}, a.preview.state == .stopped, "Stop preview lands at .stopped");
+
+            // Toggle off again.
+            ctx.menuAction(.click, "View/Preview");
+            _ = zgui.te.check(@src(), .{}, !a.show_preview, "View/Preview closes panel");
+        }
+    });
+
     _ = engine.registerTest("phase3", "project_settings_edit_save", @src(), struct {
         fn gui(_: *zgui.te.TestContext) !void {
             // Synthetic dt; tests don't observe status_timer decay.

--- a/src/modules/preview.zig
+++ b/src/modules/preview.zig
@@ -1,0 +1,94 @@
+//! Preview panel — status line + Run/Stop buttons for the editor-side
+//! preview-mode TCP session (issue #61).
+//!
+//! Reads `app.preview` (a `PreviewSession`) and renders one of:
+//!   - "Idle"
+//!   - "Listening on 127.0.0.1:PORT, waiting for engine..."
+//!   - "Connecting — engine connected, waiting for hello..."
+//!   - "Preview running (engine PID NNNN, last heartbeat Xms ago)"
+//!   - "Preview crashed"
+//!   - "Preview stopped"
+//!
+//! Buttons:
+//!   - Run preview — enabled when a project is open and no preview is
+//!     active. Delegates to `App.startPreview` (the same path the
+//!     Build menu uses).
+//!   - Stop preview — enabled while listening/connecting/running.
+//!     Delegates to `App.stopPreview`.
+//!
+//! No game pixels here — Phase 2+ (#59 umbrella) lands texture-mirror.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const preview = @import("../preview.zig");
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "preview",
+        .display_name = "Preview",
+        .is_open = &app.show_preview,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    if (!zgui.begin("Preview", .{
+        .popen = &app.show_preview,
+        .flags = .{ .always_auto_resize = true },
+    })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    renderStatus(&app.preview);
+    zgui.separator();
+    renderButtons(app);
+}
+
+fn renderStatus(p: *const preview.PreviewSession) void {
+    switch (p.state) {
+        .idle => zgui.textDisabled("Idle", .{}),
+        .listening => {
+            const port = p.port orelse 0;
+            zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Listening on 127.0.0.1:{d}, waiting for engine...", .{port});
+        },
+        .connecting => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Connecting — engine connected, waiting for hello...", .{}),
+        .running => {
+            const pid = p.engine_pid orelse 0;
+            const ago: i64 = if (p.last_heartbeat_ms) |hb| std.time.milliTimestamp() - hb else 0;
+            zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Preview running (engine PID {d}, last heartbeat {d}ms ago)", .{ pid, ago });
+            if (p.engine_version) |v| zgui.text("Engine version: {s}", .{v});
+        },
+        .crashed => zgui.textColored(.{ 1.0, 0.3, 0.3, 1.0 }, "Preview crashed", .{}),
+        .stopped => {
+            if (p.bye_reason) |r| {
+                zgui.textDisabled("Preview stopped ({s})", .{r});
+            } else {
+                zgui.textDisabled("Preview stopped", .{});
+            }
+        },
+    }
+}
+
+fn renderButtons(app: *App) void {
+    const has_project = app.project_manager.current_project != null;
+    const active = app.preview.isActive();
+
+    if (!active) {
+        if (zgui.button("Run preview##preview_run", .{ .w = 140 })) {
+            if (has_project) app.startPreview();
+        }
+        if (!has_project) {
+            zgui.sameLine(.{});
+            zgui.textDisabled("(no project open)", .{});
+        }
+    } else {
+        if (zgui.button("Stop preview##preview_stop", .{ .w = 140 })) {
+            app.stopPreview();
+        }
+    }
+}

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -1,0 +1,509 @@
+//! Preview-mode session — Phase 1 of the PIE preview umbrella (#59 / #61).
+//!
+//! Owns the editor side of the "run with telemetry" handshake:
+//!
+//!   1. `start(project_dir)` binds a TCP listener on `127.0.0.1:0`, asks
+//!      the kernel for a port, spawns `labelle run <dir> -- --preview-mode
+//!      127.0.0.1:<port>` (mirroring `src/compiler.zig`'s subprocess
+//!      pattern), and transitions to `listening`.
+//!   2. `poll()` is called every frame. While `listening`, it non-blockingly
+//!      accept()s; on a hit it transitions to `connecting`, then to
+//!      `running` once a `hello` arrives. After `connecting_timeout_ms`
+//!      with no client the child is killed and we land in `crashed`.
+//!   3. While `running`, `poll()` drains any newline-delimited JSON the
+//!      engine sent (`heartbeat`, `bye`, or unknown — which we ignore on
+//!      purpose so Phase 2+ kinds don't break the editor). EOF without a
+//!      `bye` → `crashed`. `bye` → `stopped`.
+//!   4. `stop()` closes the stream, SIGTERMs the child, waits, transitions
+//!      to `stopped`.
+//!
+//! Mock-friendly by design: the JSON message types live in `Message` so
+//! the state-machine tests can drive transitions by feeding raw bytes
+//! through `feedBytesForTest`. The end-to-end smoke against `labelle run
+//! -- --preview-mode` is manual — sibling repos (#94, #193) haven't
+//! landed it yet.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const project = @import("project.zig");
+
+/// Lifecycle of one preview session. Strictly monotonic except for the
+/// terminal `stopped`/`crashed` → `idle` reset that `stop()` does so the
+/// user can press Run again.
+pub const State = enum {
+    idle,
+    /// Listener is up, child is spawned, awaiting accept().
+    listening,
+    /// Client connected, waiting for `hello` frame.
+    connecting,
+    /// `hello` received; heartbeats are flowing.
+    running,
+    /// Stream EOFed before a `bye` arrived, or the connect timeout fired.
+    crashed,
+    /// Clean shutdown — engine sent `bye` and disconnected, or user
+    /// pressed Stop.
+    stopped,
+};
+
+pub const PreviewError = error{
+    NoProjectPath,
+    LauncherNotFound,
+    AlreadyRunning,
+    OutOfMemory,
+};
+
+/// Wire-protocol message kinds. We only enumerate what Phase 1 needs;
+/// unknown kinds parse into `unknown` via `kind_tag` and are dropped.
+/// These structs serve both as the JSON parse target *and* as the
+/// owned-fields payload `handleFrame` consumes — strings inside are
+/// always heap-allocated copies (see `parseKind`) so the session can
+/// hold them across the parse-arena teardown.
+pub const Hello = struct {
+    engine_version: ?[]u8 = null,
+    pid: ?i64 = null,
+    protocol_version: ?i64 = null,
+};
+
+pub const Heartbeat = struct {
+    t: ?i64 = null,
+};
+
+pub const Bye = struct {
+    reason: ?[]u8 = null,
+};
+
+/// How long we wait between spawning the child and getting an accept()
+/// before declaring failure. Engine cold-start is dominated by package
+/// cache resolution and build, so 2s is generous for the simple case
+/// but real `labelle run` builds may need longer — bump if false
+/// crashes show up in the field.
+pub const connecting_timeout_ms: i64 = 2_000;
+
+/// Cap on a single message frame size. Generous because the engine's
+/// hello may eventually carry richer metadata; tight enough that a
+/// runaway producer can't OOM the editor.
+const max_frame_bytes: usize = 64 * 1024;
+
+/// Read buffer growth chunk. One heartbeat is ~30 bytes, hellos are
+/// ~100. A small chunk keeps per-frame syscalls quick without
+/// re-allocating on every line.
+const read_chunk: usize = 1024;
+
+pub const PreviewSession = struct {
+    allocator: std.mem.Allocator,
+    state: State,
+
+    server: ?std.net.Server,
+    child: ?std.process.Child,
+    stream: ?std.net.Stream,
+
+    /// Port the kernel assigned at bind time. Captured so the test
+    /// harness and the UI can both display it.
+    port: ?u16,
+    engine_pid: ?i64,
+    /// Wall-clock milliseconds (std.time.milliTimestamp()) the last
+    /// heartbeat (or hello) arrived. Used by the panel to render
+    /// "X ms ago".
+    last_heartbeat_ms: ?i64,
+    /// Reported by the engine's hello; allocated in `allocator`.
+    engine_version: ?[]u8,
+    /// Reason carried by `bye`; allocated in `allocator`.
+    bye_reason: ?[]u8,
+
+    /// Timestamp when the listener went up; used to enforce the
+    /// connect-out timeout while in `listening`/`connecting`.
+    started_ms: ?i64,
+
+    /// Sliding buffer of bytes pulled from `stream`. We split on '\n'
+    /// inside `drainStream`; partial frames stay here until completed
+    /// next frame.
+    rx_buf: std.ArrayList(u8),
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{
+            .allocator = allocator,
+            .state = .idle,
+            .server = null,
+            .child = null,
+            .stream = null,
+            .port = null,
+            .engine_pid = null,
+            .last_heartbeat_ms = null,
+            .engine_version = null,
+            .bye_reason = null,
+            .started_ms = null,
+            .rx_buf = .{},
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.teardown();
+        self.rx_buf.deinit(self.allocator);
+    }
+
+    /// Spawn a preview run for `proj`. Mirrors `Compiler.buildOrRun`'s
+    /// shape: validate the project path, set up the IPC plumbing, spawn
+    /// the launcher, return — the caller polls `poll()` each frame.
+    pub fn start(self: *Self, proj: *const project.Project) PreviewError!void {
+        if (self.state == .listening or self.state == .connecting or self.state == .running) {
+            return error.AlreadyRunning;
+        }
+        const dir = proj.dir orelse return error.NoProjectPath;
+
+        // Reset terminal state from the previous run.
+        self.resetForRestart();
+
+        const addr = std.net.Address.parseIp("127.0.0.1", 0) catch return error.OutOfMemory;
+        var server = std.net.Address.listen(addr, .{
+            .reuse_address = true,
+            .force_nonblocking = true,
+        }) catch |err| {
+            std.log.err("preview: listen failed: {s}", .{@errorName(err)});
+            return error.LauncherNotFound;
+        };
+        errdefer server.deinit();
+
+        const assigned_port = server.listen_address.getPort();
+
+        // `labelle run <dir> -- --preview-mode 127.0.0.1:<port>` — the
+        // `--` passthrough is implemented in labelle-cli#193 (sibling
+        // PR). Until that lands, `labelle run` will still spawn the
+        // child but the engine won't know to connect back; the
+        // connect-timeout path is what catches that.
+        var port_buf: [32]u8 = undefined;
+        const target = std.fmt.bufPrint(&port_buf, "127.0.0.1:{d}", .{assigned_port}) catch unreachable;
+
+        var child = std.process.Child.init(&.{
+            "labelle", "run", dir, "--", "--preview-mode", target,
+        }, self.allocator);
+        child.stdin_behavior = .Ignore;
+        child.stdout_behavior = .Inherit;
+        child.stderr_behavior = .Inherit;
+
+        child.spawn() catch |err| switch (err) {
+            error.FileNotFound => return error.LauncherNotFound,
+            else => {
+                std.log.err("preview: spawn failed: {s}", .{@errorName(err)});
+                return error.LauncherNotFound;
+            },
+        };
+
+        self.server = server;
+        self.child = child;
+        self.port = assigned_port;
+        self.started_ms = std.time.milliTimestamp();
+        self.state = .listening;
+    }
+
+    /// Cooperatively shut down: close stream, SIGTERM child, wait. Safe
+    /// to call from any non-`idle` state. After this returns the session
+    /// is in `.stopped` (or stays in `.crashed` if it was already crashed).
+    pub fn stop(self: *Self) void {
+        self.teardownChildAndIo();
+        if (self.state != .crashed) self.state = .stopped;
+    }
+
+    /// Returns true if the session is currently driving a running
+    /// preview. Useful for menu enabling.
+    pub fn isActive(self: *const Self) bool {
+        return switch (self.state) {
+            .listening, .connecting, .running => true,
+            else => false,
+        };
+    }
+
+    /// Per-frame tick. Drives accept on `listening`, hello-wait on
+    /// `connecting`, and message drain on `running`. Bounded work per
+    /// call — never blocks.
+    pub fn poll(self: *Self) void {
+        switch (self.state) {
+            .idle, .stopped, .crashed => return,
+            .listening => self.tickListening(),
+            .connecting, .running => self.tickStream(),
+        }
+    }
+
+    // ─── State driving ─────────────────────────────────────────────────
+
+    fn tickListening(self: *Self) void {
+        if (self.server == null) {
+            self.state = .crashed;
+            return;
+        }
+        const srv: *std.net.Server = &self.server.?;
+
+        const conn = srv.accept() catch |err| switch (err) {
+            error.WouldBlock => {
+                self.checkConnectTimeout();
+                return;
+            },
+            else => {
+                std.log.err("preview: accept failed: {s}", .{@errorName(err)});
+                self.failWithCrash();
+                return;
+            },
+        };
+
+        // Once a client is in, the listener is done — we only accept
+        // one preview connection per session (#59 punts multi-session).
+        srv.deinit();
+        self.server = null;
+
+        setNonBlock(conn.stream.handle) catch |err| {
+            std.log.err("preview: NONBLOCK on stream failed: {s}", .{@errorName(err)});
+            conn.stream.close();
+            self.failWithCrash();
+            return;
+        };
+
+        self.stream = conn.stream;
+        self.state = .connecting;
+    }
+
+    fn tickStream(self: *Self) void {
+        const stream = self.stream orelse {
+            self.failWithCrash();
+            return;
+        };
+
+        // Drain whatever's available, then split lines.
+        var buf: [read_chunk]u8 = undefined;
+        while (true) {
+            const n = stream.read(&buf) catch |err| switch (err) {
+                error.WouldBlock => break,
+                else => {
+                    std.log.err("preview: read failed: {s}", .{@errorName(err)});
+                    self.failWithCrash();
+                    return;
+                },
+            };
+            if (n == 0) {
+                // EOF. If we've already seen a `bye` (`bye_reason` set
+                // and we transitioned to .stopped), nothing to do.
+                if (self.state == .running) {
+                    self.failWithCrash();
+                }
+                return;
+            }
+            self.rx_buf.appendSlice(self.allocator, buf[0..n]) catch {
+                self.failWithCrash();
+                return;
+            };
+            if (self.rx_buf.items.len > max_frame_bytes) {
+                std.log.err("preview: rx buffer exceeded {d} bytes", .{max_frame_bytes});
+                self.failWithCrash();
+                return;
+            }
+        }
+
+        self.consumeFrames();
+
+        if (self.state == .connecting) self.checkConnectTimeout();
+    }
+
+    fn consumeFrames(self: *Self) void {
+        var consumed: usize = 0;
+        while (true) {
+            const rest = self.rx_buf.items[consumed..];
+            const nl = std.mem.indexOfScalar(u8, rest, '\n') orelse break;
+            const line = rest[0..nl];
+            self.handleFrame(line);
+            consumed += nl + 1;
+            if (self.state == .stopped or self.state == .crashed) break;
+        }
+        if (consumed > 0) {
+            const remaining = self.rx_buf.items.len - consumed;
+            std.mem.copyForwards(u8, self.rx_buf.items[0..remaining], self.rx_buf.items[consumed..]);
+            self.rx_buf.shrinkRetainingCapacity(remaining);
+        }
+    }
+
+    fn handleFrame(self: *Self, raw: []const u8) void {
+        const trimmed = std.mem.trim(u8, raw, " \t\r");
+        if (trimmed.len == 0) return;
+
+        const kind = parseKind(self.allocator, trimmed) catch |err| {
+            std.log.warn("preview: bad frame ({s}): {s}", .{ @errorName(err), trimmed });
+            return;
+        };
+
+        // `parseKind` returns string fields already dup'd in
+        // `self.allocator`; we take ownership here (or free if we're
+        // not keeping them). Don't double-dupe.
+        switch (kind) {
+            .hello => |h| {
+                self.last_heartbeat_ms = std.time.milliTimestamp();
+                self.engine_pid = h.pid;
+                if (self.engine_version) |old| self.allocator.free(old);
+                self.engine_version = h.engine_version;
+                self.state = .running;
+            },
+            .heartbeat => {
+                if (self.state == .running) self.last_heartbeat_ms = std.time.milliTimestamp();
+            },
+            .bye => |b| {
+                if (self.bye_reason) |old| self.allocator.free(old);
+                self.bye_reason = b.reason orelse (self.allocator.dupe(u8, "normal") catch null);
+                // Treat bye as authoritative — engines that disconnect
+                // immediately after bye get the same `stopped` state
+                // as ones that keep the stream open for a few more ms.
+                self.cleanShutdown();
+            },
+            .unknown => {},
+        }
+    }
+
+    // ─── Lifecycle helpers ─────────────────────────────────────────────
+
+    fn checkConnectTimeout(self: *Self) void {
+        const started = self.started_ms orelse return;
+        const now = std.time.milliTimestamp();
+        if (now - started > connecting_timeout_ms) {
+            std.log.err("preview: timeout waiting for engine to connect", .{});
+            self.failWithCrash();
+        }
+    }
+
+    fn failWithCrash(self: *Self) void {
+        self.teardownChildAndIo();
+        self.state = .crashed;
+    }
+
+    fn cleanShutdown(self: *Self) void {
+        self.teardownChildAndIo();
+        self.state = .stopped;
+    }
+
+    fn teardown(self: *Self) void {
+        self.teardownChildAndIo();
+        self.freeStrings();
+    }
+
+    fn teardownChildAndIo(self: *Self) void {
+        if (self.stream) |s| {
+            s.close();
+            self.stream = null;
+        }
+        if (self.server) |*srv| {
+            srv.deinit();
+            self.server = null;
+        }
+        if (self.child) |*c| {
+            _ = c.kill() catch {};
+            self.child = null;
+        }
+    }
+
+    fn freeStrings(self: *Self) void {
+        if (self.engine_version) |v| {
+            self.allocator.free(v);
+            self.engine_version = null;
+        }
+        if (self.bye_reason) |r| {
+            self.allocator.free(r);
+            self.bye_reason = null;
+        }
+    }
+
+    fn resetForRestart(self: *Self) void {
+        self.teardownChildAndIo();
+        self.freeStrings();
+        self.rx_buf.clearRetainingCapacity();
+        self.port = null;
+        self.engine_pid = null;
+        self.last_heartbeat_ms = null;
+        self.started_ms = null;
+        self.state = .idle;
+    }
+
+    // ─── Testing surface ───────────────────────────────────────────────
+
+    /// Mock-server entry point. The test harness drives one or more
+    /// frames into a `PreviewSession` that's already wired to a real
+    /// loopback `Stream` (no child process). Lets the state-machine
+    /// tests skip launcher invocation entirely.
+    pub fn attachForTest(self: *Self, stream: std.net.Stream) !void {
+        self.resetForRestart();
+        try setNonBlock(stream.handle);
+        self.stream = stream;
+        self.started_ms = std.time.milliTimestamp();
+        self.state = .connecting;
+    }
+};
+
+/// Tagged-union projection over the protocol's `kind` field. Unknown
+/// kinds become `.unknown` rather than failing so the engine can grow
+/// Phase 2+ messages without breaking us.
+const Message = union(enum) {
+    hello: Hello,
+    heartbeat: Heartbeat,
+    bye: Bye,
+    unknown,
+};
+
+/// Parse-time mirrors of the wire structs — fields are `?[]const u8`
+/// because the JSON parser hands back arena-owned slices. We dupe out
+/// of the parse arena into `allocator` before returning the `Message`.
+const HelloRaw = struct {
+    engine_version: ?[]const u8 = null,
+    pid: ?i64 = null,
+    protocol_version: ?i64 = null,
+};
+const ByeRaw = struct {
+    reason: ?[]const u8 = null,
+};
+
+fn parseKind(allocator: std.mem.Allocator, raw: []const u8) !Message {
+    // Peek the `kind` field via Value so a missing-or-typo `kind` gives
+    // us a structured error rather than a parse failure that aborts.
+    // The body fields are then parsed via typed structs with
+    // `ignore_unknown_fields = true`.
+    var parsed_dyn = try std.json.parseFromSlice(std.json.Value, allocator, raw, .{});
+    defer parsed_dyn.deinit();
+
+    const obj = switch (parsed_dyn.value) {
+        .object => |o| o,
+        else => return error.UnexpectedToken,
+    };
+    const kind_val = obj.get("kind") orelse return error.MissingField;
+    const kind_str = switch (kind_val) {
+        .string => |s| s,
+        else => return error.UnexpectedToken,
+    };
+
+    if (std.mem.eql(u8, kind_str, "hello")) {
+        const p = try std.json.parseFromSlice(HelloRaw, allocator, raw, .{ .ignore_unknown_fields = true });
+        defer p.deinit();
+        const ev: ?[]u8 = if (p.value.engine_version) |v| try allocator.dupe(u8, v) else null;
+        return .{ .hello = .{ .engine_version = ev, .pid = p.value.pid, .protocol_version = p.value.protocol_version } };
+    } else if (std.mem.eql(u8, kind_str, "heartbeat")) {
+        const p = try std.json.parseFromSlice(Heartbeat, allocator, raw, .{ .ignore_unknown_fields = true });
+        defer p.deinit();
+        return .{ .heartbeat = .{ .t = p.value.t } };
+    } else if (std.mem.eql(u8, kind_str, "bye")) {
+        const p = try std.json.parseFromSlice(ByeRaw, allocator, raw, .{ .ignore_unknown_fields = true });
+        defer p.deinit();
+        const r: ?[]u8 = if (p.value.reason) |v| try allocator.dupe(u8, v) else null;
+        return .{ .bye = .{ .reason = r } };
+    }
+    return .unknown;
+}
+
+/// Put a socket fd into non-blocking mode. Mirrors what
+/// `posix.socket(SOCK.NONBLOCK)` does for listeners, except we need to
+/// apply it after `accept()` returned a fresh fd. On Windows, would-be
+/// callers go through ioctlsocket; the editor only runs on POSIX hosts
+/// for now (raylib + zglfw on Win64 is supported but the preview path
+/// hasn't been exercised there).
+fn setNonBlock(fd: std.posix.fd_t) !void {
+    if (builtin.os.tag == .windows) {
+        // POSIX-only for now. Phase 2 can add the WSAIoctl call if a
+        // Windows user surfaces.
+        return;
+    }
+    const flags = try std.posix.fcntl(fd, std.posix.F.GETFL, 0);
+    const new_flags = flags | (1 << @bitOffsetOf(std.posix.O, "NONBLOCK"));
+    _ = try std.posix.fcntl(fd, std.posix.F.SETFL, new_flags);
+}

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -14,7 +14,7 @@
 //!      engine sent (`heartbeat`, `bye`, or unknown — which we ignore on
 //!      purpose so Phase 2+ kinds don't break the editor). EOF without a
 //!      `bye` → `crashed`. `bye` → `stopped`.
-//!   4. `stop()` closes the stream, SIGTERMs the child, waits, transitions
+//!   4. `stop()` closes the stream, SIGKILLs the child, waits, transitions
 //!      to `stopped`.
 //!
 //! Mock-friendly by design: the JSON message types live in `Message` so
@@ -197,9 +197,9 @@ pub const PreviewSession = struct {
         self.state = .listening;
     }
 
-    /// Cooperatively shut down: close stream, SIGTERM child, wait. Safe
-    /// to call from any non-`idle` state. After this returns the session
-    /// is in `.stopped` (or stays in `.crashed` if it was already crashed).
+    /// Cooperatively shut down: close stream, SIGKILL child, wait. Safe
+    /// to call from any state. After this returns the session is in
+    /// `.stopped` (or stays in `.crashed` if it was already crashed).
     pub fn stop(self: *Self) void {
         self.teardownChildAndIo();
         if (self.state != .crashed) self.state = .stopped;
@@ -443,27 +443,15 @@ const Message = union(enum) {
     unknown,
 };
 
-/// Parse-time mirrors of the wire structs — fields are `?[]const u8`
-/// because the JSON parser hands back arena-owned slices. We dupe out
-/// of the parse arena into `allocator` before returning the `Message`.
-const HelloRaw = struct {
-    engine_version: ?[]const u8 = null,
-    pid: ?i64 = null,
-    protocol_version: ?i64 = null,
-};
-const ByeRaw = struct {
-    reason: ?[]const u8 = null,
-};
-
 fn parseKind(allocator: std.mem.Allocator, raw: []const u8) !Message {
-    // Peek the `kind` field via Value so a missing-or-typo `kind` gives
-    // us a structured error rather than a parse failure that aborts.
-    // The body fields are then parsed via typed structs with
-    // `ignore_unknown_fields = true`.
-    var parsed_dyn = try std.json.parseFromSlice(std.json.Value, allocator, raw, .{});
-    defer parsed_dyn.deinit();
+    // Single parse to `Value`; `kind` and all body fields are read from
+    // the same object so we avoid a second `parseFromSlice` per message.
+    // String fields that the session needs to own across the parse-arena
+    // teardown are duped into `allocator` before we return.
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, raw, .{});
+    defer parsed.deinit();
 
-    const obj = switch (parsed_dyn.value) {
+    const obj = switch (parsed.value) {
         .object => |o| o,
         else => return error.UnexpectedToken,
     };
@@ -474,18 +462,30 @@ fn parseKind(allocator: std.mem.Allocator, raw: []const u8) !Message {
     };
 
     if (std.mem.eql(u8, kind_str, "hello")) {
-        const p = try std.json.parseFromSlice(HelloRaw, allocator, raw, .{ .ignore_unknown_fields = true });
-        defer p.deinit();
-        const ev: ?[]u8 = if (p.value.engine_version) |v| try allocator.dupe(u8, v) else null;
-        return .{ .hello = .{ .engine_version = ev, .pid = p.value.pid, .protocol_version = p.value.protocol_version } };
+        const ev: ?[]u8 = if (obj.get("engine_version")) |v| switch (v) {
+            .string => |s| try allocator.dupe(u8, s),
+            else => null,
+        } else null;
+        const pid: ?i64 = if (obj.get("pid")) |v| switch (v) {
+            .integer => |n| n,
+            else => null,
+        } else null;
+        const protocol_version: ?i64 = if (obj.get("protocol_version")) |v| switch (v) {
+            .integer => |n| n,
+            else => null,
+        } else null;
+        return .{ .hello = .{ .engine_version = ev, .pid = pid, .protocol_version = protocol_version } };
     } else if (std.mem.eql(u8, kind_str, "heartbeat")) {
-        const p = try std.json.parseFromSlice(Heartbeat, allocator, raw, .{ .ignore_unknown_fields = true });
-        defer p.deinit();
-        return .{ .heartbeat = .{ .t = p.value.t } };
+        const t: ?i64 = if (obj.get("t")) |v| switch (v) {
+            .integer => |n| n,
+            else => null,
+        } else null;
+        return .{ .heartbeat = .{ .t = t } };
     } else if (std.mem.eql(u8, kind_str, "bye")) {
-        const p = try std.json.parseFromSlice(ByeRaw, allocator, raw, .{ .ignore_unknown_fields = true });
-        defer p.deinit();
-        const r: ?[]u8 = if (p.value.reason) |v| try allocator.dupe(u8, v) else null;
+        const r: ?[]u8 = if (obj.get("reason")) |v| switch (v) {
+            .string => |s| try allocator.dupe(u8, s),
+            else => null,
+        } else null;
         return .{ .bye = .{ .reason = r } };
     }
     return .unknown;

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -48,6 +48,11 @@ pub const State = enum {
 pub const PreviewError = error{
     NoProjectPath,
     LauncherNotFound,
+    /// The loopback listener couldn't bind a port (kernel out of
+    /// ephemeral ports, permission denied, etc.) — distinct from
+    /// `LauncherNotFound` so the UI can surface "OS resources" vs
+    /// "labelle not on PATH" without guessing.
+    ListenFailed,
     AlreadyRunning,
     OutOfMemory,
 };
@@ -161,7 +166,7 @@ pub const PreviewSession = struct {
             .force_nonblocking = true,
         }) catch |err| {
             std.log.err("preview: listen failed: {s}", .{@errorName(err)});
-            return error.LauncherNotFound;
+            return error.ListenFailed;
         };
         errdefer server.deinit();
 
@@ -280,9 +285,16 @@ pub const PreviewSession = struct {
                 },
             };
             if (n == 0) {
-                // EOF. If we've already seen a `bye` (`bye_reason` set
-                // and we transitioned to .stopped), nothing to do.
-                if (self.state == .running) {
+                // EOF. Flush whatever's already buffered first — the
+                // engine's common shutdown path is "write `bye`, then
+                // close the socket", so we must parse that `bye`
+                // before deciding the session crashed. After
+                // `consumeFrames`, state will be `.stopped` (clean bye)
+                // or unchanged. If we're still `.running` or
+                // `.connecting`, treat the EOF as a crash; staying in
+                // `.connecting` would just spin until the 2s timeout.
+                self.consumeFrames();
+                if (self.state == .running or self.state == .connecting) {
                     self.failWithCrash();
                 }
                 return;
@@ -391,7 +403,12 @@ pub const PreviewSession = struct {
             self.server = null;
         }
         if (self.child) |*c| {
+            // SIGKILL + reap. `wait()` is required after `kill()` to
+            // collect the exit status — otherwise the child becomes a
+            // zombie until the editor exits, and a long-running editor
+            // that runs many preview sessions would accumulate them.
             _ = c.kill() catch {};
+            _ = c.wait() catch {};
             self.child = null;
         }
     }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -13,6 +13,7 @@ const viewport = @import("modules/viewport.zig");
 const atlas = @import("atlas.zig");
 const gizmo_io = @import("gizmo_io.zig");
 const gizmos = @import("gizmos.zig");
+const preview = @import("preview.zig");
 
 test {
     zspec.runAll(@This());
@@ -2248,5 +2249,242 @@ pub const GizmosIndexTests = struct {
         idx.deinit();
         // Reaching here without leaks (std.testing.allocator is the
         // GPA) is the assertion.
+    }
+};
+
+/// Exercises the preview-mode TCP session's state machine without
+/// spawning `labelle run` (sibling agents are still landing #94 / #193
+/// for the launcher side). Each test sets up a tiny pair of connected
+/// sockets on loopback — the editor's `PreviewSession` reads from one,
+/// the test acts as a mock engine on the other.
+///
+/// Loopback delivery is "eventually" synchronous on macOS/Linux —
+/// kernel sometimes wants a microsecond to make a `writeAll` from one
+/// end visible to a non-blocking `read` on the other. `pollUntilState`
+/// retries `poll()` for a bounded budget (200ms) rather than guessing
+/// the right `Thread.sleep` value.
+pub const PreviewSessionTests = struct {
+    /// Drive `poll()` in a tight loop until the session's state
+    /// reaches `target` or 200ms elapses. Returns true if reached.
+    fn pollUntilState(s: *preview.PreviewSession, target: preview.State) bool {
+        const deadline = std.time.milliTimestamp() + 200;
+        while (std.time.milliTimestamp() < deadline) {
+            s.poll();
+            if (s.state == target) return true;
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+        }
+        return s.state == target;
+    }
+
+    /// Helper: build a connected pair (server stream + client stream)
+    /// on `127.0.0.1:0`. Returns the *client* side as the engine-mock
+    /// and *server* side as what `attachForTest` consumes (i.e. the
+    /// thing the editor would have got from `accept`).
+    const Pair = struct {
+        server: std.net.Server,
+        editor_side: std.net.Stream,
+        /// Optional so tests that need to deliberately close it early
+        /// (EOF/crash test) can nil it out and avoid the double-close
+        /// from `close()`'s teardown.
+        engine_side: ?std.net.Stream,
+
+        fn make() !Pair {
+            const addr = try std.net.Address.parseIp("127.0.0.1", 0);
+            var server = try std.net.Address.listen(addr, .{ .reuse_address = true });
+            errdefer server.deinit();
+            const engine = try std.net.tcpConnectToAddress(server.listen_address);
+            errdefer engine.close();
+            const editor_conn = try server.accept();
+            return .{ .server = server, .editor_side = editor_conn.stream, .engine_side = engine };
+        }
+
+        fn closeEngine(self: *Pair) void {
+            if (self.engine_side) |s| {
+                s.close();
+                self.engine_side = null;
+            }
+        }
+
+        fn close(self: *Pair) void {
+            self.closeEngine();
+            // editor_side is owned by the session after attach.
+            self.server.deinit();
+        }
+
+        fn write(self: *Pair, bytes: []const u8) !void {
+            try (self.engine_side orelse return error.EngineClosed).writeAll(bytes);
+        }
+    };
+
+    test "initializes in idle state" {
+        const allocator = std.testing.allocator;
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try expect.equal(s.state, .idle);
+    }
+
+    test "isActive false in idle/stopped/crashed" {
+        const allocator = std.testing.allocator;
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try expect.toBeFalse(s.isActive());
+    }
+
+    test "poll on idle is a no-op" {
+        const allocator = std.testing.allocator;
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        s.poll();
+        try expect.equal(s.state, .idle);
+    }
+
+    test "stop on idle leaves state stopped" {
+        const allocator = std.testing.allocator;
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        s.stop();
+        try expect.equal(s.state, .stopped);
+    }
+
+    test "hello transitions connecting → running" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+        try expect.equal(s.state, .connecting);
+
+        try pair.write(
+            \\{"kind":"hello","engine_version":"1.2.3","pid":424242,"protocol_version":1}
+            ++ "\n");
+
+        try expect.toBeTrue(pollUntilState(&s, .running));
+        try expect.equal(s.engine_pid.?, 424242);
+        try expect.toBeTrue(s.engine_version != null);
+        try expect.toBeTrue(std.mem.eql(u8, s.engine_version.?, "1.2.3"));
+    }
+
+    test "heartbeat updates last_heartbeat_ms" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+
+        try pair.write(
+            \\{"kind":"hello","engine_version":"x","pid":1,"protocol_version":1}
+            ++ "\n");
+        try expect.toBeTrue(pollUntilState(&s, .running));
+        const t0 = s.last_heartbeat_ms.?;
+
+        // Force a measurable gap so the heartbeat timestamp moves.
+        std.Thread.sleep(2 * std.time.ns_per_ms);
+
+        try pair.write(
+            \\{"kind":"heartbeat","t":847291}
+            ++ "\n");
+        // Drain a few polls so the heartbeat arrives.
+        var i: usize = 0;
+        while (i < 10) : (i += 1) {
+            s.poll();
+            if (s.last_heartbeat_ms.? > t0) break;
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+        }
+        try expect.toBeTrue(s.last_heartbeat_ms.? >= t0);
+        try expect.equal(s.state, .running);
+    }
+
+    test "bye transitions to stopped" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+        try pair.write(
+            \\{"kind":"hello","engine_version":"x","pid":1,"protocol_version":1}
+            ++ "\n" ++
+            \\{"kind":"bye","reason":"user_quit"}
+            ++ "\n");
+        try expect.toBeTrue(pollUntilState(&s, .stopped));
+        try expect.toBeTrue(s.bye_reason != null);
+        try expect.toBeTrue(std.mem.eql(u8, s.bye_reason.?, "user_quit"));
+    }
+
+    test "EOF without bye transitions to crashed" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+        try pair.write(
+            \\{"kind":"hello","engine_version":"x","pid":1,"protocol_version":1}
+            ++ "\n");
+        try expect.toBeTrue(pollUntilState(&s, .running));
+
+        // Close the engine side without sending bye → editor should
+        // see EOF on next poll.
+        pair.closeEngine();
+        try expect.toBeTrue(pollUntilState(&s, .crashed));
+    }
+
+    test "unknown kind is ignored (forward-compat)" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+        try pair.write(
+            \\{"kind":"hello","engine_version":"x","pid":1,"protocol_version":1}
+            ++ "\n" ++
+            \\{"kind":"future_message","whatever":42}
+            ++ "\n" ++
+            \\{"kind":"heartbeat","t":1}
+            ++ "\n");
+        try expect.toBeTrue(pollUntilState(&s, .running));
+    }
+
+    test "malformed JSON line is dropped without crashing" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+        try pair.write(
+            \\{"kind":"hello","engine_version":"x","pid":1,"protocol_version":1}
+            ++ "\n" ++
+            "this is not json at all\n" ++
+            \\{"kind":"heartbeat","t":1}
+            ++ "\n");
+        try expect.toBeTrue(pollUntilState(&s, .running));
+    }
+
+    test "stop after running transitions to stopped" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+        try pair.write(
+            \\{"kind":"hello","engine_version":"x","pid":1,"protocol_version":1}
+            ++ "\n");
+        try expect.toBeTrue(pollUntilState(&s, .running));
+
+        s.stop();
+        try expect.equal(s.state, .stopped);
+        try expect.toBeFalse(s.isActive());
     }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2416,6 +2416,52 @@ pub const PreviewSessionTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, s.bye_reason.?, "user_quit"));
     }
 
+    test "bye followed by EOF still lands in stopped (regression #62)" {
+        // Engines commonly write `bye` and then immediately close the
+        // socket. If the EOF branch returns early without draining the
+        // already-buffered `bye`, the session lands in `.crashed`.
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+        try pair.write(
+            \\{"kind":"hello","engine_version":"x","pid":1,"protocol_version":1}
+            ++ "\n" ++
+            \\{"kind":"bye","reason":"user_quit"}
+            ++ "\n");
+        // Close the engine side right after writing bye — depending on
+        // kernel scheduling, the editor's first `read` may return both
+        // the buffered bytes and trigger EOF on the next read in the
+        // same `tickStream` call.
+        pair.closeEngine();
+        try expect.toBeTrue(pollUntilState(&s, .stopped));
+        try expect.toBeTrue(s.bye_reason != null);
+        try expect.toBeTrue(std.mem.eql(u8, s.bye_reason.?, "user_quit"));
+    }
+
+    test "EOF during connecting transitions to crashed without timeout wait (regression #62)" {
+        // Engine connects then drops the socket before sending `hello`.
+        // Previously the session would stay `.connecting` and spin on
+        // EOF until the 2s connect-timeout fired. Now it should crash
+        // on the first EOF.
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try s.attachForTest(pair.editor_side);
+        try expect.equal(s.state, .connecting);
+
+        pair.closeEngine();
+        // 200ms budget is well under the 2s connect timeout, so if this
+        // passes we know we didn't fall through to `checkConnectTimeout`.
+        try expect.toBeTrue(pollUntilState(&s, .crashed));
+    }
+
     test "EOF without bye transitions to crashed" {
         const allocator = std.testing.allocator;
         var pair = try Pair.make();


### PR DESCRIPTION
## Summary

Editor-side wiring of the PIE preview umbrella (#59). Phase 1 from #61:

- **`src/preview.zig`** — new `PreviewSession` mirroring `src/compiler.zig`'s shape. State machine: `idle → listening → connecting → running → {crashed | stopped}`. Binds `127.0.0.1:0`, spawns `labelle run <dir> -- --preview-mode 127.0.0.1:<port>`, accepts the engine's connect-out, drains newline-delimited JSON (`hello` / `heartbeat` / `bye`). Connect timeout (~2s) catches the case where the launcher doesn't actually wire `--preview-mode` through yet (sibling repos #94/#193 still in flight). Unknown message kinds are dropped on purpose so Phase 2+ extensions don't break us (`ignore_unknown_fields = true`).
- **`src/modules/preview.zig`** — togglable panel module registered alongside the existing four. Status line + Run/Stop buttons. Surfaces engine PID, version, and "Xms ago" for the last heartbeat.
- **`src/app.zig`** — new `preview: PreviewSession` field (init/deinit in App lifetime), `poll()` ticked every frame, `Build > Run preview` and `Build > Stop preview` menu items.

## Test plan

- [x] `zig build` clean.
- [x] `zig build test` — 146/146 (was 135/135 on baseline; +11 PreviewSession state-machine tests covering hello → running, heartbeat refresh, bye → stopped, EOF → crashed, unknown/malformed kinds dropped, stop transitions).
- [x] `zig build gui-test` — 7/7 (was 6/6; +1 driving View > Preview toggle and the Stop path through `App.stopPreview`).
- [x] `zig build smoke` — fails identically to baseline (`labelle build` env issue, unrelated to this PR). Verified by checking out `main` and re-running.
- [ ] Manual end-to-end against the real `labelle run -- --preview-mode` — **deferred until labelle-cli#193 and labelle-assembler#94 land** (per #61).

## Out of scope (Phase 2+ of #59)

- No in-editor game rendering (texture-mirror)
- No selection sync, no breakpoints/pause/step
- No multi-session

## Coordination

Sibling agent on #48/#49 (Flows tab viewer) touches `src/app.zig` and `src/modules/project_tree.zig` in their worktree; conflicts will be mechanical (each PR adds its own module slot / OpenTab variant in a different switch arm). Whichever lands first will rebase the other.

Refs #61, umbrella #59. Locks in the protocol from #60.