### PR TITLE
Bump default version pins to match current toolkit

### DIFF
--- a/src/project.zig
+++ b/src/project.zig
@@ -72,10 +72,10 @@ pub const ProjectConfig = struct {
     backend: Backend = .raylib,
     ecs: EcsChoice = .zig_ecs,
     initial_scene: []const u8 = "main",
-    core_version: []const u8 = "1.10.0",
-    engine_version: []const u8 = "1.21.0",
-    gfx_version: []const u8 = "1.7.0",
-    assembler_version: []const u8 = "0.8.0",
+    core_version: []const u8 = "1.12.0",
+    engine_version: []const u8 = "1.35.0",
+    gfx_version: []const u8 = "1.10.0",
+    assembler_version: []const u8 = "0.17.0",
     /// Sprite atlas resources — name + JSON manifest + texture file. The
     /// engine consumes these via the generated `main.zig` (see assembler
     /// codegen). Defaults to empty; the editor adds entries.


### PR DESCRIPTION
The defaults in \`ProjectConfig\` had drifted badly. New projects created by the editor were inheriting an \`assembler_version\` of \`0.8.0\` — a release that predates several rounds of breaking changes — which is what triggered today's smoke harness failures (literal \`{{preview_setup}}\` showing up in the generated \`main.zig\` because the smoke harness pinned the stale default and hit template/binary skew with the local labelle-assembler PR #95 branch).

## Changes

| Field | Before | After |
|---|---|---|
| core_version | 1.10.0 | 1.12.0 |
| engine_version | 1.21.0 | 1.35.0 |
| gfx_version | 1.7.0 | 1.10.0 |
| assembler_version | 0.8.0 | 0.17.0 |

Source: \`../flying-platform-labelle/project.labelle\` (the toolkit's reference real-world project).

## Out of scope

- Sub-issue tracking the monorepo-mode template/binary skew that surfaced this — filed separately on labelle-cli.
- The "external project" zspec fixtures in \`src/tests.zig\` that hard-code the old version strings stay as-is — they exercise the verbatim pass-through reader, not the gui's defaults.

## Test plan

- [x] \`zig build\` clean
- [x] \`zig build test\` — 135/135 passing
- [x] \`zig build gui-test\` — 6/6 passing
- [ ] Smoke verification deferred — needs PR #95 (labelle-assembler) to merge + 0.17.0 reassembled before the cache binary matches the new templates