### PR TITLE
fix(inspector): clamp color floats before @intFromFloat in circle + polygon

### DIFF
--- a/src/modules/inspector/circle.zig
+++ b/src/modules/inspector/circle.zig
@@ -1,5 +1,6 @@
 //! Circle inspector section. Only renders when `entity.circle != null`.
 
+const std = @import("std");
 const zgui = @import("zgui");
 
 const scene_io = @import("../../scene_io.zig");
@@ -25,10 +26,14 @@ fn render(
         @as(f32, @floatFromInt(circle.a)) / 255.0,
     };
     if (zgui.colorEdit4("color", .{ .col = &col4 })) {
-        circle.r = @intFromFloat(@round(col4[0] * 255.0));
-        circle.g = @intFromFloat(@round(col4[1] * 255.0));
-        circle.b = @intFromFloat(@round(col4[2] * 255.0));
-        circle.a = @intFromFloat(@round(col4[3] * 255.0));
+        // Clamp before casting: `@intFromFloat` is safety-checked
+        // in Debug/ReleaseSafe and panics on out-of-range input.
+        // The colorEdit4 picker can produce slightly-out-of-[0,1]
+        // floats on some platforms; the clamp keeps that safe.
+        circle.r = @intFromFloat(@round(std.math.clamp(col4[0] * 255.0, 0.0, 255.0)));
+        circle.g = @intFromFloat(@round(std.math.clamp(col4[1] * 255.0, 0.0, 255.0)));
+        circle.b = @intFromFloat(@round(std.math.clamp(col4[2] * 255.0, 0.0, 255.0)));
+        circle.a = @intFromFloat(@round(std.math.clamp(col4[3] * 255.0, 0.0, 255.0)));
         is_dirty.* = true;
     }
     if (zgui.checkbox("filled", .{ .v = &circle.filled })) is_dirty.* = true;

--- a/src/modules/inspector/polygon.zig
+++ b/src/modules/inspector/polygon.zig
@@ -1,5 +1,6 @@
 //! Polygon inspector section. Only renders when `entity.polygon != null`.
 
+const std = @import("std");
 const zgui = @import("zgui");
 
 const scene_io = @import("../../scene_io.zig");
@@ -74,10 +75,11 @@ fn render(
         @as(f32, @floatFromInt(poly.a)) / 255.0,
     };
     if (zgui.colorEdit4("color", .{ .col = &col4 })) {
-        poly.r = @intFromFloat(@round(col4[0] * 255.0));
-        poly.g = @intFromFloat(@round(col4[1] * 255.0));
-        poly.b = @intFromFloat(@round(col4[2] * 255.0));
-        poly.a = @intFromFloat(@round(col4[3] * 255.0));
+        // Clamp before casting — see comment in inspector/rectangle.zig.
+        poly.r = @intFromFloat(@round(std.math.clamp(col4[0] * 255.0, 0.0, 255.0)));
+        poly.g = @intFromFloat(@round(std.math.clamp(col4[1] * 255.0, 0.0, 255.0)));
+        poly.b = @intFromFloat(@round(std.math.clamp(col4[2] * 255.0, 0.0, 255.0)));
+        poly.a = @intFromFloat(@round(std.math.clamp(col4[3] * 255.0, 0.0, 255.0)));
         is_dirty.* = true;
     }
     if (zgui.checkbox("filled", .{ .v = &poly.filled })) is_dirty.* = true;


### PR DESCRIPTION
Regression introduced by the inspector-section split (#65). The agent extracted \`circle.zig\` and \`polygon.zig\` from \`inspector.zig\` without preserving the \`std.math.clamp(_, 0.0, 255.0)\` guard that \`rectangle.zig\` correctly kept.

\`@intFromFloat\` is safety-checked in Debug/ReleaseSafe and panics on out-of-range input. \`colorEdit4\` can return slightly out-of-\[0,1\] floats on some platforms, so the cast can crash the editor at runtime — caught by gemini-code-assist's [post-merge review](https://github.com/labelle-toolkit/labelle-gui/pull/65#pullrequestreview-4273723386).

## Changes

\`src/modules/inspector/circle.zig\` and \`src/modules/inspector/polygon.zig\`:
- Add \`const std = @import("std");\`
- Wrap each \`col4[i] * 255.0\` in \`std.math.clamp(_, 0.0, 255.0)\` before \`@intFromFloat\`
- Brief comment pointing readers to \`rectangle.zig\` for the longer rationale

## Test plan

- [x] \`zig build\` clean
- [x] \`zig build test\` — 153/153 passing