### PR TITLE
Scene editor: add / remove entities + delete-key handling (#5)

### DIFF
--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -26,6 +26,16 @@ const viewport = @import("viewport.zig");
 
 const viewport_min_h: f32 = 240;
 
+/// Maximum number of `.jsonc` files we'll surface in the prefab
+/// picker that opens from the right-click context menu. Real projects
+/// in the toolkit (flying-platform etc.) carry well under 100; the
+/// cap keeps the popup bounded without an allocator on the menu path.
+const max_prefab_picker_entries: usize = 256;
+/// Per-entry stem buffer for the prefab picker. Long enough to hold
+/// the typical `<stem>.jsonc` filenames in the toolkit (most under
+/// 32 chars); names beyond this are truncated for display + selection.
+const prefab_picker_name_cap: usize = 64;
+
 pub const SceneState = struct {
     /// Owns `path` and `display_name`. `loaded` has its own internal
     /// arena (created by scene_io.parseScene) for the parsed scene.
@@ -50,6 +60,25 @@ pub const SceneState = struct {
     /// own camera.
     pan: [2]f32 = .{ 320, 240 },
     zoom: f32 = 1.0,
+    /// World-space coordinates of the most recent empty-canvas right-
+    /// click. Set by `viewport.render`; consumed by the context menu
+    /// when "Add entity here" / "Add entity from prefab…" fires.
+    /// Cleared back to null after the popup closes so a stale click
+    /// can't be re-used.
+    context_menu_world_pos: ?[2]f32 = null,
+    /// True while the prefab picker popup is open. We render it as a
+    /// nested popup off the context menu so dismissing the picker
+    /// doesn't immediately reopen the parent menu.
+    show_prefab_picker: bool = false,
+    /// Cached `.jsonc` stems under `<project>/prefabs/`, scanned once
+    /// when the picker opens. Bounded — see `max_prefab_picker_entries`.
+    prefab_picker_names: [max_prefab_picker_entries][prefab_picker_name_cap:0]u8 = undefined,
+    /// Number of valid entries in `prefab_picker_names`. Zero means
+    /// the scan hasn't run yet (or returned nothing).
+    prefab_picker_count: usize = 0,
+    /// Filter buffer for the picker's search box. Stays sticky across
+    /// reopenings — same convenience the resources panel has.
+    prefab_picker_filter: [64:0]u8 = [_:0]u8{0} ** 64,
 
     /// Load a scene from disk and wrap it in a fresh SceneState. The
     /// returned state owns an arena holding the path + display name,
@@ -124,6 +153,8 @@ pub fn render(s: *SceneState, app: *App) void {
 
     if (zgui.beginChild("##viewport_col", .{ .w = viewport_w, .h = 0 })) {
         renderViewport(s, atlas_index_ptr, gizmo_index_ptr, app.show_gizmos);
+        renderContextMenu(s, app);
+        handleDeleteKey(s);
     }
     zgui.endChild();
     zgui.sameLine(.{});
@@ -178,6 +209,10 @@ fn renderViewport(
     gizmo_index: ?*const @import("../gizmos.zig").Index,
     show_gizmos: bool,
 ) void {
+    // Capture right-click world-pos out-of-band; if the viewport sets
+    // it this frame we open the context menu before its child closes
+    // so the popup roots at the canvas, not at the scene tab body.
+    var right_click: ?[2]f32 = null;
     viewport.render(
         .{
             .pan = &s.pan,
@@ -185,6 +220,7 @@ fn renderViewport(
             .selected_idx = &s.selected_index,
             .is_dirty = &s.is_dirty,
             .drag_armed = &s.drag_armed,
+            .right_click_world = &right_click,
         },
         s.loaded.scene.entities,
         s.loaded.extras.entity_components,
@@ -192,6 +228,146 @@ fn renderViewport(
         gizmo_index,
         show_gizmos,
     );
+    if (right_click) |world| {
+        s.context_menu_world_pos = world;
+        zgui.openPopup("##scene_context", .{});
+    }
+}
+
+/// Context-menu popup that fires after a right-click in empty canvas
+/// space. Rendered outside the canvas child so the popup window roots
+/// at the scene tab, not the canvas (which closes its own ID stack).
+/// "Add entity here" appends an empty `Entity` carrying just the
+/// recorded position; "Add entity from prefab…" opens a nested
+/// picker. The picker scans `<project>/prefabs/` lazily — once per
+/// open — so a project with many prefabs doesn't penalize every frame.
+fn renderContextMenu(s: *SceneState, app: *App) void {
+    if (zgui.beginPopup("##scene_context", .{})) {
+        defer zgui.endPopup();
+        if (zgui.menuItem("Add entity here", .{})) {
+            if (s.context_menu_world_pos) |p| {
+                addBlankEntity(s, p) catch |err| {
+                    std.log.err("addEntity failed: {s}", .{@errorName(err)});
+                    app.setStatus("Add entity failed!");
+                };
+            }
+            s.context_menu_world_pos = null;
+        }
+        if (zgui.menuItem("Add entity from prefab...", .{})) {
+            scanPrefabPickerNames(s, app);
+            s.show_prefab_picker = true;
+        }
+    } else {
+        // Popup is closed (either by selection or click-away). Drop
+        // the cached world-pos so the next right-click reads fresh.
+        if (!s.show_prefab_picker) s.context_menu_world_pos = null;
+    }
+    renderPrefabPicker(s, app);
+}
+
+fn renderPrefabPicker(s: *SceneState, app: *App) void {
+    if (s.show_prefab_picker) zgui.openPopup("##scene_prefab_picker", .{});
+    if (!zgui.beginPopup("##scene_prefab_picker", .{})) {
+        s.show_prefab_picker = false;
+        return;
+    }
+    defer zgui.endPopup();
+
+    zgui.text("Select a prefab:", .{});
+    _ = zgui.inputText("##prefab_filter", .{ .buf = &s.prefab_picker_filter });
+    zgui.separator();
+
+    const filter = std.mem.sliceTo(&s.prefab_picker_filter, 0);
+    var any_shown: bool = false;
+    var i: usize = 0;
+    while (i < s.prefab_picker_count) : (i += 1) {
+        const name_buf = &s.prefab_picker_names[i];
+        const name = std.mem.sliceTo(name_buf, 0);
+        if (filter.len > 0 and std.mem.indexOf(u8, name, filter) == null) continue;
+        any_shown = true;
+        // The stored buffer is [prefab_picker_name_cap:0]u8, so its
+        // contents are sentinel-terminated already — just hand the
+        // sentinel-typed slice to `selectable`.
+        const label: [:0]const u8 = name_buf[0..name.len :0];
+        if (zgui.selectable(label, .{})) {
+            const pos = s.context_menu_world_pos orelse .{ 0, 0 };
+            addPrefabEntity(s, name, pos) catch |err| {
+                std.log.err("addPrefabEntity failed: {s}", .{@errorName(err)});
+                app.setStatus("Add entity failed!");
+            };
+            s.show_prefab_picker = false;
+            s.context_menu_world_pos = null;
+            zgui.closeCurrentPopup();
+            break;
+        }
+    }
+    if (!any_shown) zgui.textDisabled("(no prefabs found)", .{});
+}
+
+/// Walk `<project>/prefabs/` and fold each `.jsonc` filename's stem
+/// into `s.prefab_picker_names`. Errors (missing folder, permission
+/// problems) are swallowed and reported as an empty picker — same
+/// tolerance the tree view + gizmo loader use.
+fn scanPrefabPickerNames(s: *SceneState, app: *App) void {
+    s.prefab_picker_count = 0;
+    const proj = app.project_manager.current_project orelse return;
+    const proj_dir = proj.getProjectDir() orelse return;
+    const prefabs_dir = std.fs.path.join(app.allocator, &.{
+        proj_dir,
+        project.ProjectFolders.prefabs,
+    }) catch return;
+    defer app.allocator.free(prefabs_dir);
+
+    var dir = std.fs.cwd().openDir(prefabs_dir, .{ .iterate = true }) catch return;
+    defer dir.close();
+    var it = dir.iterate();
+    while (it.next() catch null) |dirent| {
+        if (s.prefab_picker_count >= max_prefab_picker_entries) break;
+        if (dirent.kind != .file) continue;
+        if (!std.mem.endsWith(u8, dirent.name, ".jsonc")) continue;
+        const stem = dirent.name[0 .. dirent.name.len - ".jsonc".len];
+        const slot = &s.prefab_picker_names[s.prefab_picker_count];
+        @memset(slot, 0);
+        const n = @min(stem.len, prefab_picker_name_cap);
+        @memcpy(slot[0..n], stem[0..n]);
+        s.prefab_picker_count += 1;
+    }
+}
+
+fn addBlankEntity(s: *SceneState, world: [2]f32) !void {
+    // No prefab name, just a Position — by-value, no arena alloc needed.
+    try scene_io.insertEntity(&s.loaded, .{
+        .position = .{ .x = world[0], .y = world[1] },
+    });
+    s.selected_index = s.loaded.scene.entities.len - 1;
+    s.is_dirty = true;
+}
+
+fn addPrefabEntity(s: *SceneState, name: []const u8, world: [2]f32) !void {
+    // Prefab name must live as long as the LoadedScene — dupe into
+    // the scene's arena so it survives across renders. Position is a
+    // by-value scalar so no allocation needed for it.
+    const arena = s.loaded.arena.allocator();
+    const dup = try arena.dupe(u8, name);
+    try scene_io.insertEntity(&s.loaded, .{
+        .prefab = dup,
+        .position = .{ .x = world[0], .y = world[1] },
+    });
+    s.selected_index = s.loaded.scene.entities.len - 1;
+    s.is_dirty = true;
+}
+
+fn handleDeleteKey(s: *SceneState) void {
+    // Delete-key path: trigger only when the canvas (or one of its
+    // children) is hovered so the inspector's text fields aren't
+    // disrupted by an entity-targeting Delete. `isKeyPressed(repeat=false)`
+    // intentionally rejects key-repeat — one press, one entity.
+    if (!zgui.isWindowHovered(.{ .child_windows = true })) return;
+    if (!zgui.isKeyPressed(.delete, false)) return;
+    const idx = s.selected_index orelse return;
+    scene_io.removeEntity(&s.loaded, idx) catch return;
+    s.selected_index = null;
+    s.is_dirty = true;
 }
 
 /// Re-exported so existing zspec tests (and any other caller of

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -24,6 +24,14 @@ pub const State = struct {
     selected_idx: *?usize,
     is_dirty: *bool,
     drag_armed: *bool,
+    /// Optional sink for right-click world coordinates. The viewport
+    /// writes the world-space point when the user right-clicks an
+    /// empty area of the canvas (no entity under the cursor); the
+    /// caller is then responsible for opening its own context menu
+    /// (e.g. via `zgui.openPopup`). Null when the caller doesn't
+    /// care about right-clicks — the prefab editor sets this to
+    /// null today.
+    right_click_world: ?*?[2]f32 = null,
 };
 
 /// Pixel radius around an entity marker that counts as a click.
@@ -121,6 +129,19 @@ pub fn render(
         state.drag_armed.* = hit != null;
     }
     if (!zgui.isMouseDown(.left)) state.drag_armed.* = false;
+
+    // Right-click on empty canvas → caller-driven context menu. We
+    // only fire when the click misses every entity marker; clicks
+    // *on* an entity stay free for a future per-entity menu.
+    if (state.right_click_world) |sink| {
+        if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.right)) {
+            const mouse = zgui.getMousePos();
+            const hit = hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
+            if (hit == null) {
+                sink.* = worldFromScreen(mouse, canvas_min, state.pan.*, state.zoom.*);
+            }
+        }
+    }
 
     if (zgui.isItemActive()) {
         if (zgui.isMouseDragging(.middle, 0)) {
@@ -415,6 +436,23 @@ fn pivotOffset(name: []const u8) [2]f32 {
     if (std.mem.eql(u8, name, "left_center")) return .{ 0.0, 0.5 };
     if (std.mem.eql(u8, name, "right_center")) return .{ 1.0, 0.5 };
     return .{ 0.5, 0.5 };
+}
+
+/// Convert a screen-space point (`mouse`) back into world space using
+/// the viewport's current pan/zoom + canvas origin. Inverse of the
+/// `cmin + pan + pos * zoom` projection `drawEntities` does (with Y
+/// flipped because world +y is up, screen +y is down). Pure so zspec
+/// can exercise the round-trip.
+pub fn worldFromScreen(
+    mouse: [2]f32,
+    canvas_min: [2]f32,
+    pan: [2]f32,
+    zoom: f32,
+) [2]f32 {
+    return .{
+        (mouse[0] - canvas_min[0] - pan[0]) / zoom,
+        -(mouse[1] - canvas_min[1] - pan[1]) / zoom,
+    };
 }
 
 /// Return the index of the closest entity whose screen-space marker

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -185,6 +185,61 @@ pub const LoadedScene = struct {
     }
 };
 
+/// Append `entity` to `loaded.scene.entities` and grow the parallel
+/// `extras.entity_components` list with an empty per-entity extras
+/// slice so the two arrays stay lock-step on save.
+///
+/// **Arena lifetime**: `entity.prefab` (if non-null) must outlive the
+/// `LoadedScene`. Pass an already-arena-allocated slice, or use the
+/// arena directly: `try loaded.arena.allocator().dupe(u8, name)`.
+/// `Position` and other scalar component buffers are by-value so they
+/// move into the array without further allocation.
+pub fn insertEntity(loaded: *LoadedScene, entity: Entity) !void {
+    const a = loaded.arena.allocator();
+    const old_entities = loaded.scene.entities;
+    const new_entities = try a.alloc(Entity, old_entities.len + 1);
+    @memcpy(new_entities[0..old_entities.len], old_entities);
+    new_entities[old_entities.len] = entity;
+    loaded.scene.entities = new_entities;
+
+    // Grow extras.entity_components in lockstep. Old entries copy
+    // through by value (they're slices pointing into the parse arena);
+    // the new tail is an empty extras list.
+    const old_extras = loaded.extras.entity_components;
+    const new_extras = try a.alloc([]const ComponentExtra, old_extras.len + 1);
+    @memcpy(new_extras[0..old_extras.len], old_extras);
+    new_extras[old_extras.len] = &.{};
+    loaded.extras.entity_components = new_extras;
+}
+
+/// Remove the entity at `idx` from `loaded.scene.entities` and the
+/// parallel `extras.entity_components` entry (when present). Returns
+/// `error.IndexOutOfBounds` if `idx` is past the end of either array.
+///
+/// Memory: the removed entries are simply skipped — the parse arena
+/// keeps holding their bytes until the whole `LoadedScene` is freed.
+/// That's fine for the editor's lifetime; a long-running session that
+/// adds + removes many entities would still bound to the file size
+/// because saves arena-reset on the next reload.
+pub fn removeEntity(loaded: *LoadedScene, idx: usize) !void {
+    const entities = loaded.scene.entities;
+    if (idx >= entities.len) return error.IndexOutOfBounds;
+
+    const a = loaded.arena.allocator();
+    const new_entities = try a.alloc(Entity, entities.len - 1);
+    @memcpy(new_entities[0..idx], entities[0..idx]);
+    @memcpy(new_entities[idx..], entities[idx + 1 ..]);
+    loaded.scene.entities = new_entities;
+
+    const old_extras = loaded.extras.entity_components;
+    if (idx < old_extras.len) {
+        const new_extras = try a.alloc([]const ComponentExtra, old_extras.len - 1);
+        @memcpy(new_extras[0..idx], old_extras[0..idx]);
+        @memcpy(new_extras[idx..], old_extras[idx + 1 ..]);
+        loaded.extras.entity_components = new_extras;
+    }
+}
+
 pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !LoadedScene {
     const raw = try std.fs.cwd().readFileAlloc(allocator, path, 16 * 1024 * 1024);
     defer allocator.free(raw);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1217,6 +1217,153 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"g\": 64") != null);
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"filled\": false") != null);
     }
+
+    test "insertEntity appends to entities and extras in lockstep" {
+        // Right-click → "Add entity here" path: the new entity must
+        // grow both arrays so the writer never reads past
+        // entity_components when emitting verbatim component blocks.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "name": "x",
+            \\    "entities": [
+            \\        { "components": { "Position": { "x": 1, "y": 2 } } }
+            \\    ]
+            \\}
+        ;
+        var loaded = try scene_io.parseScene(allocator, src);
+        defer loaded.deinit();
+        try expect.equal(loaded.scene.entities.len, 1);
+        try expect.equal(loaded.extras.entity_components.len, 1);
+
+        try scene_io.insertEntity(&loaded, .{
+            .position = .{ .x = 50, .y = 75 },
+        });
+
+        try expect.equal(loaded.scene.entities.len, 2);
+        try expect.equal(loaded.extras.entity_components.len, 2);
+        try expect.equal(loaded.extras.entity_components[1].len, 0);
+        try expect.toBeTrue(loaded.scene.entities[1].position != null);
+        try expect.equal(loaded.scene.entities[1].position.?.x, 50);
+        try expect.equal(loaded.scene.entities[1].position.?.y, 75);
+        try expect.toBeTrue(loaded.scene.entities[1].prefab == null);
+    }
+
+    test "insertEntity with prefab name (arena-owned) round-trips" {
+        // "Add entity from prefab" path: the prefab slice must
+        // survive across renders because it lives in the LoadedScene's
+        // arena. Saving and reparsing exercises the same lifetime
+        // contract the editor relies on.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "name": "x",
+            \\    "entities": []
+            \\}
+        ;
+        var loaded = try scene_io.parseScene(allocator, src);
+        defer loaded.deinit();
+
+        const prefab_name = try loaded.arena.allocator().dupe(u8, "coin");
+        try scene_io.insertEntity(&loaded, .{
+            .prefab = prefab_name,
+            .position = .{ .x = 12, .y = 34 },
+        });
+
+        const text = try scene_io.renderSceneJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"prefab\": \"coin\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"x\": 12") != null);
+
+        var loaded2 = try scene_io.parseScene(allocator, text);
+        defer loaded2.deinit();
+        try expect.equal(loaded2.scene.entities.len, 1);
+        try expect.toBeTrue(loaded2.scene.entities[0].prefab != null);
+        try expect.toBeTrue(std.mem.eql(u8, loaded2.scene.entities[0].prefab.?, "coin"));
+    }
+
+    test "removeEntity pops entities and extras together" {
+        // Delete-key path: dropping entity at idx 1 must also drop the
+        // parallel extras[1], otherwise the writer would splice the
+        // wrong unmodeled components onto the now-shifted entity.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "name": "x",
+            \\    "entities": [
+            \\        { "components": { "Position": { "x": 1, "y": 2 } } },
+            \\        { "components": { "Position": { "x": 3, "y": 4 }, "Coin": {} } },
+            \\        { "components": { "Position": { "x": 5, "y": 6 } } }
+            \\    ]
+            \\}
+        ;
+        var loaded = try scene_io.parseScene(allocator, src);
+        defer loaded.deinit();
+        try expect.equal(loaded.scene.entities.len, 3);
+        try expect.equal(loaded.extras.entity_components.len, 3);
+        try expect.equal(loaded.extras.entity_components[1].len, 1);
+
+        try scene_io.removeEntity(&loaded, 1);
+
+        try expect.equal(loaded.scene.entities.len, 2);
+        try expect.equal(loaded.extras.entity_components.len, 2);
+        // After removal, the survivors must be the entities with x=1 and x=5.
+        try expect.equal(loaded.scene.entities[0].position.?.x, 1);
+        try expect.equal(loaded.scene.entities[1].position.?.x, 5);
+        // And their extras must be the parallel-array versions — neither
+        // should now reference the dropped Coin slot.
+        try expect.equal(loaded.extras.entity_components[0].len, 0);
+        try expect.equal(loaded.extras.entity_components[1].len, 0);
+    }
+
+    test "removeEntity returns error on out-of-bounds index" {
+        // Defensive: the editor's selected_index can in principle drift
+        // (project switch, undo replay later). Out-of-bounds removal
+        // must surface as an error, not silently corrupt the slice.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{ "name": "x", "entities": [] }
+        ;
+        var loaded = try scene_io.parseScene(allocator, src);
+        defer loaded.deinit();
+
+        try std.testing.expectError(error.IndexOutOfBounds, scene_io.removeEntity(&loaded, 0));
+        try std.testing.expectError(error.IndexOutOfBounds, scene_io.removeEntity(&loaded, 42));
+    }
+
+    test "insertEntity then removeEntity round-trip through save / load" {
+        // The full editor add-and-delete cycle: add a prefab entity,
+        // then remove it again, then save. The output should match
+        // the original empty-entities form (modulo writer-driven
+        // formatting). Reparsing must yield zero entities.
+        const allocator = std.testing.allocator;
+        const src =
+            \\{
+            \\    "name": "x",
+            \\    "entities": []
+            \\}
+        ;
+        var loaded = try scene_io.parseScene(allocator, src);
+        defer loaded.deinit();
+
+        const name = try loaded.arena.allocator().dupe(u8, "wall");
+        try scene_io.insertEntity(&loaded, .{
+            .prefab = name,
+            .position = .{ .x = 7, .y = 8 },
+        });
+        try expect.equal(loaded.scene.entities.len, 1);
+        try scene_io.removeEntity(&loaded, 0);
+        try expect.equal(loaded.scene.entities.len, 0);
+        try expect.equal(loaded.extras.entity_components.len, 0);
+
+        const text = try scene_io.renderSceneJsonc(allocator, loaded);
+        defer allocator.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"wall\"") == null);
+
+        var loaded2 = try scene_io.parseScene(allocator, text);
+        defer loaded2.deinit();
+        try expect.equal(loaded2.scene.entities.len, 0);
+    }
 };
 
 pub const AtlasJsonTests = struct {


### PR DESCRIPTION
## Summary

Two new user actions in the scene editor (issue #5 remaining scope):

- **Right-click on empty canvas** opens a context menu with:
  - **Add entity here** — drops a blank `Entity` carrying just the Position at the click's world coordinates.
  - **Add entity from prefab...** — lazy-scans `<project>/prefabs/` and lets the user pick a stem; the picker has a filter box and is bounded to 256 entries.
- **Delete key** while an entity is selected removes it from both `loaded.scene.entities` and the parallel `extras.entity_components` array. Triggers only when the scene viewport (or its children) is hovered so inspector text fields aren't affected.

Implementation notes:

- New `scene_io.insertEntity` / `scene_io.removeEntity` keep the two parallel arrays lockstep. `insertEntity` grows `entity_components` with an empty `ComponentExtra` slice. `removeEntity` returns `error.IndexOutOfBounds` on misuse.
- Prefab name lifetime: dup'd into the `LoadedScene`'s arena (`loaded.arena.allocator()`) so the slice survives across renders. Positions are by-value scalars — no allocation needed.
- `modules/viewport.zig` State gains an optional `right_click_world: ?*?[2]f32` sink + a pure `worldFromScreen` helper; the prefab editor opts out by leaving the field at its default null.
- The right-click is only treated as "empty space" when the same hit-test that handles left-click selection returns null.

Refs #5.

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — 153/153 (added 5 zspec tests for insert/remove/round-trip/out-of-bounds)
- [x] `zig build gui-test` — 7/7 (baseline; no UI flow added)
- [x] `zig build smoke` — green