### PR TITLE
fix(tree_view): recurse into subdirectories under top-level project folders

### DIFF
--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -53,6 +53,16 @@ pub const TreeView = struct {
 
     const Self = @This();
 
+    /// Max bytes for the on-stack path buffers used during render +
+    /// recursion. We deliberately do NOT use `std.fs.max_path_bytes`
+    /// here — it's ~96 KiB on Windows (vs 4 KiB on POSIX), and the
+    /// recursive walker plus the per-folder `managed_storage` array
+    /// would blow the default 1 MiB Windows thread stack the moment
+    /// any subfolder expanded (bugbot #70 high). 4 KiB covers any
+    /// realistic project path on every platform; longer paths get
+    /// skipped rather than crashing.
+    const path_buf_size: usize = 4096;
+
     pub fn init(allocator: std.mem.Allocator) Self {
         return .{
             .allocator = allocator,
@@ -116,7 +126,7 @@ pub const TreeView = struct {
         // `scripts/flows`, which appears in `ProjectFolders.all` as a
         // sibling of `scripts`. Without this, recursing into `scripts`
         // would surface `flows/` a second time with the wrong icon.
-        var managed_storage: [project.ProjectFolders.all.len][std.fs.max_path_bytes]u8 = undefined;
+        var managed_storage: [project.ProjectFolders.all.len][path_buf_size]u8 = undefined;
         var managed_paths: [project.ProjectFolders.all.len][]const u8 = undefined;
         for (project.ProjectFolders.all, 0..) |fname, i| {
             managed_paths[i] = std.fmt.bufPrint(&managed_storage[i], "{s}/{s}", .{ base_path, fname }) catch "";
@@ -127,7 +137,7 @@ pub const TreeView = struct {
             const icon = FolderIcons.forFolder(folder_name);
 
             // Build folder path on stack
-            var folder_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+            var folder_path_buf: [path_buf_size]u8 = undefined;
             const folder_path = std.fmt.bufPrint(&folder_path_buf, "{s}/{s}", .{ base_path, folder_name }) catch continue;
 
             // Create tree node label directly on stack
@@ -167,12 +177,13 @@ pub const TreeView = struct {
         }
 
         for (files) |file_entry| {
-            // Build full path on stack — both for routing (selected_path)
-            // and as the ImGui ID prefix so identically named items in
-            // different parents (e.g. scenes/enemies + prefabs/enemies)
-            // don't share open/closed state.
-            var full_path_buf: [std.fs.max_path_bytes]u8 = undefined;
-            const full_path = std.fmt.bufPrint(&full_path_buf, "{s}/{s}", .{ folder_path, file_entry.name }) catch continue;
+            // Single null-terminated full-path buffer covers all three
+            // uses: routing (`selected_path`), the managed-path dedup
+            // check, and the ImGui string ID (so identically named
+            // children of different parents — e.g. scenes/enemies vs
+            // prefabs/enemies — get distinct open/closed state).
+            var full_path_buf: [path_buf_size:0]u8 = undefined;
+            const full_path = std.fmt.bufPrintZ(&full_path_buf, "{s}/{s}", .{ folder_path, file_entry.name }) catch continue;
 
             // Skip subdirectories that are already top-level entries.
             if (file_entry.is_directory) {
@@ -190,13 +201,7 @@ pub const TreeView = struct {
             const file_icon = if (file_entry.is_directory) FolderIcons.folder_closed else FolderIcons.file;
             const label = std.fmt.bufPrintZ(&label_buf, "{s} {s}", .{ file_icon, file_entry.name }) catch continue;
 
-            // Disambiguate via a pushed string ID so the visible label
-            // stays short. The full path is unique per node, so two
-            // siblings with the same leaf name (or same-named subfolders
-            // under different top-level folders) get distinct IDs.
-            var id_buf: [std.fs.max_path_bytes:0]u8 = undefined;
-            const id_str = std.fmt.bufPrintZ(&id_buf, "{s}", .{full_path}) catch continue;
-            zgui.pushStrIdZ(id_str);
+            zgui.pushStrIdZ(full_path);
             defer zgui.popId();
 
             if (file_entry.is_directory) {

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -110,12 +110,24 @@ pub const TreeView = struct {
             self.needs_refresh = false;
         }
 
+        // Precompute absolute paths of every managed top-level folder. The
+        // recursive walker uses these to skip subdirectories that are
+        // ALREADY rendered as separate top-level entries — namely
+        // `scripts/flows`, which appears in `ProjectFolders.all` as a
+        // sibling of `scripts`. Without this, recursing into `scripts`
+        // would surface `flows/` a second time with the wrong icon.
+        var managed_storage: [project.ProjectFolders.all.len][std.fs.max_path_bytes]u8 = undefined;
+        var managed_paths: [project.ProjectFolders.all.len][]const u8 = undefined;
+        for (project.ProjectFolders.all, 0..) |fname, i| {
+            managed_paths[i] = std.fmt.bufPrint(&managed_storage[i], "{s}/{s}", .{ base_path, fname }) catch "";
+        }
+
         // Render each project folder (using stack buffers to avoid heap allocations per frame)
         for (project.ProjectFolders.all) |folder_name| {
             const icon = FolderIcons.forFolder(folder_name);
 
             // Build folder path on stack
-            var folder_path_buf: [512]u8 = undefined;
+            var folder_path_buf: [std.fs.max_path_bytes]u8 = undefined;
             const folder_path = std.fmt.bufPrint(&folder_path_buf, "{s}/{s}", .{ base_path, folder_name }) catch continue;
 
             // Create tree node label directly on stack
@@ -125,44 +137,88 @@ pub const TreeView = struct {
             const node_open = zgui.treeNodeFlags(&node_label, .{});
 
             if (node_open) {
-                // Load and display files in this folder
-                const files = self.getFilesForFolder(folder_path) catch {
-                    zgui.textDisabled("  (error reading folder)", .{});
-                    zgui.treePop();
-                    continue;
-                };
+                if (self.renderFolder(folder_path, &managed_paths)) {
+                    file_selected = true;
+                }
+                zgui.treePop();
+            }
+        }
 
-                if (files.len == 0) {
-                    zgui.textDisabled("  (empty)", .{});
-                } else {
-                    for (files) |file_entry| {
-                        const file_icon = if (file_entry.is_directory) FolderIcons.folder_closed else FolderIcons.file;
+        return file_selected;
+    }
 
-                        // Create file label directly on stack
-                        var file_label: [256:0]u8 = undefined;
-                        _ = std.fmt.bufPrintZ(&file_label, "{s} {s}", .{ file_icon, file_entry.name }) catch continue;
+    /// Render the contents of a single directory. Recurses into subdirectories
+    /// (each becomes its own `treeNodeFlags`) so the user can drill arbitrarily
+    /// deep. Files at any depth render as `zgui.selectable` and route through
+    /// `self.selected_path` exactly like top-level files do. Subdirectories
+    /// whose absolute path matches a `managed_paths` entry are suppressed —
+    /// they're already rendered at top level (see `render`).
+    fn renderFolder(self: *Self, folder_path: []const u8, managed_paths: []const []const u8) bool {
+        var file_selected = false;
 
-                        // Build full path on stack for selection check
-                        var full_path_buf: [1024]u8 = undefined;
-                        const full_path = std.fmt.bufPrint(&full_path_buf, "{s}/{s}", .{ folder_path, file_entry.name }) catch continue;
+        const files = self.getFilesForFolder(folder_path) catch {
+            zgui.textDisabled("  (error reading folder)", .{});
+            return false;
+        };
 
-                        const is_selected = if (self.selected_path) |sel|
-                            std.mem.eql(u8, sel, full_path)
-                        else
-                            false;
+        if (files.len == 0) {
+            zgui.textDisabled("  (empty)", .{});
+            return false;
+        }
 
-                        if (zgui.selectable(&file_label, .{ .selected = is_selected })) {
-                            // Update selected path (only allocate when selection changes)
-                            if (self.selected_path) |old_path| {
-                                self.allocator.free(old_path);
-                            }
-                            self.selected_path = self.allocator.dupe(u8, full_path) catch null;
-                            file_selected = true;
-                        }
+        for (files) |file_entry| {
+            // Build full path on stack — both for routing (selected_path)
+            // and as the ImGui ID prefix so identically named items in
+            // different parents (e.g. scenes/enemies + prefabs/enemies)
+            // don't share open/closed state.
+            var full_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const full_path = std.fmt.bufPrint(&full_path_buf, "{s}/{s}", .{ folder_path, file_entry.name }) catch continue;
+
+            // Skip subdirectories that are already top-level entries.
+            if (file_entry.is_directory) {
+                var is_managed = false;
+                for (managed_paths) |mp| {
+                    if (mp.len != 0 and std.mem.eql(u8, mp, full_path)) {
+                        is_managed = true;
+                        break;
                     }
                 }
+                if (is_managed) continue;
+            }
 
-                zgui.treePop();
+            var label_buf: [512:0]u8 = undefined;
+            const file_icon = if (file_entry.is_directory) FolderIcons.folder_closed else FolderIcons.file;
+            const label = std.fmt.bufPrintZ(&label_buf, "{s} {s}", .{ file_icon, file_entry.name }) catch continue;
+
+            // Disambiguate via a pushed string ID so the visible label
+            // stays short. The full path is unique per node, so two
+            // siblings with the same leaf name (or same-named subfolders
+            // under different top-level folders) get distinct IDs.
+            var id_buf: [std.fs.max_path_bytes:0]u8 = undefined;
+            const id_str = std.fmt.bufPrintZ(&id_buf, "{s}", .{full_path}) catch continue;
+            zgui.pushStrIdZ(id_str);
+            defer zgui.popId();
+
+            if (file_entry.is_directory) {
+                if (zgui.treeNodeFlags(label, .{})) {
+                    if (self.renderFolder(full_path, managed_paths)) {
+                        file_selected = true;
+                    }
+                    zgui.treePop();
+                }
+            } else {
+                const is_selected = if (self.selected_path) |sel|
+                    std.mem.eql(u8, sel, full_path)
+                else
+                    false;
+
+                if (zgui.selectable(label, .{ .selected = is_selected })) {
+                    if (self.selected_path) |old_path| {
+                        self.allocator.free(old_path);
+                    }
+                    self.selected_path = self.allocator.dupe(u8, full_path) catch null;
+                    file_selected = true;
+                }
             }
         }
 


### PR DESCRIPTION
Closes #69.

## Summary

- `tree_view.render` previously walked only one level deep — subdirectories under `scenes/`, `prefabs/`, etc. rendered as flat `zgui.selectable` items that couldn't expand and didn't route on click.
- Extracted a recursive `renderFolder(folder_path, managed_paths)` that emits a `treeNodeFlags` for each `is_directory` entry and recurses inside; files at any depth route through the existing `App.openScene` / `openPrefab` / `openGizmo` / `openFlow` classifiers (all prefix-based, already nested-path-safe — see tests at `src/tests.zig:1476-1562`).
- IDs are pushed from each entry's absolute path via `zgui.pushStrIdZ` so identically named siblings in different parents (`scenes/enemies/` vs `prefabs/enemies/`) get independent open/closed state.
- Subdirectories whose absolute path matches a managed top-level entry (currently just `scripts/flows`) are suppressed during recursion so they aren't rendered twice — once under `scripts/` with a generic folder icon, once at top level with the diagram icon.
- Empty subdirectories show `(empty)` under their treeNode, matching the existing top-level empty-folder behavior.

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — 177/177
- [x] `zig build gui-test` — 8/8
- [x] Live verification against `flying-platform-labelle`:
  - [x] `scenes/debug/` expands as a tree node (one level deep)
  - [x] `scenes/debug/bandit/` expands inside it (two levels deep)
  - [x] Clicking `scenes/debug/bandit/bandit_full_chain.jsonc` opens the scene editor (`Scene: bandit_full_chain (entities: 16)`)
  - [x] `assets/raw/background/cloud_up/cloud_afternoon/` confirmed renders five levels deep
- [ ] (Spot-check optional) `scripts/flows` does not appear duplicated when `scripts/` is expanded
- [ ] (Spot-check optional) Empty subdirectories show `(empty)`