### PR TITLE
feat(prefs): user-configurable UI font size

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -30,6 +30,8 @@ const atlas = @import("atlas.zig");
 const gizmos = @import("gizmos.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
 const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
+const preferences_dialog = @import("dialogs/preferences.zig");
+const prefs_mod = @import("prefs.zig");
 
 const STATUS_BUF_LEN = 256;
 const SCENE_NAME_BUF_LEN = 128;
@@ -177,6 +179,18 @@ pub const App = struct {
     new_scene_name: [SCENE_NAME_BUF_LEN:0]u8 = [_:0]u8{0} ** SCENE_NAME_BUF_LEN,
     show_dpi_warning: bool = false,
 
+    show_preferences: bool = false,
+    /// Live preferences edited by the Preferences dialog. Changes are
+    /// persisted to disk on every slider/stepper edit; the ImGui font
+    /// atlas isn't rebuilt mid-session so values take effect on the
+    /// next launch (the dialog surfaces a "Restart to apply" notice
+    /// when `prefs.font_scale != startup_font_scale`).
+    prefs: prefs_mod.Preferences = .{},
+    /// Snapshot of `prefs` at startup. Drives the "Restart to apply"
+    /// hint: when `prefs` diverges from this we know the user changed
+    /// something that won't take effect until next launch.
+    startup_prefs: prefs_mod.Preferences = .{},
+
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
     modules: [5]module.Module = undefined,
@@ -184,7 +198,7 @@ pub const App = struct {
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator, window: *zglfw.Window) !*Self {
+    pub fn init(allocator: std.mem.Allocator, window: *zglfw.Window, user_prefs: prefs_mod.Preferences) !*Self {
         const app = try allocator.create(Self);
         errdefer allocator.destroy(app);
 
@@ -195,6 +209,8 @@ pub const App = struct {
             .tree_view = tree_view.TreeView.init(allocator),
             .compiler = compiler.Compiler.init(allocator),
             .preview = preview.PreviewSession.init(allocator),
+            .prefs = user_prefs,
+            .startup_prefs = user_prefs,
         };
 
         app.modules[0] = project_tree_mod.makeModule(app);
@@ -435,6 +451,7 @@ pub const App = struct {
         new_scene_dialog.render(self);
         close_scene_dialog.render(self);
         dpi_warning_dialog.render(self);
+        preferences_dialog.render(self);
     }
 
     // ─── Menu bar ───────────────────────────────────────────────────────
@@ -468,6 +485,8 @@ pub const App = struct {
             self.project_manager.closeProject();
             self.setStatus("Project closed");
         }
+        zgui.separator();
+        if (zgui.menuItem("Preferences...", .{})) self.show_preferences = true;
         zgui.separator();
         if (zgui.menuItem("Exit", .{})) self.window.setShouldClose(true);
     }

--- a/src/dialogs/preferences.zig
+++ b/src/dialogs/preferences.zig
@@ -1,0 +1,81 @@
+//! Preferences modal — user-scoped settings that live across projects.
+//!
+//! Currently surfaces one knob: `font_scale`, a multiplier applied on
+//! top of the DPI-derived font size at startup. ImGui's font atlas is
+//! sized once at app launch and rebuilt only on shutdown / restart, so
+//! a change here does NOT take effect mid-session. The dialog flags a
+//! "Restart to apply" line when the live value diverges from what was
+//! loaded at startup, matching the existing DPI-change UX in
+//! `dpi_warning.zig`.
+//!
+//! Persistence is per-edit: every slider tick writes the new value to
+//! the platform-appropriate app-data dir via `prefs.save`. The next
+//! launch reads it from `prefs.loadOrDefault`.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const prefs_mod = @import("../prefs.zig");
+
+pub fn render(app: *App) void {
+    if (app.show_preferences) zgui.openPopup("Preferences", .{});
+    if (!zgui.beginPopupModal("Preferences", .{
+        .popen = &app.show_preferences,
+        .flags = .{ .always_auto_resize = true },
+    })) return;
+    defer zgui.endPopup();
+
+    zgui.text("Font scale", .{});
+    zgui.textDisabled(
+        "Multiplier applied to the UI font size (on top of DPI).",
+        .{},
+    );
+
+    // `sliderFloat` returns true on the frames the value changed. We
+    // clamp before persisting so a hand-edited prefs file can't push the
+    // slider past its bounds via a previous launch.
+    var v: f32 = app.prefs.font_scale;
+    const changed = zgui.sliderFloat("##font_scale", .{
+        .v = &v,
+        .min = prefs_mod.min_font_scale,
+        .max = prefs_mod.max_font_scale,
+        .cfmt = "%.2fx",
+    });
+    if (changed) {
+        app.prefs.font_scale = std.math.clamp(
+            v,
+            prefs_mod.min_font_scale,
+            prefs_mod.max_font_scale,
+        );
+        prefs_mod.save(app.allocator, app.prefs) catch |err| {
+            std.log.err("prefs: save failed: {s}", .{@errorName(err)});
+            app.setStatus("Could not save preferences!");
+        };
+    }
+
+    if (zgui.button("Reset to default", .{})) {
+        app.prefs.font_scale = prefs_mod.default_font_scale;
+        prefs_mod.save(app.allocator, app.prefs) catch |err| {
+            std.log.err("prefs: save failed: {s}", .{@errorName(err)});
+            app.setStatus("Could not save preferences!");
+        };
+    }
+
+    zgui.spacing();
+    zgui.separator();
+    zgui.spacing();
+
+    if (app.prefs.font_scale != app.startup_prefs.font_scale) {
+        zgui.textColored(
+            .{ 1.0, 0.78, 0.25, 1.0 },
+            "Restart the app for changes to take effect.",
+            .{},
+        );
+    } else {
+        zgui.textDisabled("No pending changes.", .{});
+    }
+
+    zgui.spacing();
+    if (zgui.button("Close", .{ .w = 120 })) app.show_preferences = false;
+}

--- a/src/dialogs/preferences.zig
+++ b/src/dialogs/preferences.zig
@@ -66,7 +66,19 @@ pub fn render(app: *App) void {
     zgui.separator();
     zgui.spacing();
 
-    if (app.prefs.font_scale != app.startup_prefs.font_scale) {
+    // `approxEqAbs` instead of `!=` so tiny float drift from the slider
+    // doesn't surface a "Restart to apply" hint when the live value is
+    // visually identical to the startup value (gemini #72 medium). The
+    // slider's display format is `%.2fx`, so anything closer than 0.001
+    // is indistinguishable to the user.
+    const drift_epsilon: f32 = 0.001;
+    const has_pending = !std.math.approxEqAbs(
+        f32,
+        app.prefs.font_scale,
+        app.startup_prefs.font_scale,
+        drift_epsilon,
+    );
+    if (has_pending) {
         zgui.textColored(
             .{ 1.0, 0.78, 0.25, 1.0 },
             "Restart the app for changes to take effect.",

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -65,7 +65,7 @@ pub fn main() !void {
     const engine = zgui.te.getTestEngine().?;
     engine.setRunSpeed(.fast);
 
-    const app = try App.init(allocator, window);
+    const app = try App.init(allocator, window, .{});
     defer app.deinit();
     g_app = app;
     defer g_app = null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,6 +6,7 @@ const zstbi = @import("zstbi");
 
 const icons = @import("icons.zig");
 const config = @import("config.zig");
+const prefs_mod = @import("prefs.zig");
 const App = @import("app.zig").App;
 
 const gl = zopengl.bindings;
@@ -71,7 +72,12 @@ pub fn main() !void {
     g_initial_scale = scale_factor;
     g_current_scale.store(scale_factor, .release);
     _ = window.setContentScaleCallback(contentScaleCallback);
-    const font_size = config.ui.base_font_size * scale_factor;
+
+    // Load user preferences before sizing fonts — `font_scale` rides on
+    // top of the DPI factor (see `src/prefs.zig`). On first run or any
+    // read error this falls back to defaults, so the GUI always starts.
+    const user_prefs = prefs_mod.loadOrDefault(allocator);
+    const font_size = config.ui.base_font_size * scale_factor * user_prefs.font_scale;
 
     var default_config = zgui.FontConfig.init();
     default_config.size_pixels = font_size;
@@ -93,7 +99,7 @@ pub fn main() !void {
     zgui.backend.init(window);
     defer zgui.backend.deinit();
 
-    const app = try App.init(allocator, window);
+    const app = try App.init(allocator, window, user_prefs);
     defer app.deinit();
 
     std.log.info("Labelle started", .{});

--- a/src/prefs.zig
+++ b/src/prefs.zig
@@ -66,9 +66,13 @@ pub fn loadOrDefault(allocator: std.mem.Allocator) Preferences {
 }
 
 /// Path-injectable variant of `loadOrDefault`. Used by tests to point
-/// at a temp file; production callers go through `loadOrDefault`.
+/// at a temp file; production callers go through `loadOrDefault`. The
+/// path must be absolute — `getAppDataDir` returns one, and tests
+/// build one from `realpathAlloc`. `openFileAbsolute` over
+/// `cwd().openFile` so a Windows path on a different drive than CWD
+/// resolves correctly (gemini #72 medium).
 pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) Preferences {
-    const file = std.fs.cwd().openFile(path, .{}) catch |err| {
+    const file = std.fs.openFileAbsolute(path, .{}) catch |err| {
         if (err == error.FileNotFound) {
             std.log.info("prefs: no preferences file at {s}; using defaults", .{path});
         } else {
@@ -116,12 +120,18 @@ pub fn save(allocator: std.mem.Allocator, prefs: Preferences) !void {
     const path = try std.fs.path.join(allocator, &.{ dir, PREFS_FILENAME });
     defer allocator.free(path);
 
-    try saveToPath(path, prefs);
+    try saveToPath(allocator, path, prefs);
 }
 
 /// Path-injectable variant of `save`. The parent directory must already
 /// exist; production callers go through `save` which makePath's first.
-pub fn saveToPath(path: []const u8, prefs: Preferences) !void {
+///
+/// Writes atomically: emits to `<path>.tmp` first, then renames over the
+/// real path. A crash mid-write leaves the previous-good preferences
+/// intact (or no file at all on first run) rather than corrupting the
+/// real file (gemini #72 medium). Uses absolute-path APIs so a Windows
+/// path on a different drive than CWD resolves correctly.
+pub fn saveToPath(allocator: std.mem.Allocator, path: []const u8, prefs: Preferences) !void {
     const clamped: Preferences = .{
         .font_scale = std.math.clamp(prefs.font_scale, min_font_scale, max_font_scale),
     };
@@ -137,8 +147,14 @@ pub fn saveToPath(path: []const u8, prefs: Preferences) !void {
         \\
     , .{clamped.font_scale});
 
-    var file = try std.fs.cwd().createFile(path, .{ .truncate = true });
-    defer file.close();
-    try file.writeAll(body);
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
+    defer allocator.free(tmp_path);
+
+    {
+        var file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
+        defer file.close();
+        try file.writeAll(body);
+    }
+    try std.fs.renameAbsolute(tmp_path, path);
 }
 

--- a/src/prefs.zig
+++ b/src/prefs.zig
@@ -1,0 +1,144 @@
+//! User-scoped preferences for labelle-gui.
+//!
+//! Persisted as a small ZON file in the platform-specific app-data dir
+//! resolved by `std.fs.getAppDataDir`:
+//!
+//!   - macOS:   `~/Library/Application Support/labelle-gui/preferences.zon`
+//!   - Linux:   `~/.config/labelle-gui/preferences.zon`
+//!   - Windows: `%APPDATA%\labelle-gui\preferences.zon`
+//!
+//! Read once at startup (via `loadOrDefault`) and re-written whenever the
+//! Preferences dialog changes a value. The application reads the file's
+//! `font_scale` to size the ImGui font atlas at startup; the atlas isn't
+//! rebuilt mid-session, so changes take effect on next launch — matching
+//! the existing DPI-change UX (see `dialogs/dpi_warning.zig`).
+//!
+//! Robust to a missing or malformed file: `loadOrDefault` always returns
+//! a `Preferences` value, defaulting unknown / invalid fields. A bad file
+//! is logged and overwritten the next time `save` is called, so manual
+//! editing mistakes are self-healing.
+
+const std = @import("std");
+
+pub const APP_DATA_NAME = "labelle-gui";
+pub const PREFS_FILENAME = "preferences.zon";
+
+/// Bounds for the user-controlled scaler. Clamped on both load and save
+/// so a hand-edited file with `font_scale = 99.0` can't push the font
+/// off the screen, and a `0.1` won't render unreadably small.
+pub const min_font_scale: f32 = 0.5;
+pub const max_font_scale: f32 = 3.0;
+/// Default applied on first launch and by the "Reset to default" button.
+/// `1.5` is the readable baseline on the displays the team uses; the
+/// legacy `1.0` rendered too small at default DPI on most external
+/// monitors.
+pub const default_font_scale: f32 = 1.5;
+
+pub const Preferences = struct {
+    /// Multiplier applied on top of the DPI-derived font size at
+    /// startup. Larger values produce bigger text. The ImGui atlas is
+    /// sized at startup so a change requires a restart to take effect.
+    font_scale: f32 = default_font_scale,
+};
+
+/// Return the absolute path to the preferences file. Caller owns the
+/// returned slice. The parent directory is NOT created — `save` does
+/// that lazily so the read path stays fast on the common case where the
+/// directory already exists.
+pub fn pathOwned(allocator: std.mem.Allocator) ![]u8 {
+    const dir = try std.fs.getAppDataDir(allocator, APP_DATA_NAME);
+    defer allocator.free(dir);
+    return std.fs.path.join(allocator, &.{ dir, PREFS_FILENAME });
+}
+
+/// Load preferences from disk, falling back to defaults on any error
+/// (file missing, parse failure, unreadable directory, etc.). Logs the
+/// underlying error at `info` level on missing-file (expected first
+/// run) and `warn` for everything else.
+pub fn loadOrDefault(allocator: std.mem.Allocator) Preferences {
+    const path = pathOwned(allocator) catch |err| {
+        std.log.warn("prefs: could not resolve preferences path: {s}", .{@errorName(err)});
+        return .{};
+    };
+    defer allocator.free(path);
+
+    return loadFromPath(allocator, path);
+}
+
+/// Path-injectable variant of `loadOrDefault`. Used by tests to point
+/// at a temp file; production callers go through `loadOrDefault`.
+pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) Preferences {
+    const file = std.fs.cwd().openFile(path, .{}) catch |err| {
+        if (err == error.FileNotFound) {
+            std.log.info("prefs: no preferences file at {s}; using defaults", .{path});
+        } else {
+            std.log.warn("prefs: could not open {s}: {s}", .{ path, @errorName(err) });
+        }
+        return .{};
+    };
+    defer file.close();
+
+    const max_bytes: usize = 1 << 14; // 16 KiB — preferences are tiny.
+    const raw = file.readToEndAlloc(allocator, max_bytes) catch |err| {
+        std.log.warn("prefs: read {s} failed: {s}", .{ path, @errorName(err) });
+        return .{};
+    };
+    defer allocator.free(raw);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const src = a.dupeZ(u8, raw) catch return .{};
+
+    var diag: std.zon.parse.Diagnostics = .{};
+    defer diag.deinit(a);
+    const parsed = std.zon.parse.fromSlice(Preferences, a, src, &diag, .{
+        .ignore_unknown_fields = true,
+    }) catch |err| {
+        std.log.warn("prefs: parse {s} failed: {s} — using defaults", .{ path, @errorName(err) });
+        return .{};
+    };
+
+    return .{
+        .font_scale = std.math.clamp(parsed.font_scale, min_font_scale, max_font_scale),
+    };
+}
+
+/// Persist `prefs` to disk, creating the parent directory if needed.
+/// Clamps `font_scale` to the documented bounds before writing so the
+/// next read is self-healing.
+pub fn save(allocator: std.mem.Allocator, prefs: Preferences) !void {
+    const dir = try std.fs.getAppDataDir(allocator, APP_DATA_NAME);
+    defer allocator.free(dir);
+    try std.fs.cwd().makePath(dir);
+
+    const path = try std.fs.path.join(allocator, &.{ dir, PREFS_FILENAME });
+    defer allocator.free(path);
+
+    try saveToPath(path, prefs);
+}
+
+/// Path-injectable variant of `save`. The parent directory must already
+/// exist; production callers go through `save` which makePath's first.
+pub fn saveToPath(path: []const u8, prefs: Preferences) !void {
+    const clamped: Preferences = .{
+        .font_scale = std.math.clamp(prefs.font_scale, min_font_scale, max_font_scale),
+    };
+
+    // Hand-rolled emission keeps the file readable and avoids pulling in
+    // `std.zon.stringify`'s broader formatting choices. We only have one
+    // field and the format is dirt-simple.
+    var buf: [256]u8 = undefined;
+    const body = try std.fmt.bufPrint(&buf,
+        \\.{{
+        \\    .font_scale = {d},
+        \\}}
+        \\
+    , .{clamped.font_scale});
+
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(body);
+}
+

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -16,6 +16,7 @@ const gizmos = @import("gizmos.zig");
 const preview = @import("preview.zig");
 const flow_projector = @import("flows/projector.zig");
 const flow_types = @import("flows/types.zig");
+const prefs = @import("prefs.zig");
 
 test {
     zspec.runAll(@This());
@@ -3096,5 +3097,79 @@ pub const FlowsRendererTests = struct {
         var g = try projectStr(source);
         defer g.deinit();
         try expect.equal(g.entry_points.len, 1);
+    }
+};
+
+pub const PreferencesTests = struct {
+    fn tmpPath(allocator: std.mem.Allocator, tmp: std.testing.TmpDir) ![]u8 {
+        const dir = try tmp.dir.realpathAlloc(allocator, ".");
+        defer allocator.free(dir);
+        return std.fs.path.join(allocator, &.{ dir, prefs.PREFS_FILENAME });
+    }
+
+    test "defaults when file is missing" {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const path = try tmpPath(std.testing.allocator, tmp);
+        defer std.testing.allocator.free(path);
+
+        const loaded = prefs.loadFromPath(std.testing.allocator, path);
+        try expect.equal(loaded.font_scale, prefs.default_font_scale);
+    }
+
+    test "round-trip preserves value" {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const path = try tmpPath(std.testing.allocator, tmp);
+        defer std.testing.allocator.free(path);
+
+        try prefs.saveToPath(path, .{ .font_scale = 1.5 });
+
+        const loaded = prefs.loadFromPath(std.testing.allocator, path);
+        try expect.equal(loaded.font_scale, @as(f32, 1.5));
+    }
+
+    test "save clamps oversized values" {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const path = try tmpPath(std.testing.allocator, tmp);
+        defer std.testing.allocator.free(path);
+
+        try prefs.saveToPath(path, .{ .font_scale = 9.0 });
+
+        const loaded = prefs.loadFromPath(std.testing.allocator, path);
+        try expect.equal(loaded.font_scale, prefs.max_font_scale);
+    }
+
+    test "load clamps undersized values" {
+        // Simulates a hand-edited prefs file with an out-of-bounds value
+        // — load is expected to clamp on the way in so the rest of the
+        // app sees only valid scales.
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const path = try tmpPath(std.testing.allocator, tmp);
+        defer std.testing.allocator.free(path);
+
+        const hand_edited = ".{ .font_scale = 0.1 }\n";
+        const file = try std.fs.cwd().createFile(path, .{});
+        defer file.close();
+        try file.writeAll(hand_edited);
+
+        const loaded = prefs.loadFromPath(std.testing.allocator, path);
+        try expect.equal(loaded.font_scale, prefs.min_font_scale);
+    }
+
+    test "malformed file falls back to defaults" {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const path = try tmpPath(std.testing.allocator, tmp);
+        defer std.testing.allocator.free(path);
+
+        const file = try std.fs.cwd().createFile(path, .{});
+        defer file.close();
+        try file.writeAll("this is not zon");
+
+        const loaded = prefs.loadFromPath(std.testing.allocator, path);
+        try expect.equal(loaded.font_scale, prefs.default_font_scale);
     }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3123,7 +3123,7 @@ pub const PreferencesTests = struct {
         const path = try tmpPath(std.testing.allocator, tmp);
         defer std.testing.allocator.free(path);
 
-        try prefs.saveToPath(path, .{ .font_scale = 1.5 });
+        try prefs.saveToPath(std.testing.allocator, path, .{ .font_scale = 1.5 });
 
         const loaded = prefs.loadFromPath(std.testing.allocator, path);
         try expect.equal(loaded.font_scale, @as(f32, 1.5));
@@ -3135,7 +3135,7 @@ pub const PreferencesTests = struct {
         const path = try tmpPath(std.testing.allocator, tmp);
         defer std.testing.allocator.free(path);
 
-        try prefs.saveToPath(path, .{ .font_scale = 9.0 });
+        try prefs.saveToPath(std.testing.allocator, path, .{ .font_scale = 9.0 });
 
         const loaded = prefs.loadFromPath(std.testing.allocator, path);
         try expect.equal(loaded.font_scale, prefs.max_font_scale);


### PR DESCRIPTION
Closes #71.

## Summary

- Adds a persistent `font_scale` preference applied on top of the existing DPI factor when the ImGui font atlas is built at startup.
- File → Preferences... opens a modal with a slider over `[0.5, 3.0]`, a Reset button, and a yellow "Restart to apply" notice when the live value diverges from what loaded at startup.
- Persisted to a ZON file in the platform app-data dir (`getAppDataDir` → `~/Library/Application Support/labelle-gui/preferences.zon` on macOS, `~/.config/labelle-gui/preferences.zon` on Linux, `%APPDATA%\labelle-gui\preferences.zon` on Windows).
- Default `font_scale = 1.5` — the legacy `1.0` rendered too small at default DPI on the team's typical monitor mix.

## Scope decision

The font atlas is sized once at startup. ImGui can rebuild it live, but that path is unsolved in this codebase (the existing DPI handler in `dialogs/dpi_warning.zig` also punts to a "please restart" warning rather than rebuilding mid-session). Matching that pattern here keeps risk small and lets us ship readability today; a follow-up can unify both flows around a live rebuild later, benefiting font_scale AND the DPI handler at once.

## Implementation

- **`src/prefs.zig`** (new) — tolerant load/save. Missing or malformed files fall back to defaults and log warn (self-healing). Clamps on both ends so a hand-edited value can't push the UI off the screen. `loadFromPath` / `saveToPath` are exposed so tests can point at temp dirs without mutating real app data.
- **`src/dialogs/preferences.zig`** (new) — modal with the same shape as `dialogs/dpi_warning.zig`. Persists on every slider tick.
- **`src/main.zig`** — loads prefs early, computes `font_size = base_font_size * dpi_scale * font_scale`.
- **`src/app.zig`** — stores `prefs` (live edit value) and `startup_prefs` (snapshot loaded at launch) so the dialog can show "Restart to apply" when they diverge.

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — **182/182** (5 new prefs tests: round-trip, missing-file default, malformed-file fallback, clamp on load, clamp on save)
- [x] `zig build gui-test` — 8/8
- [x] Live verification against `flying-platform-labelle`:
  - [x] Preferences dialog opens via File → Preferences...
  - [x] Slider live-saves to disk; reopening shows the persisted value
  - [x] Restart picks up the new size across project tree, tabs, inspector, viewport
  - [x] Reset to default + restart applies `1.5`

## Follow-up (not in this PR)

- Live font-atlas rebuild that would replace both the "Restart to apply" notice here AND the existing DPI warning. Same rebuild path serves both flows.