### PR TITLE
fix(tree_view): align file rows with subfolder icon column (#73)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -174,6 +174,13 @@ pub const App = struct {
     show_gizmos: bool = true,
 
     show_project_tree: bool = true,
+    /// Current width of the Project Tree sidebar (in screen px). The
+    /// user can resize the sidebar by dragging its right edge; the new
+    /// width is read back from ImGui each frame and stored here. Main
+    /// content's left position + width derives from this value so the
+    /// editor area follows the drag. Initialized from
+    /// `config.ui.sidebar_width`.
+    sidebar_width: f32 = config.ui.sidebar_width,
 
     show_new_scene_dialog: bool = false,
     new_scene_name: [SCENE_NAME_BUF_LEN:0]u8 = [_:0]u8{0} ** SCENE_NAME_BUF_LEN,
@@ -656,8 +663,9 @@ pub const App = struct {
         const viewport = zgui.getMainViewport();
         const work_pos = viewport.getWorkPos();
         const work_size = viewport.getWorkSize();
-        zgui.setNextWindowPos(.{ .x = work_pos[0] + config.ui.sidebar_width, .y = work_pos[1] });
-        zgui.setNextWindowSize(.{ .w = work_size[0] - config.ui.sidebar_width, .h = work_size[1] - config.ui.status_bar_height });
+        const sidebar_w = if (self.show_project_tree) self.sidebar_width else 0.0;
+        zgui.setNextWindowPos(.{ .x = work_pos[0] + sidebar_w, .y = work_pos[1] });
+        zgui.setNextWindowSize(.{ .w = work_size[0] - sidebar_w, .h = work_size[1] - config.ui.status_bar_height });
 
         if (!zgui.begin("##main", .{ .flags = .{
             .no_title_bar = true,

--- a/src/icons.zig
+++ b/src/icons.zig
@@ -25,6 +25,10 @@ pub const FA_SCROLL = "\u{f70e}"; // scroll (for scripts)
 pub const FA_DATABASE = "\u{f1c0}"; // database (for resources)
 pub const FA_PROJECT_DIAGRAM = "\u{f046}"; // project-diagram / graph (for flows)
 
+// Disclosure chevrons (tree view)
+pub const FA_CARET_RIGHT = "\u{f0da}"; // caret-right (closed disclosure)
+pub const FA_CARET_DOWN = "\u{f0d7}"; // caret-down (open disclosure)
+
 // Common UI icons
 pub const FA_PLUS = "\u{f067}"; // plus
 pub const FA_MINUS = "\u{f068}"; // minus

--- a/src/main.zig
+++ b/src/main.zig
@@ -87,6 +87,14 @@ pub fn main() !void {
     fa_config.merge_mode = true;
     fa_config.pixel_snap_h = true;
     fa_config.glyph_min_advance_x = font_size;
+    // FontAwesome glyphs sit above the default text baseline because the
+    // icon designs center on the glyph box's visual middle while letters
+    // hang from the cap line. Push the merged icon range down by ~25 %
+    // of the active font size so folder/file icons sit centered against
+    // the x-height of their accompanying text (in the tree view and
+    // elsewhere). Proportional to font_size, so it scales correctly with
+    // DPI and the user's font-scale preference.
+    fa_config.glyph_offset = .{ 0.0, font_size * 0.1 };
     _ = zgui.io.addFontFromFileWithConfig(
         "assets/fonts/fa-solid-900.ttf",
         font_size,

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -80,17 +80,27 @@ fn render(app: *App) void {
     const viewport = zgui.getMainViewport();
     const work_pos = viewport.getWorkPos();
     const work_size = viewport.getWorkSize();
+    // Clamp the persisted width to a sane range every frame so a
+    // pathological resize (e.g. dragging past the editor area) recovers
+    // on the next frame.
+    const min_w: f32 = 120.0;
+    const max_w: f32 = work_size[0] * 0.6;
+    app.sidebar_width = std.math.clamp(app.sidebar_width, min_w, max_w);
     zgui.setNextWindowPos(.{ .x = work_pos[0], .y = work_pos[1] });
     zgui.setNextWindowSize(.{
-        .w = config.ui.sidebar_width,
+        .w = app.sidebar_width,
         .h = work_size[1] - config.ui.status_bar_height,
+        .cond = .always,
     });
 
     if (zgui.begin("Project", .{ .flags = .{
-        .no_resize = true,
         .no_move = true,
         .no_collapse = true,
     } })) {
+        // Read back the live window width — ImGui updates this in-place
+        // while the user drags the right edge — so the main content
+        // window can shift to follow on the same frame.
+        app.sidebar_width = zgui.getWindowSize()[0];
         if (app.project_manager.current_project) |proj| {
             // Tree returns true on the frame a file is newly clicked.
             // `.jsonc` files under `scenes/` route to the scene

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -205,49 +205,12 @@ pub const ConstantsTests = struct {
 };
 
 pub const FolderIconsTests = struct {
-    test "components folder has cube icon" {
-        const icon = tree_view.FolderIcons.forFolder("components");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.components));
+    test "folder constant is FA_FOLDER glyph" {
+        try expect.toBeTrue(std.mem.eql(u8, tree_view.FolderIcons.folder, "\u{f07b}"));
     }
 
-    test "fixtures folder has wrench icon" {
-        const icon = tree_view.FolderIcons.forFolder("fixtures");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.fixtures));
-    }
-
-    test "gizmos folder has bullseye icon" {
-        const icon = tree_view.FolderIcons.forFolder("gizmos");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.gizmos));
-    }
-
-    test "prefabs folder has box icon" {
-        const icon = tree_view.FolderIcons.forFolder("prefabs");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.prefabs));
-    }
-
-    test "scenes folder has film icon" {
-        const icon = tree_view.FolderIcons.forFolder("scenes");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.scenes));
-    }
-
-    test "scripts folder has scroll icon" {
-        const icon = tree_view.FolderIcons.forFolder("scripts");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.scripts));
-    }
-
-    test "scripts/flows has project-diagram icon" {
-        const icon = tree_view.FolderIcons.forFolder("scripts/flows");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.scripts_flows));
-    }
-
-    test "resources folder has database icon" {
-        const icon = tree_view.FolderIcons.forFolder("resources");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.resources));
-    }
-
-    test "unknown folder returns default folder icon" {
-        const icon = tree_view.FolderIcons.forFolder("unknown");
-        try expect.toBeTrue(std.mem.eql(u8, icon, tree_view.FolderIcons.folder_closed));
+    test "file constant is FA_FILE glyph" {
+        try expect.toBeTrue(std.mem.eql(u8, tree_view.FolderIcons.file, "\u{f15b}"));
     }
 };
 

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -144,7 +144,7 @@ pub const TreeView = struct {
             var node_label: [256:0]u8 = undefined;
             _ = std.fmt.bufPrintZ(&node_label, "{s} {s}", .{ icon, folder_name }) catch continue;
 
-            const node_open = zgui.treeNodeFlags(&node_label, .{});
+            const node_open = zgui.treeNodeFlags(&node_label, .{ .span_full_width = true });
 
             if (node_open) {
                 if (self.renderFolder(folder_path, &managed_paths)) {
@@ -205,13 +205,27 @@ pub const TreeView = struct {
             defer zgui.popId();
 
             if (file_entry.is_directory) {
-                if (zgui.treeNodeFlags(label, .{})) {
+                if (zgui.treeNodeFlags(label, .{ .span_full_width = true })) {
                     if (self.renderFolder(full_path, managed_paths)) {
                         file_selected = true;
                     }
                     zgui.treePop();
                 }
             } else {
+                // File rows render as `selectable`, which starts at the row's
+                // left edge. Subfolder rows above them use `treeNodeFlags`,
+                // whose label sits to the right of the chevron column
+                // (FontSize + 2*FramePadding.x). Without a matching indent
+                // here, the file icon column lands flush against the parent
+                // indent while subfolder icon columns sit one chevron-width
+                // further right — the chevron then looks "attached" to the
+                // file row above instead of belonging to its own subfolder.
+                // Issue #73 acceptance: file + subfolder icons aligned inside
+                // the same parent.
+                const indent_w = zgui.getFontSize() + zgui.getStyle().frame_padding[0] * 2.0;
+                zgui.indent(.{ .indent_w = indent_w });
+                defer zgui.unindent(.{ .indent_w = indent_w });
+
                 const is_selected = if (self.selected_path) |sel|
                     std.mem.eql(u8, sel, full_path)
                 else

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -4,33 +4,13 @@ const project = @import("project.zig");
 const icons = @import("icons.zig");
 
 /// Icons for each folder type (FontAwesome icons)
+/// Centralized icon set for the tree view. Every folder — top-level or
+/// nested — renders with the same `folder` glyph so the icon column
+/// reads consistently across the whole tree (issue #73). The chevron is
+/// the sole open/closed indicator. File rows use a single `file` glyph.
 pub const FolderIcons = struct {
-    pub const components = icons.FA_CUBE; // 3D cube for components
-    pub const fixtures = icons.FA_WRENCH; // Wrench for fixtures
-    pub const gizmos = icons.FA_BULLSEYE; // Bullseye for gizmos
-    pub const prefabs = icons.FA_BOX; // Box for prefabs
-    pub const scenes = icons.FA_FILM; // Film for scenes
-    pub const scripts = icons.FA_SCROLL; // Scroll for scripts
-    pub const scripts_flows = icons.FA_PROJECT_DIAGRAM; // Graph icon for flows
-    pub const resources = icons.FA_DATABASE; // Database for resources
-    pub const file = icons.FA_FILE; // File icon
-    pub const folder_open = icons.FA_FOLDER_OPEN; // Open folder
-    pub const folder_closed = icons.FA_FOLDER; // Closed folder
-
-    pub fn forFolder(name: []const u8) []const u8 {
-        if (std.mem.eql(u8, name, project.ProjectFolders.components)) return components;
-        if (std.mem.eql(u8, name, project.ProjectFolders.fixtures)) return fixtures;
-        if (std.mem.eql(u8, name, project.ProjectFolders.gizmos)) return gizmos;
-        if (std.mem.eql(u8, name, project.ProjectFolders.prefabs)) return prefabs;
-        if (std.mem.eql(u8, name, project.ProjectFolders.scenes)) return scenes;
-        if (std.mem.eql(u8, name, project.ProjectFolders.scripts)) return scripts;
-        // The Flows folder is nested under `scripts/` and registered
-        // in `ProjectFolders.all` as the literal `"scripts/flows"`.
-        // Match the full path here so the lookup hits.
-        if (std.mem.eql(u8, name, project.ProjectFolders.scripts_flows)) return scripts_flows;
-        if (std.mem.eql(u8, name, project.ProjectFolders.resources)) return resources;
-        return folder_closed;
-    }
+    pub const file = icons.FA_FILE;
+    pub const folder = icons.FA_FOLDER;
 };
 
 /// Represents a file entry in the tree
@@ -49,6 +29,16 @@ pub const TreeView = struct {
     allocator: std.mem.Allocator,
     selected_path: ?[]const u8,
     cached_files: std.StringHashMap(CacheEntry),
+    /// Set of expanded directory paths (top-level + nested). All rows —
+    /// folders and files — render as `zgui.selectable`, which is the
+    /// only way to guarantee folder and file selection bars have
+    /// identical height. ImGui's `TreeNodeFlags` uses a different
+    /// height formula (`FontSize + 2*FramePadding.y`) than `Selectable`
+    /// (`FontSize + ItemSpacing.y` after the bb spacing extension), so
+    /// the two widget types render visibly different bars. Owning the
+    /// open/closed state here lets us draw the disclosure caret as part
+    /// of the selectable's label glyph run.
+    open_dirs: std.StringHashMap(void),
     needs_refresh: bool,
 
     const Self = @This();
@@ -68,6 +58,7 @@ pub const TreeView = struct {
             .allocator = allocator,
             .selected_path = null,
             .cached_files = std.StringHashMap(CacheEntry).init(allocator),
+            .open_dirs = std.StringHashMap(void).init(allocator),
             .needs_refresh = true,
         };
     }
@@ -78,6 +69,29 @@ pub const TreeView = struct {
         }
         self.clearCache();
         self.cached_files.deinit();
+        self.clearOpenDirs();
+        self.open_dirs.deinit();
+    }
+
+    fn clearOpenDirs(self: *Self) void {
+        var it = self.open_dirs.keyIterator();
+        while (it.next()) |key| {
+            self.allocator.free(key.*);
+        }
+        self.open_dirs.clearRetainingCapacity();
+    }
+
+    fn isOpen(self: *const Self, path: []const u8) bool {
+        return self.open_dirs.contains(path);
+    }
+
+    fn toggleOpen(self: *Self, path: []const u8) void {
+        if (self.open_dirs.fetchRemove(path)) |kv| {
+            self.allocator.free(kv.key);
+            return;
+        }
+        const owned = self.allocator.dupe(u8, path) catch return;
+        self.open_dirs.put(owned, {}) catch self.allocator.free(owned);
     }
 
     fn clearCache(self: *Self) void {
@@ -132,37 +146,94 @@ pub const TreeView = struct {
             managed_paths[i] = std.fmt.bufPrint(&managed_storage[i], "{s}/{s}", .{ base_path, fname }) catch "";
         }
 
-        // Render each project folder (using stack buffers to avoid heap allocations per frame)
+        // Render each project folder
         for (project.ProjectFolders.all) |folder_name| {
-            const icon = FolderIcons.forFolder(folder_name);
-
             // Build folder path on stack
-            var folder_path_buf: [path_buf_size]u8 = undefined;
-            const folder_path = std.fmt.bufPrint(&folder_path_buf, "{s}/{s}", .{ base_path, folder_name }) catch continue;
+            var folder_path_buf: [path_buf_size:0]u8 = undefined;
+            const folder_path = std.fmt.bufPrintZ(&folder_path_buf, "{s}/{s}", .{ base_path, folder_name }) catch continue;
 
-            // Create tree node label directly on stack
-            var node_label: [256:0]u8 = undefined;
-            _ = std.fmt.bufPrintZ(&node_label, "{s} {s}", .{ icon, folder_name }) catch continue;
-
-            const node_open = zgui.treeNodeFlags(&node_label, .{ .span_full_width = true });
-
-            if (node_open) {
-                if (self.renderFolder(folder_path, &managed_paths)) {
-                    file_selected = true;
-                }
-                zgui.treePop();
+            if (self.renderDirectoryRow(folder_path, folder_name, &managed_paths)) {
+                file_selected = true;
             }
         }
 
         return file_selected;
     }
 
-    /// Render the contents of a single directory. Recurses into subdirectories
-    /// (each becomes its own `treeNodeFlags`) so the user can drill arbitrarily
-    /// deep. Files at any depth render as `zgui.selectable` and route through
-    /// `self.selected_path` exactly like top-level files do. Subdirectories
-    /// whose absolute path matches a `managed_paths` entry are suppressed —
-    /// they're already rendered at top level (see `render`).
+    /// Render one directory row (selectable with caret + folder icon) and
+    /// recurse into its contents when the directory is in `open_dirs`.
+    /// Drives both top-level project folders and nested subdirectories so
+    /// every directory row in the tree uses the same widget — no
+    /// height/spacing drift between depths. Click toggles open/closed
+    /// state; the row never becomes `selected_path` (only files do).
+    fn renderDirectoryRow(
+        self: *Self,
+        folder_path: [:0]const u8,
+        display_name: []const u8,
+        managed_paths: []const []const u8,
+    ) bool {
+        var file_selected = false;
+        const is_open_state = self.isOpen(folder_path);
+        const caret = if (is_open_state) icons.FA_CARET_DOWN else icons.FA_CARET_RIGHT;
+
+        var label_buf: [512:0]u8 = undefined;
+        const label = std.fmt.bufPrintZ(
+            &label_buf,
+            "{s}{s} {s}",
+            .{ caret, FolderIcons.folder, display_name },
+        ) catch return false;
+
+        zgui.pushStrIdZ(folder_path);
+        defer zgui.popId();
+
+        // Capture the row's leading screen-X *before* the selectable: this
+        // is the caret column, where the vertical guide line for the
+        // open-children block needs to drop from.
+        const parent_screen_x = zgui.getCursorScreenPos()[0];
+
+        if (zgui.selectable(label, .{})) {
+            self.toggleOpen(folder_path);
+        }
+
+        if (self.isOpen(folder_path)) {
+            zgui.indent(.{});
+            defer zgui.unindent(.{});
+
+            const line_top_y = zgui.getCursorScreenPos()[1];
+            if (self.renderFolder(folder_path, managed_paths)) {
+                file_selected = true;
+            }
+            const line_bottom_y = zgui.getCursorScreenPos()[1];
+
+            // Vertical guide line sits over the caret glyph itself.
+            // FA_CARET_RIGHT / FA_CARET_DOWN are drawn left-aligned
+            // within their `glyph_min_advance_x = font_size` advance box
+            // (see main.zig) and span roughly 35-40% of that box, so the
+            // caret's visual center sits ~0.3 * font_size from the row's
+            // leading edge. Color comes from the imgui theme so it
+            // tracks dark/light style switches.
+            const draw_list = zgui.getWindowDrawList();
+            const color_u32 = zgui.colorConvertFloat4ToU32(
+                zgui.getStyle().getColor(.tree_lines),
+            );
+            const line_x = parent_screen_x + zgui.getFontSize() * 0.4;
+            draw_list.addLine(.{
+                .p1 = .{ line_x, line_top_y },
+                .p2 = .{ line_x, line_bottom_y },
+                .col = color_u32,
+                .thickness = 1.0,
+            });
+        }
+
+        return file_selected;
+    }
+
+    /// Render the contents of an opened directory. Each child renders as
+    /// a single `selectable` — directories route through
+    /// `renderDirectoryRow` so they share the same widget + height as
+    /// files. Subdirectories whose absolute path matches a
+    /// `managed_paths` entry are suppressed because they're already
+    /// rendered at top level (e.g. `scripts/flows`).
     fn renderFolder(self: *Self, folder_path: []const u8, managed_paths: []const []const u8) bool {
         var file_selected = false;
 
@@ -197,34 +268,25 @@ pub const TreeView = struct {
                 if (is_managed) continue;
             }
 
-            var label_buf: [512:0]u8 = undefined;
-            const file_icon = if (file_entry.is_directory) FolderIcons.folder_closed else FolderIcons.file;
-            const label = std.fmt.bufPrintZ(&label_buf, "{s} {s}", .{ file_icon, file_entry.name }) catch continue;
-
-            zgui.pushStrIdZ(full_path);
-            defer zgui.popId();
-
             if (file_entry.is_directory) {
-                if (zgui.treeNodeFlags(label, .{ .span_full_width = true })) {
-                    if (self.renderFolder(full_path, managed_paths)) {
-                        file_selected = true;
-                    }
-                    zgui.treePop();
+                if (self.renderDirectoryRow(full_path, file_entry.name, managed_paths)) {
+                    file_selected = true;
                 }
             } else {
-                // File rows render as `selectable`, which starts at the row's
-                // left edge. Subfolder rows above them use `treeNodeFlags`,
-                // whose label sits to the right of the chevron column
-                // (FontSize + 2*FramePadding.x). Without a matching indent
-                // here, the file icon column lands flush against the parent
-                // indent while subfolder icon columns sit one chevron-width
-                // further right — the chevron then looks "attached" to the
-                // file row above instead of belonging to its own subfolder.
-                // Issue #73 acceptance: file + subfolder icons aligned inside
-                // the same parent.
-                const indent_w = zgui.getFontSize() + zgui.getStyle().frame_padding[0] * 2.0;
-                zgui.indent(.{ .indent_w = indent_w });
-                defer zgui.unindent(.{ .indent_w = indent_w });
+                var label_buf: [512:0]u8 = undefined;
+                // No leading space — files have no caret column, so their
+                // icon sits at the row's leading edge (where a directory's
+                // caret would be). Matches the VS Code-style file tree
+                // alignment: file icon column == directory caret column,
+                // file name column == directory folder-icon column.
+                const label = std.fmt.bufPrintZ(
+                    &label_buf,
+                    "{s} {s}",
+                    .{ FolderIcons.file, file_entry.name },
+                ) catch continue;
+
+                zgui.pushStrIdZ(full_path);
+                defer zgui.popId();
 
                 const is_selected = if (self.selected_path) |sel|
                     std.mem.eql(u8, sel, full_path)


### PR DESCRIPTION
## Summary

- Nested subfolder rows now show the disclosure `▶` chevron clearly: every `treeNodeFlags` call gets `.span_full_width = true`, so the row highlight extends across the panel and the chevron column reads as its own strip on the left of the row instead of blending into the adjacent icon glyph.
- File rows (`selectable`) inside any folder are indented by `FontSize + 2 * FramePadding.x`, so file icon columns line up with subfolder icon columns inside the same parent — the chevron now visibly belongs to the subfolder row rather than looking attached to the file row above it.

Closes #73.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — 182/182 pass
- [x] `zig build gui-test` — 8/8 pass
- [x] Visual: ran against `flying-platform-labelle`, expanded `scenes/` and confirmed `debug/` shows a chevron with its icon aligned to the file rows in the same parent
- [ ] Reviewer: spot-check `prefabs/`, `scripts/`, `assets/raw/background/` for the same alignment