### PR TITLE
Split inspector.zig into per-component sections (#38)

### DIFF
--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -7,6 +7,18 @@
 //! "needs save" on its side — `SceneState.is_dirty` for scenes,
 //! `PrefabState.is_dirty` for prefabs. Any edit (Position input,
 //! comment change) flips it.
+//!
+//! Layout note: each typed-component section lives in its own file
+//! under `inspector/` and exposes a `section()` constructor that
+//! returns an `InspectorSection`. This file just walks the registry
+//! and dispatches — adding a new typed component is one new file +
+//! one line in the `sections` array. See issue #38 for the
+//! parallel-development motivation. The Module/Registry pattern in
+//! `../module.zig` is the template.
+//!
+//! The trailing "Other components (N)" group isn't a registry entry —
+//! it walks the `component_extras` slice rather than a typed `Entity`
+//! field, so it's special-cased as the closing block of `renderEntity`.
 
 const std = @import("std");
 const zgui = @import("zgui");
@@ -14,38 +26,26 @@ const zgui = @import("zgui");
 const scene_io = @import("../scene_io.zig");
 const atlas = @import("../atlas.zig");
 
-/// Canonical Sprite.pivot values, matching the engine's pivot enum
-/// and the order in `modules/viewport.zig:pivotOffset`. Index 0
-/// (`center`) is the default when the buffer is empty or unknown.
-const pivot_names = [_][]const u8{
-    "center",
-    "bottom_center",
-    "top_center",
-    "bottom_left",
-    "bottom_right",
-    "top_left",
-    "top_right",
-    "left_center",
-    "right_center",
-};
+pub const InspectorSection = @import("inspector/section.zig").InspectorSection;
 
-/// Zero-separated, zero-terminated form of `pivot_names` for
-/// `zgui.combo`'s `items_separated_by_zeros` argument. Built at
-/// comptime from `pivot_names` so the two lists can't drift.
-const pivot_items: [:0]const u8 = blk: {
-    var res: [:0]const u8 = "";
-    for (pivot_names) |name| {
-        res = res ++ name ++ "\x00";
-    }
-    break :blk res;
+/// Registry of typed-component sections, rendered in this order.
+/// Adding a new typed component: drop a file in `inspector/`, export
+/// `section()`, and append it here. No other files need to change.
+pub const sections = [_]InspectorSection{
+    @import("inspector/position.zig").section(),
+    @import("inspector/sprite.zig").section(),
+    @import("inspector/rectangle.zig").section(),
+    @import("inspector/circle.zig").section(),
+    @import("inspector/polygon.zig").section(),
+    @import("inspector/comment.zig").section(),
 };
 
 /// Render the editable surface for one entity:
 ///
 /// - Heading: prefab name (plus optional `Entity #N` label for scene
 ///   entities; pass `null` for the lone entity in a prefab).
-/// - `Position` collapsing header with x/y inputs.
-/// - `Comment` collapsing header with the multiline comment buffer.
+/// - One collapsing header per registered `InspectorSection` whose
+///   `is_present` returns true for `entity`.
 /// - `Other components (N)` group with a collapsing header per
 ///   unmodeled component, body shown verbatim (read-only for v1).
 ///
@@ -68,185 +68,12 @@ pub fn renderEntity(
     }
     zgui.spacing();
 
-    if (zgui.collapsingHeader("Position", .{ .default_open = true })) {
-        if (entity.position) |*pos| {
-            if (zgui.inputFloat("x", .{ .v = &pos.x })) is_dirty.* = true;
-            if (zgui.inputFloat("y", .{ .v = &pos.y })) is_dirty.* = true;
-        } else {
-            zgui.textDisabled("(no Position component)", .{});
-        }
-    }
-
-    if (entity.sprite) |sprite| {
-        if (zgui.collapsingHeader("Sprite", .{ .default_open = true })) {
-            if (zgui.inputText("sprite_name", .{ .buf = &sprite.sprite_name })) is_dirty.* = true;
-            // Resolve the typed sprite name against the project's
-            // atlas index; surface a soft `(missing)` hint when it
-            // doesn't match anything. Doesn't block edits — the
-            // engine ultimately decides what's valid; we just guide.
-            if (atlas_index) |idx| {
-                const name_str = std.mem.sliceTo(&sprite.sprite_name, 0);
-                if (name_str.len > 0 and idx.find(name_str) == null) {
-                    zgui.sameLine(.{});
-                    zgui.textColored(.{ 1.0, 0.5, 0.4, 1.0 }, "(missing)", .{});
-                }
-            }
-            // Pivot is a closed enum on the engine side — let the
-            // user pick from the 9 valid names rather than free-type.
-            // Order matches `pivotOffset` in modules/viewport.zig.
-            const current_pivot = std.mem.sliceTo(&sprite.pivot, 0);
-            var pivot_idx: i32 = for (pivot_names, 0..) |n, i| {
-                if (std.mem.eql(u8, current_pivot, n)) break @intCast(i);
-            } else 0;
-            if (zgui.combo("pivot", .{
-                .current_item = &pivot_idx,
-                .items_separated_by_zeros = pivot_items,
-            })) {
-                const chosen = pivot_names[@intCast(pivot_idx)];
-                @memset(&sprite.pivot, 0);
-                @memcpy(sprite.pivot[0..chosen.len], chosen);
-                is_dirty.* = true;
-            }
-            if (zgui.inputText("layer", .{ .buf = &sprite.layer })) is_dirty.* = true;
-
-            // z_index is optional in the source; the checkbox toggles
-            // whether we emit it at all. Editing the int alone (with
-            // the box unchecked) doesn't suddenly add a `"z_index"`
-            // key to the file — the user has to opt in explicitly.
-            if (zgui.checkbox("z_index?", .{ .v = &sprite.has_z_index })) is_dirty.* = true;
-            if (sprite.has_z_index) {
-                zgui.sameLine(.{});
-                if (zgui.inputInt("##z_index", .{ .v = &sprite.z_index })) is_dirty.* = true;
+    inline for (sections) |s| {
+        if (s.is_present(entity)) {
+            if (zgui.collapsingHeader(s.name, .{ .default_open = s.default_open })) {
+                s.render(entity, is_dirty, atlas_index);
             }
         }
-    }
-
-    if (entity.rectangle) |rect| {
-        if (zgui.collapsingHeader("Rectangle", .{ .default_open = true })) {
-            if (zgui.inputFloat("width", .{ .v = &rect.width })) is_dirty.* = true;
-            if (zgui.inputFloat("height", .{ .v = &rect.height })) is_dirty.* = true;
-
-            // Convert u8 RGBA to imgui's float-in-[0,1] color picker
-            // and back. The reverse conversion rounds to the nearest
-            // u8 so the source round-trip is stable across saves.
-            var col4: [4]f32 = .{
-                @as(f32, @floatFromInt(rect.r)) / 255.0,
-                @as(f32, @floatFromInt(rect.g)) / 255.0,
-                @as(f32, @floatFromInt(rect.b)) / 255.0,
-                @as(f32, @floatFromInt(rect.a)) / 255.0,
-            };
-            if (zgui.colorEdit4("color", .{ .col = &col4 })) {
-                // Clamp before casting: `@intFromFloat` is safety-checked
-                // and would panic on values outside `[0, 255]`, which can
-                // happen due to float precision or manual hex/int input.
-                rect.r = @intFromFloat(@round(std.math.clamp(col4[0] * 255.0, 0.0, 255.0)));
-                rect.g = @intFromFloat(@round(std.math.clamp(col4[1] * 255.0, 0.0, 255.0)));
-                rect.b = @intFromFloat(@round(std.math.clamp(col4[2] * 255.0, 0.0, 255.0)));
-                rect.a = @intFromFloat(@round(std.math.clamp(col4[3] * 255.0, 0.0, 255.0)));
-                is_dirty.* = true;
-            }
-            if (zgui.checkbox("filled", .{ .v = &rect.filled })) is_dirty.* = true;
-        }
-    }
-
-    if (entity.circle) |circle| {
-        if (zgui.collapsingHeader("Circle", .{ .default_open = true })) {
-            if (zgui.inputFloat("radius", .{ .v = &circle.radius })) is_dirty.* = true;
-
-            var col4: [4]f32 = .{
-                @as(f32, @floatFromInt(circle.r)) / 255.0,
-                @as(f32, @floatFromInt(circle.g)) / 255.0,
-                @as(f32, @floatFromInt(circle.b)) / 255.0,
-                @as(f32, @floatFromInt(circle.a)) / 255.0,
-            };
-            if (zgui.colorEdit4("color", .{ .col = &col4 })) {
-                circle.r = @intFromFloat(@round(col4[0] * 255.0));
-                circle.g = @intFromFloat(@round(col4[1] * 255.0));
-                circle.b = @intFromFloat(@round(col4[2] * 255.0));
-                circle.a = @intFromFloat(@round(col4[3] * 255.0));
-                is_dirty.* = true;
-            }
-            if (zgui.checkbox("filled", .{ .v = &circle.filled })) is_dirty.* = true;
-        }
-    }
-
-    if (entity.polygon) |poly| {
-        if (zgui.collapsingHeader("Polygon", .{ .default_open = true })) {
-            // Render the points as a numbered list. Each row carries
-            // two `inputFloat` widgets and a small `×` remove button.
-            // We walk by index because the remove path needs to
-            // shift the tail down (no realloc — fixed-cap inline
-            // buffer, see scene_io.Polygon).
-            var idx: u32 = 0;
-            // ImGui needs distinct IDs per row; push the index as a
-            // scope so the `x` / `y` / `×` labels can repeat.
-            while (idx < poly.point_count) {
-                zgui.pushIntId(@intCast(idx));
-                defer zgui.popId();
-
-                zgui.text("#{d}", .{idx});
-                zgui.sameLine(.{});
-                zgui.setNextItemWidth(80);
-                if (zgui.inputFloat("x", .{ .v = &poly.points[idx].x })) is_dirty.* = true;
-                zgui.sameLine(.{});
-                zgui.setNextItemWidth(80);
-                if (zgui.inputFloat("y", .{ .v = &poly.points[idx].y })) is_dirty.* = true;
-                zgui.sameLine(.{});
-
-                var removed = false;
-                if (zgui.smallButton("x##rm")) {
-                    // Shift the tail of the inline buffer down. Cheap:
-                    // the cap is small (64), and removal is rare.
-                    var k: u32 = idx;
-                    while (k + 1 < poly.point_count) : (k += 1) {
-                        poly.points[k] = poly.points[k + 1];
-                    }
-                    poly.point_count -= 1;
-                    poly.points[poly.point_count] = .{};
-                    is_dirty.* = true;
-                    removed = true;
-                }
-                if (!removed) idx += 1;
-            }
-
-            // Add-point button. Hidden when the buffer is at cap so
-            // the user can't drive past it silently.
-            if (poly.point_count < scene_io.polygon_max_points) {
-                if (zgui.button("+ Add point", .{})) {
-                    poly.points[poly.point_count] = .{};
-                    poly.point_count += 1;
-                    is_dirty.* = true;
-                }
-            } else {
-                zgui.textDisabled("(at cap: {d} points)", .{scene_io.polygon_max_points});
-            }
-
-            // Convert u8 RGBA to imgui's float color picker; same
-            // round-to-nearest reverse conversion as Sprite/Rectangle
-            // so the source round-trip is stable across saves.
-            var col4: [4]f32 = .{
-                @as(f32, @floatFromInt(poly.r)) / 255.0,
-                @as(f32, @floatFromInt(poly.g)) / 255.0,
-                @as(f32, @floatFromInt(poly.b)) / 255.0,
-                @as(f32, @floatFromInt(poly.a)) / 255.0,
-            };
-            if (zgui.colorEdit4("color", .{ .col = &col4 })) {
-                poly.r = @intFromFloat(@round(col4[0] * 255.0));
-                poly.g = @intFromFloat(@round(col4[1] * 255.0));
-                poly.b = @intFromFloat(@round(col4[2] * 255.0));
-                poly.a = @intFromFloat(@round(col4[3] * 255.0));
-                is_dirty.* = true;
-            }
-            if (zgui.checkbox("filled", .{ .v = &poly.filled })) is_dirty.* = true;
-        }
-    }
-
-    if (zgui.collapsingHeader("Comment", .{})) {
-        if (zgui.inputTextMultiline("##comment", .{
-            .buf = &entity.comment,
-            .w = 0,
-            .h = 80,
-        })) is_dirty.* = true;
     }
 
     if (component_extras.len > 0) {

--- a/src/modules/inspector/circle.zig
+++ b/src/modules/inspector/circle.zig
@@ -1,0 +1,44 @@
+//! Circle inspector section. Only renders when `entity.circle != null`.
+
+const zgui = @import("zgui");
+
+const scene_io = @import("../../scene_io.zig");
+const atlas = @import("../../atlas.zig");
+const InspectorSection = @import("section.zig").InspectorSection;
+
+fn isPresent(entity: *scene_io.Entity) bool {
+    return entity.circle != null;
+}
+
+fn render(
+    entity: *scene_io.Entity,
+    is_dirty: *bool,
+    _: ?*const atlas.Index,
+) void {
+    const circle = entity.circle.?;
+    if (zgui.inputFloat("radius", .{ .v = &circle.radius })) is_dirty.* = true;
+
+    var col4: [4]f32 = .{
+        @as(f32, @floatFromInt(circle.r)) / 255.0,
+        @as(f32, @floatFromInt(circle.g)) / 255.0,
+        @as(f32, @floatFromInt(circle.b)) / 255.0,
+        @as(f32, @floatFromInt(circle.a)) / 255.0,
+    };
+    if (zgui.colorEdit4("color", .{ .col = &col4 })) {
+        circle.r = @intFromFloat(@round(col4[0] * 255.0));
+        circle.g = @intFromFloat(@round(col4[1] * 255.0));
+        circle.b = @intFromFloat(@round(col4[2] * 255.0));
+        circle.a = @intFromFloat(@round(col4[3] * 255.0));
+        is_dirty.* = true;
+    }
+    if (zgui.checkbox("filled", .{ .v = &circle.filled })) is_dirty.* = true;
+}
+
+pub fn section() InspectorSection {
+    return .{
+        .name = "Circle",
+        .default_open = true,
+        .is_present = isPresent,
+        .render = render,
+    };
+}

--- a/src/modules/inspector/comment.zig
+++ b/src/modules/inspector/comment.zig
@@ -1,0 +1,34 @@
+//! Comment inspector section. Always present — the comment buffer
+//! lives on `Entity` itself (not behind an optional), so the section
+//! shows up for every entity. Defaults to collapsed.
+
+const zgui = @import("zgui");
+
+const scene_io = @import("../../scene_io.zig");
+const atlas = @import("../../atlas.zig");
+const InspectorSection = @import("section.zig").InspectorSection;
+
+fn isPresent(_: *scene_io.Entity) bool {
+    return true;
+}
+
+fn render(
+    entity: *scene_io.Entity,
+    is_dirty: *bool,
+    _: ?*const atlas.Index,
+) void {
+    if (zgui.inputTextMultiline("##comment", .{
+        .buf = &entity.comment,
+        .w = 0,
+        .h = 80,
+    })) is_dirty.* = true;
+}
+
+pub fn section() InspectorSection {
+    return .{
+        .name = "Comment",
+        .default_open = false,
+        .is_present = isPresent,
+        .render = render,
+    };
+}

--- a/src/modules/inspector/polygon.zig
+++ b/src/modules/inspector/polygon.zig
@@ -1,0 +1,93 @@
+//! Polygon inspector section. Only renders when `entity.polygon != null`.
+
+const zgui = @import("zgui");
+
+const scene_io = @import("../../scene_io.zig");
+const atlas = @import("../../atlas.zig");
+const InspectorSection = @import("section.zig").InspectorSection;
+
+fn isPresent(entity: *scene_io.Entity) bool {
+    return entity.polygon != null;
+}
+
+fn render(
+    entity: *scene_io.Entity,
+    is_dirty: *bool,
+    _: ?*const atlas.Index,
+) void {
+    const poly = entity.polygon.?;
+    // Render the points as a numbered list. Each row carries two
+    // `inputFloat` widgets and a small `×` remove button. We walk
+    // by index because the remove path needs to shift the tail down
+    // (no realloc — fixed-cap inline buffer, see scene_io.Polygon).
+    var idx: u32 = 0;
+    // ImGui needs distinct IDs per row; push the index as a scope
+    // so the `x` / `y` / `×` labels can repeat.
+    while (idx < poly.point_count) {
+        zgui.pushIntId(@intCast(idx));
+        defer zgui.popId();
+
+        zgui.text("#{d}", .{idx});
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(80);
+        if (zgui.inputFloat("x", .{ .v = &poly.points[idx].x })) is_dirty.* = true;
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(80);
+        if (zgui.inputFloat("y", .{ .v = &poly.points[idx].y })) is_dirty.* = true;
+        zgui.sameLine(.{});
+
+        var removed = false;
+        if (zgui.smallButton("x##rm")) {
+            // Shift the tail of the inline buffer down. Cheap: the
+            // cap is small (64), and removal is rare.
+            var k: u32 = idx;
+            while (k + 1 < poly.point_count) : (k += 1) {
+                poly.points[k] = poly.points[k + 1];
+            }
+            poly.point_count -= 1;
+            poly.points[poly.point_count] = .{};
+            is_dirty.* = true;
+            removed = true;
+        }
+        if (!removed) idx += 1;
+    }
+
+    // Add-point button. Hidden when the buffer is at cap so the
+    // user can't drive past it silently.
+    if (poly.point_count < scene_io.polygon_max_points) {
+        if (zgui.button("+ Add point", .{})) {
+            poly.points[poly.point_count] = .{};
+            poly.point_count += 1;
+            is_dirty.* = true;
+        }
+    } else {
+        zgui.textDisabled("(at cap: {d} points)", .{scene_io.polygon_max_points});
+    }
+
+    // Convert u8 RGBA to imgui's float color picker; same
+    // round-to-nearest reverse conversion as Sprite/Rectangle so
+    // the source round-trip is stable across saves.
+    var col4: [4]f32 = .{
+        @as(f32, @floatFromInt(poly.r)) / 255.0,
+        @as(f32, @floatFromInt(poly.g)) / 255.0,
+        @as(f32, @floatFromInt(poly.b)) / 255.0,
+        @as(f32, @floatFromInt(poly.a)) / 255.0,
+    };
+    if (zgui.colorEdit4("color", .{ .col = &col4 })) {
+        poly.r = @intFromFloat(@round(col4[0] * 255.0));
+        poly.g = @intFromFloat(@round(col4[1] * 255.0));
+        poly.b = @intFromFloat(@round(col4[2] * 255.0));
+        poly.a = @intFromFloat(@round(col4[3] * 255.0));
+        is_dirty.* = true;
+    }
+    if (zgui.checkbox("filled", .{ .v = &poly.filled })) is_dirty.* = true;
+}
+
+pub fn section() InspectorSection {
+    return .{
+        .name = "Polygon",
+        .default_open = true,
+        .is_present = isPresent,
+        .render = render,
+    };
+}

--- a/src/modules/inspector/position.zig
+++ b/src/modules/inspector/position.zig
@@ -1,0 +1,35 @@
+//! Position inspector section. Always present — when `entity.position`
+//! is null the body shows a "(no Position component)" hint instead of
+//! editor widgets, matching the pre-refactor behavior.
+
+const zgui = @import("zgui");
+
+const scene_io = @import("../../scene_io.zig");
+const atlas = @import("../../atlas.zig");
+const InspectorSection = @import("section.zig").InspectorSection;
+
+fn isPresent(_: *scene_io.Entity) bool {
+    return true;
+}
+
+fn render(
+    entity: *scene_io.Entity,
+    is_dirty: *bool,
+    _: ?*const atlas.Index,
+) void {
+    if (entity.position) |*pos| {
+        if (zgui.inputFloat("x", .{ .v = &pos.x })) is_dirty.* = true;
+        if (zgui.inputFloat("y", .{ .v = &pos.y })) is_dirty.* = true;
+    } else {
+        zgui.textDisabled("(no Position component)", .{});
+    }
+}
+
+pub fn section() InspectorSection {
+    return .{
+        .name = "Position",
+        .default_open = true,
+        .is_present = isPresent,
+        .render = render,
+    };
+}

--- a/src/modules/inspector/rectangle.zig
+++ b/src/modules/inspector/rectangle.zig
@@ -1,0 +1,52 @@
+//! Rectangle inspector section. Only renders when `entity.rectangle != null`.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const scene_io = @import("../../scene_io.zig");
+const atlas = @import("../../atlas.zig");
+const InspectorSection = @import("section.zig").InspectorSection;
+
+fn isPresent(entity: *scene_io.Entity) bool {
+    return entity.rectangle != null;
+}
+
+fn render(
+    entity: *scene_io.Entity,
+    is_dirty: *bool,
+    _: ?*const atlas.Index,
+) void {
+    const rect = entity.rectangle.?;
+    if (zgui.inputFloat("width", .{ .v = &rect.width })) is_dirty.* = true;
+    if (zgui.inputFloat("height", .{ .v = &rect.height })) is_dirty.* = true;
+
+    // Convert u8 RGBA to imgui's float-in-[0,1] color picker and back.
+    // The reverse conversion rounds to the nearest u8 so the source
+    // round-trip is stable across saves.
+    var col4: [4]f32 = .{
+        @as(f32, @floatFromInt(rect.r)) / 255.0,
+        @as(f32, @floatFromInt(rect.g)) / 255.0,
+        @as(f32, @floatFromInt(rect.b)) / 255.0,
+        @as(f32, @floatFromInt(rect.a)) / 255.0,
+    };
+    if (zgui.colorEdit4("color", .{ .col = &col4 })) {
+        // Clamp before casting: `@intFromFloat` is safety-checked
+        // and would panic on values outside `[0, 255]`, which can
+        // happen due to float precision or manual hex/int input.
+        rect.r = @intFromFloat(@round(std.math.clamp(col4[0] * 255.0, 0.0, 255.0)));
+        rect.g = @intFromFloat(@round(std.math.clamp(col4[1] * 255.0, 0.0, 255.0)));
+        rect.b = @intFromFloat(@round(std.math.clamp(col4[2] * 255.0, 0.0, 255.0)));
+        rect.a = @intFromFloat(@round(std.math.clamp(col4[3] * 255.0, 0.0, 255.0)));
+        is_dirty.* = true;
+    }
+    if (zgui.checkbox("filled", .{ .v = &rect.filled })) is_dirty.* = true;
+}
+
+pub fn section() InspectorSection {
+    return .{
+        .name = "Rectangle",
+        .default_open = true,
+        .is_present = isPresent,
+        .render = render,
+    };
+}

--- a/src/modules/inspector/section.zig
+++ b/src/modules/inspector/section.zig
@@ -1,0 +1,31 @@
+//! `InspectorSection` — one collapsing-header section in the entity
+//! inspector. Mirrors the Module/Registry pattern in `../../module.zig`:
+//! each typed component lives in its own file under `inspector/`, exports
+//! a `section()` constructor, and the parent `inspector.zig` just iterates
+//! a comptime-fixed array.
+//!
+//! The trailing "Other components (N)" group isn't modeled here because
+//! it doesn't read a typed field on `Entity` — it walks an extras slice.
+//! It stays special-cased in `inspector.zig`.
+
+const scene_io = @import("../../scene_io.zig");
+const atlas = @import("../../atlas.zig");
+
+pub const InspectorSection = struct {
+    /// Collapsing-header label. Must be a stable C string for imgui.
+    name: [:0]const u8,
+    /// Initial open state for the section's collapsing header.
+    default_open: bool = false,
+    /// True when the section applies to `entity` — e.g. the Sprite
+    /// section only renders when `entity.sprite != null`. Position
+    /// is always present (it renders a "(no Position component)"
+    /// hint when the field is null).
+    is_present: *const fn (*scene_io.Entity) bool,
+    /// Body of the section. The caller has already opened the
+    /// collapsing header; this just paints into it.
+    render: *const fn (
+        entity: *scene_io.Entity,
+        is_dirty: *bool,
+        atlas_index: ?*const atlas.Index,
+    ) void,
+};

--- a/src/modules/inspector/sprite.zig
+++ b/src/modules/inspector/sprite.zig
@@ -1,0 +1,98 @@
+//! Sprite inspector section. Only renders when `entity.sprite != null`.
+//!
+//! Surfaces a soft "(missing)" hint when the typed `sprite_name`
+//! doesn't resolve against the project's atlas index — doesn't block
+//! edits (the engine ultimately decides what's valid; we just guide).
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const scene_io = @import("../../scene_io.zig");
+const atlas = @import("../../atlas.zig");
+const InspectorSection = @import("section.zig").InspectorSection;
+
+/// Canonical Sprite.pivot values, matching the engine's pivot enum
+/// and the order in `modules/viewport.zig:pivotOffset`. Index 0
+/// (`center`) is the default when the buffer is empty or unknown.
+const pivot_names = [_][]const u8{
+    "center",
+    "bottom_center",
+    "top_center",
+    "bottom_left",
+    "bottom_right",
+    "top_left",
+    "top_right",
+    "left_center",
+    "right_center",
+};
+
+/// Zero-separated, zero-terminated form of `pivot_names` for
+/// `zgui.combo`'s `items_separated_by_zeros` argument. Built at
+/// comptime from `pivot_names` so the two lists can't drift.
+const pivot_items: [:0]const u8 = blk: {
+    var res: [:0]const u8 = "";
+    for (pivot_names) |name| {
+        res = res ++ name ++ "\x00";
+    }
+    break :blk res;
+};
+
+fn isPresent(entity: *scene_io.Entity) bool {
+    return entity.sprite != null;
+}
+
+fn render(
+    entity: *scene_io.Entity,
+    is_dirty: *bool,
+    atlas_index: ?*const atlas.Index,
+) void {
+    const sprite = entity.sprite.?;
+    if (zgui.inputText("sprite_name", .{ .buf = &sprite.sprite_name })) is_dirty.* = true;
+    // Resolve the typed sprite name against the project's atlas
+    // index; surface a soft `(missing)` hint when it doesn't match
+    // anything. Doesn't block edits — the engine ultimately decides
+    // what's valid; we just guide.
+    if (atlas_index) |idx| {
+        const name_str = std.mem.sliceTo(&sprite.sprite_name, 0);
+        if (name_str.len > 0 and idx.find(name_str) == null) {
+            zgui.sameLine(.{});
+            zgui.textColored(.{ 1.0, 0.5, 0.4, 1.0 }, "(missing)", .{});
+        }
+    }
+    // Pivot is a closed enum on the engine side — let the user pick
+    // from the 9 valid names rather than free-type. Order matches
+    // `pivotOffset` in modules/viewport.zig.
+    const current_pivot = std.mem.sliceTo(&sprite.pivot, 0);
+    var pivot_idx: i32 = for (pivot_names, 0..) |n, i| {
+        if (std.mem.eql(u8, current_pivot, n)) break @intCast(i);
+    } else 0;
+    if (zgui.combo("pivot", .{
+        .current_item = &pivot_idx,
+        .items_separated_by_zeros = pivot_items,
+    })) {
+        const chosen = pivot_names[@intCast(pivot_idx)];
+        @memset(&sprite.pivot, 0);
+        @memcpy(sprite.pivot[0..chosen.len], chosen);
+        is_dirty.* = true;
+    }
+    if (zgui.inputText("layer", .{ .buf = &sprite.layer })) is_dirty.* = true;
+
+    // z_index is optional in the source; the checkbox toggles whether
+    // we emit it at all. Editing the int alone (with the box unchecked)
+    // doesn't suddenly add a `"z_index"` key to the file — the user has
+    // to opt in explicitly.
+    if (zgui.checkbox("z_index?", .{ .v = &sprite.has_z_index })) is_dirty.* = true;
+    if (sprite.has_z_index) {
+        zgui.sameLine(.{});
+        if (zgui.inputInt("##z_index", .{ .v = &sprite.z_index })) is_dirty.* = true;
+    }
+}
+
+pub fn section() InspectorSection {
+    return .{
+        .name = "Sprite",
+        .default_open = true,
+        .is_present = isPresent,
+        .render = render,
+    };
+}


### PR DESCRIPTION
## Summary

`src/modules/inspector.zig` rendered every typed component inline. With five geometry / sprite sections already in place, every new component PR collided textually with every other in-flight PR on the same file — the four-PR batch on 2026-05-11 (#34/#35/#36/#37) hit this repeatedly. Closes #38.

This refactor mirrors the Module/Registry pattern from `src/module.zig`: each typed component (Position, Sprite, Rectangle, Circle, Polygon, Comment) now lives in its own file under `src/modules/inspector/` and exports a `section()` constructor returning an `InspectorSection`. The parent `inspector.zig` is a thin registry + dispatcher that iterates a comptime-fixed `sections` array. Adding a typed component is now one new file + one line. The `renderEntity` signature is unchanged — `scene.zig` and `prefab.zig` are untouched. The trailing "Other components (N)" extras block stays special-cased because it walks a slice rather than a typed `Entity` field.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — 148/148 pass
- [x] `zig build gui-test` — 7/7 pass
- [x] `zig build smoke` — generate + build via launcher succeeded
- [x] Section order, default-open state, and collapsing-header labels are byte-identical to pre-refactor
- [x] Diff against `origin/feat/flows-phase1` confirms zero overlap with PR #63