### PR TITLE
Scene editor: snap-to-grid (#5)

### DIFF
--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -38,9 +38,12 @@ pub const PrefabState = struct {
     drag_armed: bool = false,
     pan: [2]f32 = .{ 320, 240 },
     zoom: f32 = 1.0,
-    /// Snap-to-grid for child drag-to-move. Off by default.
+    /// World-space spacing for the viewport's visual grid. When
+    /// `snap_enabled` is on, child drag-to-move also snaps to this
+    /// step. Default 16; per-tab today.
+    grid_step: f32 = 16,
+    /// When true, child drag-to-move snaps to the grid above.
     snap_enabled: bool = false,
-    snap_step: f32 = 16,
 
     pub fn open(allocator: std.mem.Allocator, path: []const u8) !PrefabState {
         const arena = try allocator.create(std.heap.ArenaAllocator);
@@ -91,13 +94,13 @@ pub fn render(s: *PrefabState, app: *App) void {
     zgui.sameLine(.{});
     _ = zgui.checkbox("gizmos", .{ .v = &app.show_gizmos });
     zgui.sameLine(.{});
+    zgui.text("grid", .{});
+    zgui.sameLine(.{});
+    zgui.setNextItemWidth(64);
+    _ = zgui.inputFloat("##grid_step", .{ .v = &s.grid_step });
+    if (s.grid_step <= 0) s.grid_step = 1;
+    zgui.sameLine(.{});
     _ = zgui.checkbox("snap", .{ .v = &s.snap_enabled });
-    if (s.snap_enabled) {
-        zgui.sameLine(.{});
-        zgui.setNextItemWidth(64);
-        _ = zgui.inputFloat("##snap_step", .{ .v = &s.snap_step });
-        if (s.snap_step <= 0) s.snap_step = 1;
-    }
     zgui.sameLine(.{});
     if (zgui.button("Save", .{})) savePrefab(s, app);
     zgui.separator();
@@ -117,7 +120,8 @@ pub fn render(s: *PrefabState, app: *App) void {
                 .selected_idx = &s.selected_child_idx,
                 .is_dirty = &s.is_dirty,
                 .drag_armed = &s.drag_armed,
-                .snap_step = if (s.snap_enabled) s.snap_step else null,
+                .grid_step = s.grid_step,
+                .snap_enabled = s.snap_enabled,
             },
             s.loaded.children,
             s.loaded.children_extras,

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -38,6 +38,9 @@ pub const PrefabState = struct {
     drag_armed: bool = false,
     pan: [2]f32 = .{ 320, 240 },
     zoom: f32 = 1.0,
+    /// Snap-to-grid for child drag-to-move. Off by default.
+    snap_enabled: bool = false,
+    snap_step: f32 = 16,
 
     pub fn open(allocator: std.mem.Allocator, path: []const u8) !PrefabState {
         const arena = try allocator.create(std.heap.ArenaAllocator);
@@ -88,6 +91,14 @@ pub fn render(s: *PrefabState, app: *App) void {
     zgui.sameLine(.{});
     _ = zgui.checkbox("gizmos", .{ .v = &app.show_gizmos });
     zgui.sameLine(.{});
+    _ = zgui.checkbox("snap", .{ .v = &s.snap_enabled });
+    if (s.snap_enabled) {
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(64);
+        _ = zgui.inputFloat("##snap_step", .{ .v = &s.snap_step });
+        if (s.snap_step <= 0) s.snap_step = 1;
+    }
+    zgui.sameLine(.{});
     if (zgui.button("Save", .{})) savePrefab(s, app);
     zgui.separator();
 
@@ -106,6 +117,7 @@ pub fn render(s: *PrefabState, app: *App) void {
                 .selected_idx = &s.selected_child_idx,
                 .is_dirty = &s.is_dirty,
                 .drag_armed = &s.drag_armed,
+                .snap_step = if (s.snap_enabled) s.snap_step else null,
             },
             s.loaded.children,
             s.loaded.children_extras,

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -79,11 +79,16 @@ pub const SceneState = struct {
     /// Filter buffer for the picker's search box. Stays sticky across
     /// reopenings — same convenience the resources panel has.
     prefab_picker_filter: [64:0]u8 = [_:0]u8{0} ** 64,
-    /// Snap-to-grid: when enabled, drag-to-move rounds the dragged
-    /// entity's world position to multiples of `snap_step`. Off by
-    /// default so existing behavior is preserved.
+    /// World-space spacing for the viewport's visual grid. When
+    /// `snap_enabled` is on, drag-to-move also rounds to multiples of
+    /// this value — one number, both behaviors. Default 16 works for
+    /// most pixel-tile setups; flying-platform-labelle uses a much
+    /// finer step so users will typically dial this down per tab.
+    /// Per-tab today; per-project persistence is a follow-up.
+    grid_step: f32 = 16,
+    /// When true, drag-to-move snaps to the grid above. Off by default
+    /// so existing behavior is preserved.
     snap_enabled: bool = false,
-    snap_step: f32 = 16,
 
     /// Load a scene from disk and wrap it in a fresh SceneState. The
     /// returned state owns an arena holding the path + display name,
@@ -146,13 +151,16 @@ pub fn render(s: *SceneState, app: *App) void {
     zgui.sameLine(.{});
     _ = zgui.checkbox("gizmos", .{ .v = &app.show_gizmos });
     zgui.sameLine(.{});
+    // Grid step drives the visual grid and (when snap is on) the snap
+    // step. Always editable so the user can dial in the world units
+    // their project uses without having to enable snap first.
+    zgui.text("grid", .{});
+    zgui.sameLine(.{});
+    zgui.setNextItemWidth(64);
+    _ = zgui.inputFloat("##grid_step", .{ .v = &s.grid_step });
+    if (s.grid_step <= 0) s.grid_step = 1;
+    zgui.sameLine(.{});
     _ = zgui.checkbox("snap", .{ .v = &s.snap_enabled });
-    if (s.snap_enabled) {
-        zgui.sameLine(.{});
-        zgui.setNextItemWidth(64);
-        _ = zgui.inputFloat("##snap_step", .{ .v = &s.snap_step });
-        if (s.snap_step <= 0) s.snap_step = 1;
-    }
     zgui.sameLine(.{});
     if (zgui.button("Save", .{})) saveScene(s, app);
     zgui.separator();
@@ -234,7 +242,8 @@ fn renderViewport(
             .is_dirty = &s.is_dirty,
             .drag_armed = &s.drag_armed,
             .right_click_world = &right_click,
-            .snap_step = if (s.snap_enabled) s.snap_step else null,
+            .grid_step = s.grid_step,
+            .snap_enabled = s.snap_enabled,
         },
         s.loaded.scene.entities,
         s.loaded.extras.entity_components,

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -79,6 +79,11 @@ pub const SceneState = struct {
     /// Filter buffer for the picker's search box. Stays sticky across
     /// reopenings — same convenience the resources panel has.
     prefab_picker_filter: [64:0]u8 = [_:0]u8{0} ** 64,
+    /// Snap-to-grid: when enabled, drag-to-move rounds the dragged
+    /// entity's world position to multiples of `snap_step`. Off by
+    /// default so existing behavior is preserved.
+    snap_enabled: bool = false,
+    snap_step: f32 = 16,
 
     /// Load a scene from disk and wrap it in a fresh SceneState. The
     /// returned state owns an arena holding the path + display name,
@@ -140,6 +145,14 @@ pub fn render(s: *SceneState, app: *App) void {
     zgui.text("zoom: {d:.2}x", .{s.zoom});
     zgui.sameLine(.{});
     _ = zgui.checkbox("gizmos", .{ .v = &app.show_gizmos });
+    zgui.sameLine(.{});
+    _ = zgui.checkbox("snap", .{ .v = &s.snap_enabled });
+    if (s.snap_enabled) {
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(64);
+        _ = zgui.inputFloat("##snap_step", .{ .v = &s.snap_step });
+        if (s.snap_step <= 0) s.snap_step = 1;
+    }
     zgui.sameLine(.{});
     if (zgui.button("Save", .{})) saveScene(s, app);
     zgui.separator();
@@ -221,6 +234,7 @@ fn renderViewport(
             .is_dirty = &s.is_dirty,
             .drag_armed = &s.drag_armed,
             .right_click_world = &right_click,
+            .snap_step = if (s.snap_enabled) s.snap_step else null,
         },
         s.loaded.scene.entities,
         s.loaded.extras.entity_components,

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -32,12 +32,18 @@ pub const State = struct {
     /// care about right-clicks — the prefab editor sets this to
     /// null today.
     right_click_world: ?*?[2]f32 = null,
-    /// Optional snap step in world units. When non-null and a drag is
-    /// in progress, the dragged entity's running position is rounded to
-    /// the nearest multiple of `snap_step` (relative to `snap_origin`)
-    /// before being written back. Null disables snapping.
-    snap_step: ?f32 = null,
-    /// World-space origin for the snap grid. The default keeps the grid
+    /// World-space spacing for the visual grid AND, when snapping is on,
+    /// the snap step. One number drives both so the grid the user sees
+    /// is the grid their drags land on. Default 16 matches what most 2D
+    /// engines treat as a pixel-tile baseline; flying-platform-labelle's
+    /// world is much smaller-stepped so users will typically dial this
+    /// down. Must be > 0.
+    grid_step: f32 = 16,
+    /// When true, the dragged entity's running position is rounded to
+    /// the nearest multiple of `grid_step` (relative to `snap_origin`)
+    /// before being written back. The visual grid is always drawn.
+    snap_enabled: bool = false,
+    /// World-space origin for the grid. The default keeps the grid
     /// aligned to the world origin; callers can shift it later (no UI
     /// for this yet).
     snap_origin: [2]f32 = .{ 0, 0 },
@@ -128,7 +134,7 @@ pub fn render(
         .col = 0xff202225,
     });
 
-    drawGrid(dl, canvas_min, canvas_max, state.pan.*, state.zoom.*);
+    drawGrid(dl, canvas_min, canvas_max, state.pan.*, state.zoom.*, state.grid_step);
     drawEntities(dl, canvas_min, state, entities, atlas_index);
     if (show_gizmos) if (gizmo_index) |gi| {
         drawGizmoOverlay(dl, canvas_min, state, entities, entity_extras, gi);
@@ -176,11 +182,9 @@ pub fn render(
                         pos.x += d[0] / state.zoom.*;
                         // World +y is up; screen +y is down.
                         pos.y -= d[1] / state.zoom.*;
-                        if (state.snap_step) |step| {
-                            if (step > 0) {
-                                pos.x = snapValue(pos.x, state.snap_origin[0], step);
-                                pos.y = snapValue(pos.y, state.snap_origin[1], step);
-                            }
+                        if (state.snap_enabled and state.grid_step > 0) {
+                            pos.x = snapValue(pos.x, state.snap_origin[0], state.grid_step);
+                            pos.y = snapValue(pos.y, state.snap_origin[1], state.grid_step);
                         }
                         state.is_dirty.* = true;
                         zgui.resetMouseDragDelta(.left);
@@ -191,8 +195,8 @@ pub fn render(
     }
 }
 
-fn drawGrid(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, pan: [2]f32, zoom: f32) void {
-    const grid_world: f32 = 64;
+fn drawGrid(dl: zgui.DrawList, cmin: [2]f32, cmax: [2]f32, pan: [2]f32, zoom: f32, grid_world: f32) void {
+    if (grid_world <= 0) return;
     const step = grid_world * zoom;
     if (step <= 4) return;
 

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -32,7 +32,24 @@ pub const State = struct {
     /// care about right-clicks — the prefab editor sets this to
     /// null today.
     right_click_world: ?*?[2]f32 = null,
+    /// Optional snap step in world units. When non-null and a drag is
+    /// in progress, the dragged entity's running position is rounded to
+    /// the nearest multiple of `snap_step` (relative to `snap_origin`)
+    /// before being written back. Null disables snapping.
+    snap_step: ?f32 = null,
+    /// World-space origin for the snap grid. The default keeps the grid
+    /// aligned to the world origin; callers can shift it later (no UI
+    /// for this yet).
+    snap_origin: [2]f32 = .{ 0, 0 },
 };
+
+/// Round a single 1-D world coordinate to the nearest snap step relative
+/// to `origin`. Pulled out so zspec can exercise the math without an
+/// imgui draw context. `step` must be > 0; callers guard with the
+/// optional `snap_step` field of `State`.
+pub fn snapValue(value: f32, origin: f32, step: f32) f32 {
+    return origin + @round((value - origin) / step) * step;
+}
 
 /// Pixel radius around an entity marker that counts as a click.
 pub const hit_radius: f32 = 10.0;
@@ -159,6 +176,12 @@ pub fn render(
                         pos.x += d[0] / state.zoom.*;
                         // World +y is up; screen +y is down.
                         pos.y -= d[1] / state.zoom.*;
+                        if (state.snap_step) |step| {
+                            if (step > 0) {
+                                pos.x = snapValue(pos.x, state.snap_origin[0], step);
+                                pos.y = snapValue(pos.y, state.snap_origin[1], step);
+                            }
+                        }
                         state.is_dirty.* = true;
                         zgui.resetMouseDragDelta(.left);
                     }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1682,6 +1682,47 @@ pub const ViewportRenderPlanTests = struct {
     }
 };
 
+pub const ViewportSnapTests = struct {
+    // Snap-to-grid math — exercised independently of the imgui draw
+    // path. Drag-to-move calls `snapValue` once per axis with the
+    // user's step and origin; the formula is
+    //   snapped = origin + round((value - origin) / step) * step
+    // so the snap grid is aligned to `origin` (defaults to world 0).
+
+    test "rounds to nearest multiple of step at origin 0" {
+        try expect.equal(viewport.snapValue(0, 0, 16), 0);
+        try expect.equal(viewport.snapValue(7, 0, 16), 0);
+        try expect.equal(viewport.snapValue(8, 0, 16), 16); // ties-away (zig @round)
+        try expect.equal(viewport.snapValue(9, 0, 16), 16);
+        try expect.equal(viewport.snapValue(23, 0, 16), 16);
+        try expect.equal(viewport.snapValue(24, 0, 16), 32);
+    }
+
+    test "negative values snap symmetrically" {
+        try expect.equal(viewport.snapValue(-7, 0, 16), 0);
+        try expect.equal(viewport.snapValue(-9, 0, 16), -16);
+        try expect.equal(viewport.snapValue(-16, 0, 16), -16);
+    }
+
+    test "non-zero origin shifts the grid" {
+        // origin=5, step=10 → grid is { ..., -5, 5, 15, 25, ... }.
+        try expect.equal(viewport.snapValue(6, 5, 10), 5);
+        try expect.equal(viewport.snapValue(11, 5, 10), 15);
+        try expect.equal(viewport.snapValue(0, 5, 10), -5);
+    }
+
+    test "values already on a grid line stay put" {
+        try expect.equal(viewport.snapValue(32, 0, 16), 32);
+        try expect.equal(viewport.snapValue(-48, 0, 16), -48);
+    }
+
+    test "non-integer step rounds to that step" {
+        // Use loose tolerance: 0.5 floating ops are exact in f32.
+        try expect.equal(viewport.snapValue(1.2, 0, 0.5), 1.0);
+        try expect.equal(viewport.snapValue(1.3, 0, 0.5), 1.5);
+    }
+};
+
 pub const SceneTemplateTests = struct {
     /// Strip `//`-to-end-of-line comments so the JSONC template can be
     /// fed to std.json (which doesn't accept comments). Replaces the


### PR DESCRIPTION
## Summary

Optional snap-to-grid in the scene and prefab viewports (part of #5's
"Scene Editor remaining scope"). Off by default; when enabled, dragging
an entity rounds its world position to a configurable step (default
16px) on each axis.

- `viewport.State` gains `snap_step: ?f32` and `snap_origin: [2]f32`.
  The drag handler applies `snapValue(value, origin, step)` per axis
  after the existing zoom-relative delta update — the math is the
  spec's `origin + round((value - origin) / step) * step`.
- `scene.zig` and `prefab.zig` each grow `snap_enabled: bool = false`
  and `snap_step: f32 = 16`, plus header controls: a `snap` checkbox
  next to the existing `gizmos` checkbox and (when enabled) a 64px-
  wide `inputFloat` for the step. They pass
  `snap_step: if (snap_enabled) snap_step else null` into the viewport.
- No UI for `snap_origin` yet — defaults to world origin per the task
  brief. Grid rendering math is unchanged.

Tests: 5 new zspec tests in `ViewportSnapTests` cover the snap formula
directly (positive/negative inputs, non-zero origin, non-integer step,
already-on-grid values). UI path is not unit-tested.

Refs #5.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — 153/153 passing (was 148; +5 new snap tests)
- [x] `zig build gui-test` — 7/7 passing (unchanged from baseline at
      a17312d on this worktree)
- [x] `zig build smoke` — green