### PR TITLE
feat(scene): prefab cache, AABB drag, double-click jump, Add prefab button

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -28,6 +28,7 @@ const gizmo_mod = @import("modules/gizmo.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
 const atlas = @import("atlas.zig");
 const gizmos = @import("gizmos.zig");
+const prefab_index = @import("prefab_index.zig");
 const new_scene_dialog = @import("dialogs/new_scene.zig");
 const dpi_warning_dialog = @import("dialogs/dpi_warning.zig");
 const preferences_dialog = @import("dialogs/preferences.zig");
@@ -155,6 +156,13 @@ pub const App = struct {
     /// the close-confirmation dialog is shown and other tabs can't be
     /// closed.
     pending_close_idx: ?usize = null,
+    /// Deferred "open prefab as a tab" path used by the scene editor's
+    /// double-click + Edit-prefab affordance. The act of opening a
+    /// prefab mutates `open_tabs`, which would invalidate the scene
+    /// tab's `SceneState *s` pointer mid-render. Setting this field
+    /// during render and processing it on the next frame keeps the
+    /// list stable for the rest of the current frame.
+    pending_open_prefab_path: ?[]u8 = null,
     /// Last seen `ProjectManager.generation`. Compared each frame so
     /// `closeAllTabs` runs the frame the active project changes.
     last_project_generation: ?u64 = null,
@@ -169,6 +177,12 @@ pub const App = struct {
     /// on project new/load; viewport queries it when `show_gizmos`
     /// is true to draw debug visualizations over matched entities.
     gizmo_index: ?gizmos.Index = null,
+    /// Per-project prefab cache (name → parsed prefab). Built alongside
+    /// `atlas_index` and `gizmo_index`; the scene viewport uses it to
+    /// resolve `{ "prefab": "canteen" }` references into renderable
+    /// sprites when the scene entity has no Sprite component of its
+    /// own. Invalidated when the project generation bumps.
+    prefab_index: ?prefab_index.Index = null,
     /// User toggle for the gizmo overlay; on by default so the
     /// overlay shows up immediately when a project with gizmos opens.
     show_gizmos: bool = true,
@@ -235,6 +249,8 @@ pub const App = struct {
         self.open_tabs.deinit(self.allocator);
         if (self.atlas_index) |*idx| idx.deinit();
         if (self.gizmo_index) |*idx| idx.deinit();
+        if (self.prefab_index) |*idx| idx.deinit();
+        if (self.pending_open_prefab_path) |p| self.allocator.free(p);
         self.project_manager.deinit();
         self.tree_view.deinit();
         self.compiler.deinit();
@@ -291,6 +307,23 @@ pub const App = struct {
         );
     }
 
+    /// Rebuild the prefab cache by walking `<project_dir>/prefabs/`
+    /// recursively and parsing every `.jsonc`. Same generation-keyed
+    /// invalidation rule the atlas + gizmo indexes use.
+    pub fn rebuildPrefabIndex(self: *Self) void {
+        if (self.prefab_index) |*idx| {
+            idx.deinit();
+            self.prefab_index = null;
+        }
+        const proj = self.project_manager.current_project orelse return;
+        const dir = proj.dir orelse return;
+        self.prefab_index = prefab_index.Index.build(
+            self.allocator,
+            dir,
+            self.project_manager.generation,
+        );
+    }
+
     // ─── Scene tabs ─────────────────────────────────────────────────────
 
     /// Open a `.jsonc` scene file (under `<project>/scenes/`) as a
@@ -329,6 +362,35 @@ pub const App = struct {
         const new_idx = self.open_tabs.items.len - 1;
         self.active_tab_idx = new_idx;
         self.focus_tab_idx = new_idx;
+    }
+
+    /// Queue a `openPrefab` call to run at the start of the next
+    /// frame. Used by the scene editor's double-click + Edit-prefab
+    /// affordance, which fires mid-render — opening a tab right then
+    /// would realloc `open_tabs` and invalidate the scene's
+    /// `SceneState` pointer the caller is still using. Path is dup'd
+    /// onto the heap; ownership transfers to App until the request
+    /// is flushed in `flushPendingOpens`.
+    pub fn requestOpenPrefab(self: *Self, path: []const u8) void {
+        if (self.pending_open_prefab_path) |existing| {
+            // A pending request from earlier in the same frame was
+            // never flushed (would only happen if this is called
+            // twice in one frame). Drop the older one.
+            self.allocator.free(existing);
+            self.pending_open_prefab_path = null;
+        }
+        self.pending_open_prefab_path = self.allocator.dupe(u8, path) catch return;
+    }
+
+    fn flushPendingOpens(self: *Self) void {
+        if (self.pending_open_prefab_path) |path| {
+            self.pending_open_prefab_path = null;
+            defer self.allocator.free(path);
+            self.openPrefab(path) catch |err| {
+                std.log.err("Failed to open prefab {s}: {s}", .{ path, @errorName(err) });
+                self.setStatus("Error opening prefab!");
+            };
+        }
     }
 
     /// Open a `.zig` file (under `<project>/scripts/flows/`) as a
@@ -431,6 +493,14 @@ pub const App = struct {
     pub fn renderFrame(self: *Self, dt_seconds: f32) void {
         if (self.status_timer > 0) self.status_timer -= dt_seconds;
 
+        // Process deferred actions from the previous frame BEFORE
+        // touching the project/tab structures. Mid-frame "open this
+        // prefab" requests (scene editor double-click + Edit prefab
+        // button) queue here so the act of mutating `open_tabs`
+        // doesn't invalidate the SceneState pointer the requester is
+        // still rendering against.
+        self.flushPendingOpens();
+
         // Project transitions close all open scene tabs so the next
         // frame doesn't read into freed memory belonging to the old
         // project. Detected via ProjectManager.generation, which is
@@ -442,10 +512,12 @@ pub const App = struct {
                 self.closeAllTabs();
                 self.rebuildAtlasIndex();
                 self.rebuildGizmoIndex();
+                self.rebuildPrefabIndex();
             }
         } else {
             self.rebuildAtlasIndex();
             self.rebuildGizmoIndex();
+            self.rebuildPrefabIndex();
         }
         self.last_project_generation = gen;
 

--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -57,12 +57,29 @@ pub fn renderEntity(
     is_dirty: *bool,
     entity_index: ?usize,
     atlas_index: ?*const atlas.Index,
+    /// Optional sink: when non-null AND the entity references a
+    /// prefab, the inspector renders an "Edit prefab" button next to
+    /// the prefab name. Clicking it writes the prefab name into the
+    /// sink; the caller resolves the file path and opens the prefab
+    /// as a tab. The scene editor wires this; the prefab editor passes
+    /// null because there's no further level to descend into.
+    request_open_prefab: ?*?[]const u8,
 ) void {
     if (entity_index) |n| {
         zgui.text("Entity #{d}", .{n});
     }
     if (entity.prefab) |p| {
         zgui.text("prefab: {s}", .{p});
+        if (request_open_prefab) |sink| {
+            zgui.sameLine(.{});
+            // ImGui identifies buttons by label; the "##..." suffix is
+            // a hidden discriminator so the button's ID stays stable
+            // even if a future Sprite section also wants to surface
+            // an "Edit prefab" affordance.
+            if (zgui.smallButton("Edit prefab##inspector_edit_prefab")) {
+                sink.* = p;
+            }
+        }
     } else {
         zgui.textDisabled("(no prefab)", .{});
     }

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -36,6 +36,11 @@ pub const PrefabState = struct {
     selected_child_idx: ?usize = null,
     is_dirty: bool = false,
     drag_armed: bool = false,
+    /// Entity's world-space position at the moment a drag was armed.
+    /// The viewport uses this snapshot + the cumulative drag delta to
+    /// compute each frame's live target, so snap-to-grid doesn't fight
+    /// the running position (see comment on `viewport.State.drag_start_world`).
+    drag_start_world: [2]f32 = .{ 0, 0 },
     pan: [2]f32 = .{ 320, 240 },
     zoom: f32 = 1.0,
     /// World-space spacing for the viewport's visual grid. When
@@ -111,6 +116,7 @@ pub fn render(s: *PrefabState, app: *App) void {
 
     const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
     const gizmo_index_ptr: ?*const @import("../gizmos.zig").Index = if (app.gizmo_index) |*ix| ix else null;
+    const prefab_index_ptr: ?*const @import("../prefab_index.zig").Index = if (app.prefab_index) |*ix| ix else null;
 
     if (zgui.beginChild("##prefab_viewport_col", .{ .w = viewport_w, .h = 0 })) {
         viewport.render(
@@ -120,12 +126,14 @@ pub fn render(s: *PrefabState, app: *App) void {
                 .selected_idx = &s.selected_child_idx,
                 .is_dirty = &s.is_dirty,
                 .drag_armed = &s.drag_armed,
+                .drag_start_world = &s.drag_start_world,
                 .grid_step = s.grid_step,
                 .snap_enabled = s.snap_enabled,
             },
             s.loaded.children,
             s.loaded.children_extras,
             atlas_index_ptr,
+            prefab_index_ptr,
             gizmo_index_ptr,
             app.show_gizmos,
         );
@@ -149,6 +157,13 @@ pub fn savePrefab(s: *PrefabState, app: *App) void {
         return;
     };
     s.is_dirty = false;
+    // Invalidate the project's prefab cache so scenes referencing
+    // this prefab pick up the new layout on their next render. The
+    // cache holds an independently-parsed copy of every prefab; the
+    // PrefabState we just saved is its own copy that lives only in
+    // this tab. Without a rebuild the scene viewport keeps drawing
+    // the pre-save geometry until the project is reopened.
+    app.rebuildPrefabIndex();
     app.setStatus("Prefab saved!");
 }
 
@@ -174,14 +189,14 @@ fn renderInspector(s: *PrefabState, atlas_index: ?*const @import("../atlas.zig")
         else
             &[_]scene_io.ComponentExtra{};
 
-        inspector.renderEntity(child, extras, &s.is_dirty, idx, atlas_index);
+        inspector.renderEntity(child, extras, &s.is_dirty, idx, atlas_index, null);
         return;
     }
 
     // Nothing selected → show the prefab's own components.
     zgui.text("Prefab body", .{});
     zgui.spacing();
-    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null, atlas_index);
+    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null, atlas_index, null);
 
     if (s.loaded.children.len > 0) {
         zgui.spacing();

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -56,6 +56,11 @@ pub const SceneState = struct {
     /// drag started in empty canvas space doesn't move the previously
     /// selected entity by accident.
     drag_armed: bool = false,
+    /// Entity's world-space position at the moment a drag was armed.
+    /// The viewport uses this snapshot + the cumulative drag delta to
+    /// compute each frame's live target, so snap-to-grid doesn't fight
+    /// the running position (see comment on `viewport.State.drag_start_world`).
+    drag_start_world: [2]f32 = .{ 0, 0 },
     /// Viewport pan / zoom state. Per-tab — each open scene keeps its
     /// own camera.
     pan: [2]f32 = .{ 320, 240 },
@@ -162,6 +167,19 @@ pub fn render(s: *SceneState, app: *App) void {
     zgui.sameLine(.{});
     _ = zgui.checkbox("snap", .{ .v = &s.snap_enabled });
     zgui.sameLine(.{});
+    // Toolbar entry point into the prefab picker — same flow the
+    // right-click-on-empty-canvas → "Add entity from prefab..." path
+    // uses. Spawn position falls back to the world position of the
+    // currently-selected entity (so "select-and-clone" feels natural)
+    // or world origin when nothing is selected. The user drags the
+    // new entity from there to its real home; the right-click flow
+    // already supplies a precise click-site world pos.
+    if (zgui.button("Add prefab", .{})) {
+        s.context_menu_world_pos = defaultSpawnWorldPos(s);
+        scanPrefabPickerNames(s, app);
+        s.show_prefab_picker = true;
+    }
+    zgui.sameLine(.{});
     if (zgui.button("Save", .{})) saveScene(s, app);
     zgui.separator();
 
@@ -171,9 +189,10 @@ pub fn render(s: *SceneState, app: *App) void {
 
     const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
     const gizmo_index_ptr: ?*const @import("../gizmos.zig").Index = if (app.gizmo_index) |*ix| ix else null;
+    const prefab_index_ptr: ?*const @import("../prefab_index.zig").Index = if (app.prefab_index) |*ix| ix else null;
 
     if (zgui.beginChild("##viewport_col", .{ .w = viewport_w, .h = 0 })) {
-        renderViewport(s, atlas_index_ptr, gizmo_index_ptr, app.show_gizmos);
+        renderViewport(s, app, atlas_index_ptr, prefab_index_ptr, gizmo_index_ptr, app.show_gizmos);
         renderContextMenu(s, app);
         handleDeleteKey(s);
     }
@@ -184,7 +203,7 @@ pub fn render(s: *SceneState, app: *App) void {
         .h = 0,
         .child_flags = .{ .border = true },
     })) {
-        renderInspector(s, atlas_index_ptr);
+        renderInspector(s, app, atlas_index_ptr);
     }
     zgui.endChild();
 }
@@ -201,7 +220,7 @@ pub fn saveScene(s: *SceneState, app: *App) void {
     app.setStatus("Scene saved!");
 }
 
-fn renderInspector(s: *SceneState, atlas_index: ?*const @import("../atlas.zig").Index) void {
+fn renderInspector(s: *SceneState, app: *App, atlas_index: ?*const @import("../atlas.zig").Index) void {
     zgui.text("Inspector", .{});
     zgui.separator();
 
@@ -221,19 +240,28 @@ fn renderInspector(s: *SceneState, atlas_index: ?*const @import("../atlas.zig").
     else
         &[_]scene_io.ComponentExtra{};
 
-    inspector.renderEntity(entity, extras, &s.is_dirty, idx, atlas_index);
+    var open_prefab_request: ?[]const u8 = null;
+    inspector.renderEntity(entity, extras, &s.is_dirty, idx, atlas_index, &open_prefab_request);
+    if (open_prefab_request) |_| {
+        // The button was clicked — resolve via the prefab cache and
+        // open the file. Same routing used by the double-click jump.
+        openPrefabFromEntity(app, s, idx);
+    }
 }
 
 fn renderViewport(
     s: *SceneState,
+    app: *App,
     atlas_index: ?*const @import("../atlas.zig").Index,
+    prefab_index: ?*const @import("../prefab_index.zig").Index,
     gizmo_index: ?*const @import("../gizmos.zig").Index,
     show_gizmos: bool,
 ) void {
-    // Capture right-click world-pos out-of-band; if the viewport sets
-    // it this frame we open the context menu before its child closes
-    // so the popup roots at the canvas, not at the scene tab body.
+    // Capture right-click world-pos + double-click entity index
+    // out-of-band; the viewport writes through these sinks during its
+    // render so we can react after it returns.
     var right_click: ?[2]f32 = null;
+    var double_click: ?usize = null;
     viewport.render(
         .{
             .pan = &s.pan,
@@ -241,13 +269,16 @@ fn renderViewport(
             .selected_idx = &s.selected_index,
             .is_dirty = &s.is_dirty,
             .drag_armed = &s.drag_armed,
+            .drag_start_world = &s.drag_start_world,
             .right_click_world = &right_click,
+            .double_click_entity = &double_click,
             .grid_step = s.grid_step,
             .snap_enabled = s.snap_enabled,
         },
         s.loaded.scene.entities,
         s.loaded.extras.entity_components,
         atlas_index,
+        prefab_index,
         gizmo_index,
         show_gizmos,
     );
@@ -255,6 +286,24 @@ fn renderViewport(
         s.context_menu_world_pos = world;
         zgui.openPopup("##scene_context", .{});
     }
+    if (double_click) |idx| {
+        openPrefabFromEntity(app, s, idx);
+    }
+}
+
+/// Double-click jump: when the user double-clicks a scene entity
+/// whose `prefab` field is set and resolves against the project's
+/// prefab index, queue an open-prefab request for the next frame
+/// (deferred so the act of appending to `open_tabs` doesn't
+/// invalidate the SceneState pointer this function is reached
+/// through). Only legal place for per-child edits — see issue notes
+/// on the scene/prefab atomicity contract.
+fn openPrefabFromEntity(app: *App, s: *SceneState, idx: usize) void {
+    if (idx >= s.loaded.scene.entities.len) return;
+    const name = s.loaded.scene.entities[idx].prefab orelse return;
+    const pfx_index = if (app.prefab_index) |*ix| ix else return;
+    const entry = pfx_index.findEntry(name) orelse return;
+    app.requestOpenPrefab(entry.path);
 }
 
 /// Context-menu popup that fires after a right-click in empty canvas
@@ -297,6 +346,17 @@ fn renderPrefabPicker(s: *SceneState, app: *App) void {
     defer zgui.endPopup();
 
     zgui.text("Select a prefab:", .{});
+    zgui.sameLine(.{});
+    // Explicit cancel button so the popup is dismissable without
+    // having to click the canvas behind it (some users miss the
+    // click-away affordance). Closes the popup without writing
+    // anything to the scene.
+    if (zgui.smallButton("Cancel##scene_prefab_picker_cancel")) {
+        s.show_prefab_picker = false;
+        s.context_menu_world_pos = null;
+        zgui.closeCurrentPopup();
+        return;
+    }
     _ = zgui.inputText("##prefab_filter", .{ .buf = &s.prefab_picker_filter });
     zgui.separator();
 
@@ -327,34 +387,40 @@ fn renderPrefabPicker(s: *SceneState, app: *App) void {
     if (!any_shown) zgui.textDisabled("(no prefabs found)", .{});
 }
 
-/// Walk `<project>/prefabs/` and fold each `.jsonc` filename's stem
-/// into `s.prefab_picker_names`. Errors (missing folder, permission
-/// problems) are swallowed and reported as an empty picker — same
-/// tolerance the tree view + gizmo loader use.
+/// Populate `s.prefab_picker_names` from the project's prefab cache.
+/// The cache already walks `<project>/prefabs/` recursively (so prefab
+/// files nested in subfolders like `prefabs/rooms/canteen.jsonc` show
+/// up; the earlier non-recursive scanner missed them). When the cache
+/// hasn't been built yet (no project loaded), the picker shows empty.
 fn scanPrefabPickerNames(s: *SceneState, app: *App) void {
     s.prefab_picker_count = 0;
-    const proj = app.project_manager.current_project orelse return;
-    const proj_dir = proj.getProjectDir() orelse return;
-    const prefabs_dir = std.fs.path.join(app.allocator, &.{
-        proj_dir,
-        project.ProjectFolders.prefabs,
-    }) catch return;
-    defer app.allocator.free(prefabs_dir);
+    const pfx_index = if (app.prefab_index) |*ix| ix else return;
 
-    var dir = std.fs.cwd().openDir(prefabs_dir, .{ .iterate = true }) catch return;
-    defer dir.close();
-    var it = dir.iterate();
-    while (it.next() catch null) |dirent| {
+    var it = pfx_index.entries.keyIterator();
+    while (it.next()) |key_ptr| {
         if (s.prefab_picker_count >= max_prefab_picker_entries) break;
-        if (dirent.kind != .file) continue;
-        if (!std.mem.endsWith(u8, dirent.name, ".jsonc")) continue;
-        const stem = dirent.name[0 .. dirent.name.len - ".jsonc".len];
+        const stem = key_ptr.*;
         const slot = &s.prefab_picker_names[s.prefab_picker_count];
         @memset(slot, 0);
         const n = @min(stem.len, prefab_picker_name_cap);
         @memcpy(slot[0..n], stem[0..n]);
         s.prefab_picker_count += 1;
     }
+}
+
+/// World-space spawn position for toolbar-initiated prefab inserts.
+/// Returns the currently-selected entity's Position if any (lets the
+/// user "select-and-clone" by clicking + Prefab), falling back to
+/// world origin. The user can drag the new entity from there.
+fn defaultSpawnWorldPos(s: *SceneState) [2]f32 {
+    if (s.selected_index) |idx| {
+        if (idx < s.loaded.scene.entities.len) {
+            if (s.loaded.scene.entities[idx].position) |p| {
+                return .{ p.x, p.y };
+            }
+        }
+    }
+    return .{ 0, 0 };
 }
 
 fn addBlankEntity(s: *SceneState, world: [2]f32) !void {

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -14,6 +14,7 @@ const zgui = @import("zgui");
 const scene_io = @import("../scene_io.zig");
 const atlas = @import("../atlas.zig");
 const gizmos = @import("../gizmos.zig");
+const prefab_index_mod = @import("../prefab_index.zig");
 
 pub const min_h: f32 = 240;
 
@@ -24,6 +25,14 @@ pub const State = struct {
     selected_idx: *?usize,
     is_dirty: *bool,
     drag_armed: *bool,
+    /// World-space position of the dragged entity at the moment the
+    /// drag was armed. The drag handler computes the live target as
+    /// `drag_start_world + total_drag_delta / zoom` (snapped when
+    /// applicable) rather than accumulating incremental deltas onto
+    /// the entity's running position; the accumulated approach
+    /// silently breaks snap because the running position keeps
+    /// rounding back to the same cell while the cursor drifts.
+    drag_start_world: *[2]f32,
     /// Optional sink for right-click world coordinates. The viewport
     /// writes the world-space point when the user right-clicks an
     /// empty area of the canvas (no entity under the cursor); the
@@ -32,6 +41,15 @@ pub const State = struct {
     /// care about right-clicks — the prefab editor sets this to
     /// null today.
     right_click_world: ?*?[2]f32 = null,
+    /// Optional sink for "double-click on a scene entity that
+    /// references a prefab". The viewport writes the entity index
+    /// when the user double-clicks inside the AABB of a prefab-
+    /// referencing scene entity; the caller is then responsible for
+    /// opening the prefab editor for `entities[idx].prefab`. Null
+    /// when the caller doesn't want the descend-into-prefab path
+    /// (the prefab editor itself sets this to null — there's no
+    /// further level to descend into).
+    double_click_entity: ?*?usize = null,
     /// World-space spacing for the visual grid AND, when snapping is on,
     /// the snap step. One number drives both so the grid the user sees
     /// is the grid their drags land on. Default 16 matches what most 2D
@@ -107,6 +125,7 @@ pub fn render(
     /// (gizmo matching against unmodeled components is skipped).
     entity_extras: []const []const scene_io.ComponentExtra,
     atlas_index: ?*const atlas.Index,
+    prefab_index: ?*const prefab_index_mod.Index,
     gizmo_index: ?*const gizmos.Index,
     show_gizmos: bool,
 ) void {
@@ -135,23 +154,50 @@ pub fn render(
     });
 
     drawGrid(dl, canvas_min, canvas_max, state.pan.*, state.zoom.*, state.grid_step);
-    drawEntities(dl, canvas_min, state, entities, atlas_index);
+    drawEntities(dl, canvas_min, state, entities, atlas_index, prefab_index);
     if (show_gizmos) if (gizmo_index) |gi| {
         drawGizmoOverlay(dl, canvas_min, state, entities, entity_extras, gi);
     };
 
     _ = zgui.invisibleButton("##canvas_drag", .{ .w = canvas_size[0], .h = canvas_size[1], .flags = .{} });
 
-    // Mouse-down: hit-test markers, arm drag-to-move only when the
-    // click landed on an entity (otherwise drag in empty space
-    // would drift the previously-selected entity).
+    // Mouse-down: hit-test entity AABBs first (so a click anywhere on
+    // an expanded prefab's visual footprint grabs the whole room),
+    // fall back to the radial marker hit-test for degenerate cases
+    // (no sprite, no prefab — the AABB collapses to a point and
+    // `entityWorldAabb` returns the radial-equivalent box). Arm
+    // drag-to-move only when the click landed on something.
     if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.left)) {
         const mouse = zgui.getMousePos();
-        const hit = hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
+        const hit = hitTestEntityAabb(entities, mouse, canvas_min, state.pan.*, state.zoom.*, atlas_index, prefab_index) orelse
+            hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
         state.selected_idx.* = hit;
         state.drag_armed.* = hit != null;
+        // Snapshot the entity's starting world position so the drag
+        // handler can compute the live target from total delta. ImGui
+        // also begins accumulating mouse-drag delta from this click,
+        // so the math lines up: position = start + delta/zoom.
+        if (hit) |idx| {
+            if (idx < entities.len) {
+                if (entities[idx].position) |p| {
+                    state.drag_start_world.* = .{ p.x, p.y };
+                }
+            }
+        }
     }
     if (!zgui.isMouseDown(.left)) state.drag_armed.* = false;
+
+    // Double-click on a scene entity whose AABB contains the cursor
+    // surfaces the index to the caller, which opens the entity's
+    // referenced prefab as a tab (only the scene editor wires this —
+    // the prefab editor passes null because there's no further level
+    // to descend into).
+    if (state.double_click_entity) |sink| {
+        if (zgui.isItemHovered(.{}) and zgui.isMouseDoubleClicked(.left)) {
+            const mouse = zgui.getMousePos();
+            sink.* = hitTestEntityAabb(entities, mouse, canvas_min, state.pan.*, state.zoom.*, atlas_index, prefab_index);
+        }
+    }
 
     // Right-click on empty canvas → caller-driven context menu. We
     // only fire when the click misses every entity marker; clicks
@@ -159,7 +205,8 @@ pub fn render(
     if (state.right_click_world) |sink| {
         if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.right)) {
             const mouse = zgui.getMousePos();
-            const hit = hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
+            const hit = hitTestEntityAabb(entities, mouse, canvas_min, state.pan.*, state.zoom.*, atlas_index, prefab_index) orelse
+                hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
             if (hit == null) {
                 sink.* = worldFromScreen(mouse, canvas_min, state.pan.*, state.zoom.*);
             }
@@ -178,16 +225,26 @@ pub fn render(
                 if (idx < entities.len and zgui.isMouseDragging(.left, 0)) {
                     const e = &entities[idx];
                     if (e.position) |*pos| {
+                        // Total delta in screen pixels since the
+                        // drag started — NOT incremental. We DON'T
+                        // reset it, so each frame we compute the
+                        // live target from the snapshot, which makes
+                        // snap behave (the running position would
+                        // otherwise round back to its cell every
+                        // frame while the cursor drifted away).
                         const d = zgui.getMouseDragDelta(.left, .{});
-                        pos.x += d[0] / state.zoom.*;
+                        var nx = state.drag_start_world[0] + d[0] / state.zoom.*;
                         // World +y is up; screen +y is down.
-                        pos.y -= d[1] / state.zoom.*;
+                        var ny = state.drag_start_world[1] - d[1] / state.zoom.*;
                         if (state.snap_enabled and state.grid_step > 0) {
-                            pos.x = snapValue(pos.x, state.snap_origin[0], state.grid_step);
-                            pos.y = snapValue(pos.y, state.snap_origin[1], state.grid_step);
+                            nx = snapValue(nx, state.snap_origin[0], state.grid_step);
+                            ny = snapValue(ny, state.snap_origin[1], state.grid_step);
                         }
-                        state.is_dirty.* = true;
-                        zgui.resetMouseDragDelta(.left);
+                        if (pos.x != nx or pos.y != ny) {
+                            pos.x = nx;
+                            pos.y = ny;
+                            state.is_dirty.* = true;
+                        }
                     }
                 }
             }
@@ -235,6 +292,7 @@ fn drawEntities(
     state: State,
     entities: []scene_io.Entity,
     atlas_index: ?*const atlas.Index,
+    prefab_index: ?*const prefab_index_mod.Index,
 ) void {
     for (entities, 0..) |e, i| {
         const pos = e.position orelse continue;
@@ -244,7 +302,8 @@ fn drawEntities(
 
         // Render priority: sprite (when it resolves against the
         // atlas) > rectangle geometry > circle geometry > polygon
-        // geometry > colored-circle marker. A declared-but-unresolved
+        // geometry > expanded prefab tree (if the entity references a
+        // prefab) > colored-circle marker. A declared-but-unresolved
         // sprite still gets a `?` overlay on whatever fallback it
         // falls into.
         const drew_sprite = drawSpriteIfResolved(dl, e, px, py, state.zoom.*, atlas_index);
@@ -261,6 +320,18 @@ fn drawEntities(
             drawPolygon(dl, e.polygon.?.*, px, py, state.zoom.*);
             drew_visual = true;
         }
+        if (!drew_visual and e.prefab != null and atlas_index != null and prefab_index != null) {
+            drew_visual = drawPrefabAtPosition(
+                dl,
+                e.prefab.?,
+                px,
+                py,
+                state.zoom.*,
+                atlas_index.?,
+                prefab_index.?,
+                0,
+            );
+        }
         if (!drew_visual) {
             const col = colorForPrefab(e.prefab);
             dl.addCircleFilled(.{
@@ -275,13 +346,30 @@ fn drawEntities(
         }
 
         if (selected) {
-            dl.addCircle(.{
-                .p = .{ px, py },
-                .r = 12,
-                .col = 0xff_ff_d2_40,
-                .num_segments = 24,
-                .thickness = 2.0,
-            });
+            // Outline the entity's full footprint (AABB of its sprite
+            // or expanded prefab tree) so the user can see the whole
+            // grabbable region. Falls back to a circle around the
+            // anchor when no AABB resolves (point-only entities).
+            if (entityWorldAabb(e, atlas_index, prefab_index)) |aabb| {
+                const sx0 = cmin[0] + state.pan[0] + aabb.min[0] * state.zoom.*;
+                const sy0 = cmin[1] + state.pan[1] - aabb.max[1] * state.zoom.*; // world y_max → screen y_min
+                const sx1 = cmin[0] + state.pan[0] + aabb.max[0] * state.zoom.*;
+                const sy1 = cmin[1] + state.pan[1] - aabb.min[1] * state.zoom.*;
+                dl.addRect(.{
+                    .pmin = .{ sx0, sy0 },
+                    .pmax = .{ sx1, sy1 },
+                    .col = 0xff_ff_d2_40,
+                    .thickness = 2.0,
+                });
+            } else {
+                dl.addCircle(.{
+                    .p = .{ px, py },
+                    .r = 12,
+                    .col = 0xff_ff_d2_40,
+                    .num_segments = 24,
+                    .thickness = 2.0,
+                });
+            }
         }
         if (e.prefab) |p| {
             dl.addText(.{ px + 8, py - 8 }, 0xff_e0_e0_e0, "{s}", .{p});
@@ -302,7 +390,20 @@ fn drawSpriteIfResolved(
 ) bool {
     const sprite = e.sprite orelse return false;
     const idx = atlas_index orelse return false;
+    return drawSpriteValueAt(dl, sprite.*, px, py, zoom, idx);
+}
 
+/// Lower-level sprite draw: takes the Sprite value directly so callers
+/// that aren't iterating `Entity`s (e.g. the prefab-child walker) can
+/// reuse the atlas resolve + UV math. Returns true on a hit.
+fn drawSpriteValueAt(
+    dl: zgui.DrawList,
+    sprite: scene_io.Sprite,
+    px: f32,
+    py: f32,
+    zoom: f32,
+    idx: *const atlas.Index,
+) bool {
     const name = std.mem.sliceTo(&sprite.sprite_name, 0);
     if (name.len == 0) return false;
     const ref = idx.find(name) orelse return false;
@@ -351,6 +452,62 @@ fn drawSpriteIfResolved(
         .uvmax = uv1,
     });
     return true;
+}
+
+/// Walk a prefab tree starting at `(px, py)` (screen space), drawing
+/// every Sprite encountered at its child-offset position. When a child
+/// itself references another prefab (no Sprite of its own), recurses
+/// into that prefab using the child's Position as the offset. Returns
+/// true if at least one sprite was actually drawn — caller uses that
+/// to decide whether the generic colored marker is still needed.
+///
+/// The depth limit is a guard against pathological cycles
+/// (`prefab A` referencing `B` referencing `A`). Real prefab trees in
+/// the example projects bottom out in 2–3 levels.
+const max_prefab_depth: u32 = 8;
+
+fn drawPrefabAtPosition(
+    dl: zgui.DrawList,
+    prefab_name: []const u8,
+    px: f32,
+    py: f32,
+    zoom: f32,
+    atlas_index: *const atlas.Index,
+    pfx_index: *const prefab_index_mod.Index,
+    depth: u32,
+) bool {
+    if (depth >= max_prefab_depth) return false;
+    const pfx = pfx_index.find(prefab_name) orelse return false;
+
+    var drew_any = false;
+
+    // 1. Root sprite (most prefabs that visually represent a single
+    // object live here — e.g. `background_sky`).
+    if (pfx.entity.sprite) |s| {
+        if (drawSpriteValueAt(dl, s.*, px, py, zoom, atlas_index)) drew_any = true;
+    }
+
+    // 2. Children: each one has its own Position offset relative to
+    // the prefab root. Render its Sprite if present, otherwise recurse
+    // into its referenced prefab.
+    for (pfx.children) |child| {
+        const off = child.position orelse continue;
+        const cx = px + off.x * zoom;
+        const cy = py - off.y * zoom;
+        if (child.sprite) |cs| {
+            if (drawSpriteValueAt(dl, cs.*, cx, cy, zoom, atlas_index)) {
+                drew_any = true;
+                continue;
+            }
+        }
+        if (child.prefab) |sub_name| {
+            if (drawPrefabAtPosition(dl, sub_name, cx, cy, zoom, atlas_index, pfx_index, depth + 1)) {
+                drew_any = true;
+            }
+        }
+    }
+
+    return drew_any;
 }
 
 /// Draw a `Rectangle` geometry component centered on `(px, py)` in
@@ -507,6 +664,174 @@ pub fn hitTestEntity(
         }
     }
     return best;
+}
+
+/// Axis-aligned bounding box in *world* coordinates. World +y is up
+/// (same convention `drawEntities` uses for the world→screen map).
+pub const WorldAabb = struct {
+    min: [2]f32,
+    max: [2]f32,
+
+    pub fn fromPoint(p: [2]f32) WorldAabb {
+        return .{ .min = p, .max = p };
+    }
+
+    pub fn expandToInclude(self: *WorldAabb, p: [2]f32) void {
+        self.min[0] = @min(self.min[0], p[0]);
+        self.min[1] = @min(self.min[1], p[1]);
+        self.max[0] = @max(self.max[0], p[0]);
+        self.max[1] = @max(self.max[1], p[1]);
+    }
+
+    pub fn merge(self: *WorldAabb, other: WorldAabb) void {
+        self.expandToInclude(other.min);
+        self.expandToInclude(other.max);
+    }
+};
+
+/// Sprite footprint in world coordinates around `anchor_world`,
+/// respecting the named pivot. `pivot.x` is the fraction of the
+/// sprite to the right of the anchor; `pivot.y` is the fraction
+/// above the anchor (world +y up). E.g. `bottom_center` →
+/// `(0.5, 0)` puts the anchor at the sprite's bottom midpoint, so
+/// the sprite extends `w/2` left, `w/2` right, `h` up, `0` down.
+fn spriteWorldAabb(sprite: scene_io.Sprite, anchor_world: [2]f32, ref: atlas.SpriteRef) WorldAabb {
+    const w: f32 = @floatFromInt(ref.frame.w);
+    const h: f32 = @floatFromInt(ref.frame.h);
+    const pivot_name = std.mem.sliceTo(&sprite.pivot, 0);
+    const pivot = pivotOffset(pivot_name);
+    return .{
+        .min = .{
+            anchor_world[0] - pivot[0] * w,
+            anchor_world[1] - pivot[1] * h,
+        },
+        .max = .{
+            anchor_world[0] + (1.0 - pivot[0]) * w,
+            anchor_world[1] + (1.0 - pivot[1]) * h,
+        },
+    };
+}
+
+/// Walk the prefab tree the same way `drawPrefabAtPosition` does,
+/// but accumulate AABBs of every resolvable sprite instead of issuing
+/// draw calls. Returns null when nothing in the tree resolves to a
+/// drawable sprite — caller can then fall back to a point-radius
+/// AABB. Depth-limited by `max_prefab_depth` to guard against cycles.
+fn prefabWorldAabb(
+    prefab_name: []const u8,
+    anchor_world: [2]f32,
+    atlas_idx: *const atlas.Index,
+    pfx_index: *const prefab_index_mod.Index,
+    depth: u32,
+) ?WorldAabb {
+    if (depth >= max_prefab_depth) return null;
+    const pfx = pfx_index.find(prefab_name) orelse return null;
+
+    var box: ?WorldAabb = null;
+
+    if (pfx.entity.sprite) |s| {
+        const name = std.mem.sliceTo(&s.sprite_name, 0);
+        if (name.len > 0) {
+            if (atlas_idx.find(name)) |ref| {
+                const sub = spriteWorldAabb(s.*, anchor_world, ref);
+                if (box) |*b| b.merge(sub) else box = sub;
+            }
+        }
+    }
+
+    for (pfx.children) |child| {
+        const off = child.position orelse continue;
+        const child_anchor: [2]f32 = .{ anchor_world[0] + off.x, anchor_world[1] + off.y };
+        if (child.sprite) |cs| {
+            const cname = std.mem.sliceTo(&cs.sprite_name, 0);
+            if (cname.len > 0) {
+                if (atlas_idx.find(cname)) |cref| {
+                    const sub = spriteWorldAabb(cs.*, child_anchor, cref);
+                    if (box) |*b| b.merge(sub) else box = sub;
+                    continue;
+                }
+            }
+        }
+        if (child.prefab) |sub_name| {
+            if (prefabWorldAabb(sub_name, child_anchor, atlas_idx, pfx_index, depth + 1)) |sub| {
+                if (box) |*b| b.merge(sub) else box = sub;
+            }
+        }
+    }
+
+    return box;
+}
+
+/// World-space AABB of a single scene entity, accounting for its
+/// own typed Sprite, its referenced prefab tree (when applicable),
+/// and falling back to a small point-radius box otherwise. Returns
+/// null when the entity has no Position (we don't draw it then —
+/// matches the `drawEntities` skip).
+pub fn entityWorldAabb(
+    entity: scene_io.Entity,
+    atlas_idx: ?*const atlas.Index,
+    pfx_index: ?*const prefab_index_mod.Index,
+) ?WorldAabb {
+    const pos = entity.position orelse return null;
+    const anchor: [2]f32 = .{ pos.x, pos.y };
+
+    if (entity.sprite) |s| {
+        if (atlas_idx) |ai| {
+            const name = std.mem.sliceTo(&s.sprite_name, 0);
+            if (name.len > 0) {
+                if (ai.find(name)) |ref| {
+                    return spriteWorldAabb(s.*, anchor, ref);
+                }
+            }
+        }
+    }
+
+    if (entity.prefab) |p| {
+        if (atlas_idx) |ai| if (pfx_index) |pi| {
+            if (prefabWorldAabb(p, anchor, ai, pi, 0)) |b| return b;
+        };
+    }
+
+    // Fallback: a small box around the anchor so degenerate entities
+    // (no sprite, no resolved prefab) still get a clickable target the
+    // same size as the marker dot.
+    const r: f32 = hit_radius;
+    return .{ .min = .{ anchor[0] - r, anchor[1] - r }, .max = .{ anchor[0] + r, anchor[1] + r } };
+}
+
+/// AABB hit-test: pick the topmost (last in iteration order) entity
+/// whose world-AABB contains the mouse position. Used by the scene
+/// viewport so room-sized prefab footprints become clickable
+/// everywhere they paint, not just within `hit_radius` of the
+/// anchor.
+pub fn hitTestEntityAabb(
+    entities: []scene_io.Entity,
+    mouse: [2]f32,
+    canvas_min: [2]f32,
+    pan: [2]f32,
+    zoom: f32,
+    atlas_idx: ?*const atlas.Index,
+    pfx_index: ?*const prefab_index_mod.Index,
+) ?usize {
+    // World-space mouse so we compare in the same coords the AABB is
+    // computed in. World +y is up; screen +y is down, hence the flip.
+    const mouse_world: [2]f32 = .{
+        (mouse[0] - canvas_min[0] - pan[0]) / zoom,
+        -(mouse[1] - canvas_min[1] - pan[1]) / zoom,
+    };
+    // Reverse iter so overlapping rooms select the one drawn last
+    // (= the one painted on top).
+    var i: usize = entities.len;
+    while (i > 0) {
+        i -= 1;
+        const aabb = entityWorldAabb(entities[i], atlas_idx, pfx_index) orelse continue;
+        if (mouse_world[0] >= aabb.min[0] and mouse_world[0] <= aabb.max[0] and
+            mouse_world[1] >= aabb.min[1] and mouse_world[1] <= aabb.max[1])
+        {
+            return i;
+        }
+    }
+    return null;
 }
 
 /// Walk every entity, check every gizmo's predicates, draw the gizmo's

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -195,7 +195,13 @@ pub fn render(
     if (state.double_click_entity) |sink| {
         if (zgui.isItemHovered(.{}) and zgui.isMouseDoubleClicked(.left)) {
             const mouse = zgui.getMousePos();
-            sink.* = hitTestEntityAabb(entities, mouse, canvas_min, state.pan.*, state.zoom.*, atlas_index, prefab_index);
+            // Same fallback chain the single + right-click handlers
+            // use: AABB first, then radial. Without the radial chain a
+            // degenerate entity (no AABB resolves) would be
+            // single-clickable but un-double-clickable, even though
+            // its `prefab` field may still be set and openable.
+            sink.* = hitTestEntityAabb(entities, mouse, canvas_min, state.pan.*, state.zoom.*, atlas_index, prefab_index) orelse
+                hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
         }
     }
 
@@ -671,10 +677,6 @@ pub fn hitTestEntity(
 pub const WorldAabb = struct {
     min: [2]f32,
     max: [2]f32,
-
-    pub fn fromPoint(p: [2]f32) WorldAabb {
-        return .{ .min = p, .max = p };
-    }
 
     pub fn expandToInclude(self: *WorldAabb, p: [2]f32) void {
         self.min[0] = @min(self.min[0], p[0]);

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -762,11 +762,12 @@ fn prefabWorldAabb(
     return box;
 }
 
-/// World-space AABB of a single scene entity, accounting for its
-/// own typed Sprite, its referenced prefab tree (when applicable),
-/// and falling back to a small point-radius box otherwise. Returns
-/// null when the entity has no Position (we don't draw it then —
-/// matches the `drawEntities` skip).
+/// World-space AABB of a single scene entity. Matches the visual
+/// priority `drawEntities` uses (sprite → rectangle → circle →
+/// polygon → expanded prefab tree → degenerate marker box), so the
+/// selection outline + hit-test region always agree with what's
+/// actually painted on the canvas. Returns null when the entity has
+/// no Position — same skip `drawEntities` applies.
 pub fn entityWorldAabb(
     entity: scene_io.Entity,
     atlas_idx: ?*const atlas.Index,
@@ -786,17 +787,60 @@ pub fn entityWorldAabb(
         }
     }
 
+    // Rectangle is centered on the anchor (see `drawRectangle`).
+    if (entity.rectangle) |r| {
+        const half_w = r.width * 0.5;
+        const half_h = r.height * 0.5;
+        return .{
+            .min = .{ anchor[0] - half_w, anchor[1] - half_h },
+            .max = .{ anchor[0] + half_w, anchor[1] + half_h },
+        };
+    }
+
+    // Circle is centered on the anchor with `radius` (see `drawCircle`).
+    if (entity.circle) |c| {
+        const rad = c.radius;
+        return .{
+            .min = .{ anchor[0] - rad, anchor[1] - rad },
+            .max = .{ anchor[0] + rad, anchor[1] + rad },
+        };
+    }
+
+    // Polygon points are world-space offsets from the anchor; bounds
+    // come from the actual point set rather than a constructed
+    // rectangle (see `drawPolygon`'s `px + points[i].x * zoom` map).
+    if (entity.polygon) |p| {
+        if (p.point_count > 0) {
+            const first = p.points[0];
+            var box: WorldAabb = .{
+                .min = .{ anchor[0] + first.x, anchor[1] + first.y },
+                .max = .{ anchor[0] + first.x, anchor[1] + first.y },
+            };
+            var i: u32 = 1;
+            while (i < p.point_count) : (i += 1) {
+                const pt = p.points[i];
+                box.expandToInclude(.{ anchor[0] + pt.x, anchor[1] + pt.y });
+            }
+            return box;
+        }
+    }
+
     if (entity.prefab) |p| {
         if (atlas_idx) |ai| if (pfx_index) |pi| {
             if (prefabWorldAabb(p, anchor, ai, pi, 0)) |b| return b;
         };
     }
 
-    // Fallback: a small box around the anchor so degenerate entities
-    // (no sprite, no resolved prefab) still get a clickable target the
-    // same size as the marker dot.
-    const r: f32 = hit_radius;
-    return .{ .min = .{ anchor[0] - r, anchor[1] - r }, .max = .{ anchor[0] + r, anchor[1] + r } };
+    // No drawable shape resolved: return null rather than a fake
+    // world-space radius. The screen-pixel `hit_radius` constant is
+    // not a world quantity, so using it here scaled the hit region
+    // wildly with zoom (huge at 10×, sub-marker at 0.1×) and made
+    // the circle-fallback selection draw dead code. Caller chains
+    // `hitTestEntityAabb(...) orelse hitTestEntity(...)`, so a null
+    // here cleanly hands these degenerate entities back to the
+    // existing radial hit test, and the `else` branch in the
+    // selection draw renders the small circle around the anchor.
+    return null;
 }
 
 /// AABB hit-test: pick the topmost (last in iteration order) entity

--- a/src/prefab_index.zig
+++ b/src/prefab_index.zig
@@ -1,0 +1,143 @@
+//! Per-project prefab cache. Walks `<project>/prefabs/**/*.jsonc` on
+//! project load, parses each via `scene_io.loadPrefabFromFile`, and
+//! stores the result keyed by filename stem (the same name the engine
+//! uses when a scene entity writes `{ "prefab": "canteen" }`).
+//!
+//! The viewport uses this so that scene entities referencing a prefab
+//! display the prefab's image(s) at their position instead of the
+//! generic colored marker. Sprite resolution is recursive: when a
+//! prefab itself has no Sprite but has children that do (or that
+//! reference further prefabs), those are drawn at their child-position
+//! offsets relative to the scene entity's world position.
+//!
+//! The cache is owned by `App` and bound to a `ProjectManager`
+//! `generation`. When the generation bumps (project new/load/close)
+//! the cache is invalidated and rebuilt.
+
+const std = @import("std");
+
+const scene_io = @import("scene_io.zig");
+
+/// One cached prefab entry. `path` is owned by the index (heap dup);
+/// `loaded` carries its own arena. Both freed by `Index.deinit`.
+pub const Entry = struct {
+    path: []const u8,
+    loaded: scene_io.LoadedPrefab,
+};
+
+pub const Index = struct {
+    allocator: std.mem.Allocator,
+    /// Owns every `Entry.loaded.arena` + `Entry.path` + key string in
+    /// `by_name`. `Entry.loaded.deinit` is called for each on
+    /// `Index.deinit`.
+    entries: std.StringHashMapUnmanaged(Entry) = .{},
+    /// `ProjectManager.generation` this index was built against. App
+    /// invalidates when the live generation changes.
+    generation: u64,
+
+    pub fn deinit(self: *Index) void {
+        var it = self.entries.iterator();
+        while (it.next()) |entry| {
+            entry.value_ptr.loaded.deinit();
+            self.allocator.free(entry.value_ptr.path);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.entries.deinit(self.allocator);
+    }
+
+    /// Returns the cached prefab body by name (filename stem), or
+    /// null when the project has no prefab with that name. Kept for
+    /// call sites that only care about the parsed body; use
+    /// `findEntry` when you also need the source path.
+    pub fn find(self: *const Index, name: []const u8) ?*const scene_io.LoadedPrefab {
+        return if (self.entries.getPtr(name)) |e| &e.loaded else null;
+    }
+
+    /// Like `find`, but returns both the parsed body and the source
+    /// path so callers (e.g. "double-click → open prefab tab") can
+    /// drive `app.openPrefab` without re-walking the filesystem.
+    pub fn findEntry(self: *const Index, name: []const u8) ?*const Entry {
+        return self.entries.getPtr(name);
+    }
+
+    /// Walk `<project_dir>/prefabs/` recursively and load every
+    /// `.jsonc` file. Errors on a single file are logged and skipped —
+    /// same tolerance the atlas and gizmo loaders use. The key is the
+    /// file's stem (basename minus `.jsonc`); collisions across
+    /// subdirectories keep the first hit and log a warning.
+    pub fn build(
+        allocator: std.mem.Allocator,
+        project_dir: []const u8,
+        generation: u64,
+    ) Index {
+        var idx: Index = .{ .allocator = allocator, .generation = generation };
+
+        const prefabs_dir = std.fs.path.join(allocator, &.{ project_dir, "prefabs" }) catch return idx;
+        defer allocator.free(prefabs_dir);
+
+        walk(allocator, &idx, prefabs_dir);
+        return idx;
+    }
+};
+
+/// Recursive directory walk. Picked over `std.fs.Dir.walk` because the
+/// latter allocates a queue and we want to keep the call site simple +
+/// errors locally absorbed.
+fn walk(allocator: std.mem.Allocator, idx: *Index, path: []const u8) void {
+    var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch return;
+    defer dir.close();
+
+    var it = dir.iterate();
+    while (it.next() catch null) |dirent| {
+        const full = std.fs.path.join(allocator, &.{ path, dirent.name }) catch continue;
+        defer allocator.free(full);
+
+        switch (dirent.kind) {
+            .directory => walk(allocator, idx, full),
+            .file => {
+                if (!std.mem.endsWith(u8, dirent.name, ".jsonc")) continue;
+                loadOne(allocator, idx, full, dirent.name) catch |err| {
+                    std.log.warn("Prefab '{s}' failed to load: {s}", .{ full, @errorName(err) });
+                };
+            },
+            else => {},
+        }
+    }
+}
+
+fn loadOne(
+    allocator: std.mem.Allocator,
+    idx: *Index,
+    full_path: []const u8,
+    basename: []const u8,
+) !void {
+    // Filename stem = basename minus `.jsonc` extension. Matches how
+    // the engine/assembler resolves `{ "prefab": "<stem>" }` lookups.
+    const stem = basename[0 .. basename.len - ".jsonc".len];
+
+    const gop = try idx.entries.getOrPut(allocator, stem);
+    if (gop.found_existing) {
+        std.log.warn("Prefab name '{s}' duplicated across subfolders; keeping first hit", .{stem});
+        return;
+    }
+    // getOrPut wrote the input slice as the key — replace it with an
+    // owned copy so the slot survives `basename`'s caller-owned buffer.
+    const owned_key = allocator.dupe(u8, stem) catch |err| {
+        _ = idx.entries.remove(stem);
+        return err;
+    };
+    gop.key_ptr.* = owned_key;
+
+    const owned_path = allocator.dupe(u8, full_path) catch |err| {
+        _ = idx.entries.remove(owned_key);
+        allocator.free(owned_key);
+        return err;
+    };
+    const loaded = scene_io.loadPrefabFromFile(allocator, full_path) catch |err| {
+        allocator.free(owned_path);
+        _ = idx.entries.remove(owned_key);
+        allocator.free(owned_key);
+        return err;
+    };
+    gop.value_ptr.* = .{ .path = owned_path, .loaded = loaded };
+}


### PR DESCRIPTION
## Summary

Scene-side prefab support. Placed prefab instances are now visually expanded, atomically selectable + draggable as a whole, and route back to their canonical prefab file via a clear UI path. Scene/prefab atomicity contract preserved (no per-instance child overrides — that's a separate data-model change, see comments).

### What's in here

- **`src/prefab_index.zig`** (new): per-project cache, walks `<project>/prefabs/` recursively, stores `{ path, LoadedPrefab }` keyed by filename stem. Generation-keyed invalidation mirrors `atlas_index` / `gizmo_index`.
- **`app.zig`**: wires `prefab_index` alongside the other per-project indexes (build on project change, deinit on app close, rebuild on prefab save). Adds `requestOpenPrefab` deferred-action queue flushed at the top of each frame so mid-render "open prefab as tab" requests don't realloc `open_tabs` and invalidate the SceneState pointer the requester is still rendering against.
- **`modules/viewport.zig`**:
  - When a scene entity references a prefab and has no Sprite of its own, recursively expand the prefab tree and draw every resolvable Sprite at its accumulated world position. Depth-limited to guard cycles.
  - New `entityWorldAabb` + `hitTestEntityAabb` make the entire prefab footprint clickable. Selection draws a rectangle around the AABB instead of a circle around the anchor.
  - Drag now snapshots the entity's world position at drag-start; each frame's target is `start + total_drag_delta / zoom` (snapped when applicable). Fixes the cursor-drift bug where snap-mode drag rounded the running position back to its cell every frame while the cursor kept moving.
- **`modules/scene.zig`**: "Add prefab" toolbar button → existing picker. Spawn position defaults to the currently-selected entity's position (so select-and-clone is natural), falling back to world origin. Picker popup gains a Cancel button and now sources names from the prefab cache (so nested files like `prefabs/rooms/canteen.jsonc` actually show up — the previous flat scanner missed them). Double-click on a scene entity → opens its prefab file as a tab.
- **`modules/inspector.zig`**: "Edit prefab" small button next to the `prefab:` line when a scene entity references a prefab. Same routing as double-click. Caller passes a `?*?[]const u8` sink for opt-in; prefab editor passes `null` because there's no further level to descend into.
- **`modules/prefab.zig`**: `savePrefab` calls `app.rebuildPrefabIndex()` so scene tabs pick up the new layout on their next render without requiring a project reload.

### Why prefab instances are atomic in the scene

A scene entity's shape is fixed: `{ prefab?, components: { Position, Sprite, Rectangle, Circle, Polygon } }`. There's no slot in the file format for per-child overrides on a placed prefab. The UI now makes that explicit:
- **Scene editor** = "where does each room go in the world?" — AABB drag, one click = whole prefab.
- **Prefab editor** = "what's inside each room?" — per-child marker drag, already worked.
- **Double-click / Edit prefab** = fast path to descend into the canonical layout.

If we ever want per-instance child overrides (Unity-style prefab overrides), that's a separate RFC: scene format + parser + writer + engine support.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — 182 / 182 pass
- [x] `zig build gui-test` — 8 / 8 pass
- [x] Visual: `flying-platform-labelle/scenes/main.jsonc` — every room (canteen, kitchen, condenser, …) now draws its expanded prefab tree at its world position; click anywhere on a room selects it; drag moves the whole thing; double-click opens its prefab file; "Add prefab" lists every nested prefab; snap-mode drag tracks the cursor without drift.
- [ ] Reviewer: open another scene that references prefabs; verify the cache stays correct after editing + saving a prefab (the scene should pick up the new layout on the next frame without a reload).