### PR TITLE
ci: cache Zig deps + share gui-tests artifact (#75)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,10 @@ jobs:
         run: |
           export DISPLAY=:99
           Xvfb :99 -screen 0 1280x720x24 &
-          sleep 1
+          XVFB_PID=$!
+          sleep 2
           ./zig-out/bin/gui-tests
+          kill $XVFB_PID 2>/dev/null || true
 
   # Process-launch sanity check — confirms the production binary starts,
   # doesn't crash for a few seconds, and renders something. Separate from

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,34 @@ jobs:
         with:
           version: 0.15.2
 
+      # Cache the Zig package store and the build cache so repeat runs
+      # don't re-download or re-compile the C++ deps (imgui, glfw, etc.)
+      # that dominate cold-build time. Keyed on the dep lockfile + build
+      # script, so any dep bump or build graph change invalidates cleanly.
+      - name: Cache Zig deps + build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/zig
+            .zig-cache
+          key: zig-${{ runner.os }}-${{ hashFiles('build.zig.zon', 'build.zig') }}
+          restore-keys: |
+            zig-${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
 
-      - name: Build
+      - name: Build production binary
         run: zig build -Dcpu=baseline
+
+      - name: Build UI-test binary
+        # Same build cache as the step above — the only extra cost is the
+        # second zgui compilation with `with_te = true`. Lands the test
+        # binary at zig-out/bin/gui-tests so the `ui-tests` job can pick
+        # it up from the artifact instead of re-building from scratch.
+        run: zig build gui-test-build -Dcpu=baseline
 
       - name: Unit Tests (zspec)
         run: zig build test -Dcpu=baseline
@@ -38,10 +59,9 @@ jobs:
           path: zig-out/bin/
           if-no-files-found: error
 
-  # ImGui Test Engine harness — `zig build gui-test`. Drives real menu
-  # actions against a hidden GLFW window and asserts on App state. Still
-  # needs an X display on Linux because zglfw.init touches X even with
-  # the window kept invisible.
+  # ImGui Test Engine harness — downloads the gui-tests binary built by
+  # the `build` job and runs it under Xvfb. No Zig toolchain or build
+  # step needed here; the heavy compilation happened once upstream.
   ui-tests:
     runs-on: ubuntu-latest
     name: ImGui Test Engine
@@ -50,23 +70,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        # The test binary needs the project tree at runtime to locate
+        # `assets/fonts/fa-solid-900.ttf` (loaded relative to cwd by
+        # `addFontFromFileWithConfig`). Source code isn't compiled here.
 
-      - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v4
         with:
-          version: 0.15.2
+          name: labelle-gui-Linux
+          path: zig-out/bin/
 
-      - name: Install dependencies
+      - name: Make executable
+        run: chmod +x zig-out/bin/gui-tests
+
+      - name: Install runtime dependencies
+        # Runtime-only libs (no -dev) since we're not compiling here.
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb libgtk-3-dev libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+          sudo apt-get install -y \
+            xvfb \
+            libgtk-3-0 \
+            libgl1 \
+            libxrandr2 \
+            libxinerama1 \
+            libxcursor1 \
+            libxi6
 
       - name: Run UI tests under Xvfb
         run: |
           export DISPLAY=:99
           Xvfb :99 -screen 0 1280x720x24 &
           sleep 1
-          zig build gui-test -Dcpu=baseline
+          ./zig-out/bin/gui-tests
 
   # Process-launch sanity check — confirms the production binary starts,
   # doesn't crash for a few seconds, and renders something. Separate from

--- a/build.zig
+++ b/build.zig
@@ -139,6 +139,15 @@ pub fn build(b: *std.Build) void {
     const gui_test_step = b.step("gui-test", "Run the UI test runner");
     gui_test_step.dependOn(&run_gui_tests.step);
 
+    // Build-only step for CI: produces `zig-out/bin/gui-tests` without
+    // running it, so the artifact can be uploaded once by the `build`
+    // job and reused by the `ui-tests` job (which then only needs Xvfb
+    // and runtime libs, no Zig toolchain). Local dev still uses
+    // `zig build gui-test` to build + run in one shot.
+    const install_gui_tests = b.addInstallArtifact(gui_tests_exe, .{});
+    const gui_test_build_step = b.step("gui-test-build", "Build the UI test runner binary (no run)");
+    gui_test_build_step.dependOn(&install_gui_tests.step);
+
     // End-to-end smoke check ----------------------------------------------
     //
     // Drives the gui's project writer + Compiler.launcherGenerate against


### PR DESCRIPTION
## Summary

- Add `actions/cache@v4` covering `~/.cache/zig` and `.zig-cache`, keyed on the hash of `build.zig.zon` + `build.zig`. Repeat runs reuse the compiled imgui / glfw / nfd / zstbi trees instead of re-fetching and re-compiling them from scratch.
- The `build` job now also runs `zig build gui-test-build` (new step in `build.zig`), installing the Test-Engine-flavored binary to `zig-out/bin/gui-tests`. The `ui-tests` job drops its checkout / setup-zig / build steps and downloads that binary the same way `launch-check` already downloads the production binary. Runtime libs + Xvfb + run, no Zig toolchain needed in `ui-tests`.

Expected effect: typical PR feedback drops from ~13–17 min to ~5 min once the cache warms.

Closes #75.

## Test plan

- [ ] First CI run on this PR: cold cache; total time should still be in the historical range or slightly lower (build job does ~30 s more for the second zgui compile, ui-tests skips ~5–8 min of duplicate build).
- [ ] Re-trigger CI (push an empty commit or rebase) — second run should hit the cache and complete noticeably faster.
- [ ] `launch-check` still passes (consumes the existing artifact unchanged).
- [ ] `ui-tests` passes against the downloaded `gui-tests` binary running under Xvfb.