### PR TITLE
fix(preview): surface launcher / engine stderr when session crashes (#79)

### DIFF
--- a/src/modules/preview.zig
+++ b/src/modules/preview.zig
@@ -63,7 +63,10 @@ fn renderStatus(p: *const preview.PreviewSession) void {
             zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Preview running (engine PID {d}, last heartbeat {d}ms ago)", .{ pid, ago });
             if (p.engine_version) |v| zgui.text("Engine version: {s}", .{v});
         },
-        .crashed => zgui.textColored(.{ 1.0, 0.3, 0.3, 1.0 }, "Preview crashed", .{}),
+        .crashed => {
+            zgui.textColored(.{ 1.0, 0.3, 0.3, 1.0 }, "Preview crashed", .{});
+            renderCapturedStderr(p);
+        },
         .stopped => {
             if (p.bye_reason) |r| {
                 zgui.textDisabled("Preview stopped ({s})", .{r});
@@ -72,6 +75,29 @@ fn renderStatus(p: *const preview.PreviewSession) void {
             }
         },
     }
+}
+
+/// Surface the child's captured stderr tail when a session has
+/// failed. Empty buffer → the child either never produced output
+/// before it was killed, OR it was the connect-timeout path with a
+/// well-behaved launcher that just didn't pass the args through —
+/// fall back to a hint instead of an empty rectangle so the user
+/// always sees *some* signal about what went wrong.
+fn renderCapturedStderr(p: *const preview.PreviewSession) void {
+    const captured = p.capturedStderr();
+    zgui.spacing();
+    zgui.textDisabled("Launcher / engine output:", .{});
+    if (captured.len == 0) {
+        zgui.textDisabled("  (no stderr captured — child may have exited silently or never started)", .{});
+        return;
+    }
+    // Bounded child-window so a long stderr tail doesn't push the
+    // Run/Stop buttons off-screen. Read-only — the user can scroll
+    // through and copy/paste, no editing.
+    if (zgui.beginChild("##preview_stderr", .{ .w = 0, .h = 160, .child_flags = .{ .border = true } })) {
+        zgui.textUnformatted(captured);
+    }
+    zgui.endChild();
 }
 
 fn renderButtons(app: *App) void {

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -214,7 +214,13 @@ pub const PreviewSession = struct {
         // fails. Without this the user sees only "Preview crashed"
         // and has to re-run the editor from a terminal to learn
         // anything actionable.
-        child.stderr_behavior = .Pipe;
+        //
+        // Windows: we don't have a non-blocking-read story for the
+        // pipe yet, and a blocking `read` on `drainStderr` would
+        // freeze the gui's render thread. Fall back to inherit there
+        // — capture stays POSIX-only until a Windows-safe IOCP path
+        // lands.
+        child.stderr_behavior = if (builtin.os.tag == .windows) .Inherit else .Pipe;
 
         child.spawn() catch |err| switch (err) {
             error.FileNotFound => return error.LauncherNotFound,
@@ -226,11 +232,16 @@ pub const PreviewSession = struct {
 
         // Non-block the captured stderr so `drainStderr` can pull
         // whatever the child has produced so far without ever blocking
-        // the render thread. POSIX-only — the helper short-circuits on
-        // Windows (see `setNonBlock`).
+        // the render thread. If NONBLOCK fails we close the pipe and
+        // null `child.stderr` *before* assigning into `self.child`, so
+        // `drainStderr` can't accidentally land on a blocking fd and
+        // freeze the gui. Failure here means no stderr capture, not a
+        // crash.
         if (child.stderr) |se_file| {
             setNonBlock(se_file.handle) catch |err| {
-                std.log.warn("preview: NONBLOCK on stderr pipe failed: {s}", .{@errorName(err)});
+                std.log.warn("preview: NONBLOCK on stderr pipe failed; capture disabled: {s}", .{@errorName(err)});
+                se_file.close();
+                child.stderr = null;
             };
         }
 
@@ -279,18 +290,33 @@ pub const PreviewSession = struct {
     /// Appends every available byte into `stderr_buf` (capped so a
     /// runaway child can't OOM the editor). Safe to call from any
     /// active state — silently no-ops when the child or pipe is
-    /// absent. Errors other than `WouldBlock` (EOF, broken pipe)
-    /// also exit cleanly; the captured tail stays in `stderr_buf`.
+    /// absent. On EOF or a non-`WouldBlock` read error we close the
+    /// pipe and clear `child.stderr` so subsequent frames don't keep
+    /// retrying a broken / drained fd. We pin a pointer into the
+    /// optional rather than copying the Child struct so those
+    /// modifications actually stick on the session.
     fn drainStderr(self: *Self) void {
-        const child = self.child orelse return;
+        if (self.child == null) return;
+        const child = &self.child.?;
         const stderr = child.stderr orelse return;
         var buf: [stderr_read_chunk]u8 = undefined;
         while (true) {
             const n = stderr.read(&buf) catch |err| switch (err) {
                 error.WouldBlock => return,
-                else => return,
+                else => {
+                    std.log.warn("preview: stderr read failed; capture disabled: {s}", .{@errorName(err)});
+                    stderr.close();
+                    child.stderr = null;
+                    return;
+                },
             };
-            if (n == 0) return;
+            if (n == 0) {
+                // EOF — child closed its stderr (typical on a clean
+                // exit). Stop trying so we don't spin on a dead pipe.
+                stderr.close();
+                child.stderr = null;
+                return;
+            }
             self.appendStderrCapped(buf[0..n]);
         }
     }

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -94,6 +94,18 @@ const max_frame_bytes: usize = 64 * 1024;
 /// re-allocating on every line.
 const read_chunk: usize = 1024;
 
+/// Cap on captured-child-stderr bytes. We keep the tail so the user
+/// sees the most recent (most diagnostic) output when a session fails.
+/// 8 KiB is enough for a CLI usage error + a small stack trace; tight
+/// enough that a misbehaving child spamming stderr can't OOM the
+/// editor.
+const max_stderr_bytes: usize = 8 * 1024;
+
+/// Read buffer for non-blocking stderr drains. Matches `read_chunk`
+/// in spirit; small enough to avoid stack pressure, big enough to
+/// pull a typical CLI error line in one syscall.
+const stderr_read_chunk: usize = 1024;
+
 pub const PreviewSession = struct {
     allocator: std.mem.Allocator,
     state: State,
@@ -124,6 +136,16 @@ pub const PreviewSession = struct {
     /// next frame.
     rx_buf: std.ArrayList(u8),
 
+    /// Captured child-stderr tail, drained non-blockingly each frame.
+    /// Surfaced verbatim by the preview panel when the session lands
+    /// in `crashed` so the user sees the CLI's actual error message
+    /// (e.g. "labelle run: unknown flag '--'" when the installed
+    /// launcher is too old to forward the preview-mode args) instead
+    /// of a generic "Preview crashed". Capped at `max_stderr_bytes`;
+    /// older bytes are dropped from the front so the most-recent (most
+    /// diagnostic) tail wins.
+    stderr_buf: std.ArrayList(u8),
+
     const Self = @This();
 
     pub fn init(allocator: std.mem.Allocator) Self {
@@ -140,12 +162,14 @@ pub const PreviewSession = struct {
             .bye_reason = null,
             .started_ms = null,
             .rx_buf = .{},
+            .stderr_buf = .{},
         };
     }
 
     pub fn deinit(self: *Self) void {
         self.teardown();
         self.rx_buf.deinit(self.allocator);
+        self.stderr_buf.deinit(self.allocator);
     }
 
     /// Spawn a preview run for `proj`. Mirrors `Compiler.buildOrRun`'s
@@ -185,7 +209,12 @@ pub const PreviewSession = struct {
         }, self.allocator);
         child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Inherit;
-        child.stderr_behavior = .Inherit;
+        // Capture stderr so we can surface the launcher / engine's
+        // own error messages in the preview panel when a session
+        // fails. Without this the user sees only "Preview crashed"
+        // and has to re-run the editor from a terminal to learn
+        // anything actionable.
+        child.stderr_behavior = .Pipe;
 
         child.spawn() catch |err| switch (err) {
             error.FileNotFound => return error.LauncherNotFound,
@@ -194,6 +223,16 @@ pub const PreviewSession = struct {
                 return error.LauncherNotFound;
             },
         };
+
+        // Non-block the captured stderr so `drainStderr` can pull
+        // whatever the child has produced so far without ever blocking
+        // the render thread. POSIX-only — the helper short-circuits on
+        // Windows (see `setNonBlock`).
+        if (child.stderr) |se_file| {
+            setNonBlock(se_file.handle) catch |err| {
+                std.log.warn("preview: NONBLOCK on stderr pipe failed: {s}", .{@errorName(err)});
+            };
+        }
 
         self.server = server;
         self.child = child;
@@ -225,9 +264,53 @@ pub const PreviewSession = struct {
     pub fn poll(self: *Self) void {
         switch (self.state) {
             .idle, .stopped, .crashed => return,
-            .listening => self.tickListening(),
-            .connecting, .running => self.tickStream(),
+            .listening => {
+                self.drainStderr();
+                self.tickListening();
+            },
+            .connecting, .running => {
+                self.drainStderr();
+                self.tickStream();
+            },
         }
+    }
+
+    /// Non-blocking pull from the child's captured stderr pipe.
+    /// Appends every available byte into `stderr_buf` (capped so a
+    /// runaway child can't OOM the editor). Safe to call from any
+    /// active state — silently no-ops when the child or pipe is
+    /// absent. Errors other than `WouldBlock` (EOF, broken pipe)
+    /// also exit cleanly; the captured tail stays in `stderr_buf`.
+    fn drainStderr(self: *Self) void {
+        const child = self.child orelse return;
+        const stderr = child.stderr orelse return;
+        var buf: [stderr_read_chunk]u8 = undefined;
+        while (true) {
+            const n = stderr.read(&buf) catch |err| switch (err) {
+                error.WouldBlock => return,
+                else => return,
+            };
+            if (n == 0) return;
+            self.appendStderrCapped(buf[0..n]);
+        }
+    }
+
+    fn appendStderrCapped(self: *Self, data: []const u8) void {
+        self.stderr_buf.appendSlice(self.allocator, data) catch return;
+        if (self.stderr_buf.items.len <= max_stderr_bytes) return;
+        // Drop from the front to retain the tail — diagnostic output
+        // is most useful right before the failure, so the most-recent
+        // bytes are the ones we want to keep visible to the user.
+        const overflow = self.stderr_buf.items.len - max_stderr_bytes;
+        self.stderr_buf.replaceRange(self.allocator, 0, overflow, &.{}) catch {};
+    }
+
+    /// Read-only view of the captured-child stderr tail. The panel
+    /// renders this verbatim under the "Preview crashed" header.
+    /// Empty when the session never spawned a child or when nothing
+    /// has been read yet.
+    pub fn capturedStderr(self: *const Self) []const u8 {
+        return self.stderr_buf.items;
     }
 
     // ─── State driving ─────────────────────────────────────────────────
@@ -379,6 +462,10 @@ pub const PreviewSession = struct {
     }
 
     fn failWithCrash(self: *Self) void {
+        // Last chance to capture diagnostic output from the child
+        // before we SIGKILL it — anything queued in the kernel pipe
+        // buffer is lost otherwise.
+        self.drainStderr();
         self.teardownChildAndIo();
         self.state = .crashed;
     }
@@ -428,6 +515,7 @@ pub const PreviewSession = struct {
         self.teardownChildAndIo();
         self.freeStrings();
         self.rx_buf.clearRetainingCapacity();
+        self.stderr_buf.clearRetainingCapacity();
         self.port = null;
         self.engine_pid = null;
         self.last_heartbeat_ms = null;


### PR DESCRIPTION
## Summary

Until [labelle-cli's v1.38.0 release](https://github.com/labelle-toolkit/labelle-cli/pull/194) ships, every preview-mode run on a current dev machine hits the same opaque "Preview crashed" because the installed CLI rejects the gui's `--` passthrough. The actual error (\`labelle run: unknown flag '--'\`) is going straight to the gui's own stderr — invisible unless you launched the editor from a terminal.

Capture it and surface it in the panel.

- `child.stderr_behavior`: `.Inherit` → `.Pipe`, with non-block on POSIX so the drain never blocks the frame.
- New `PreviewSession.stderr_buf` (8 KiB cap, oldest-bytes-dropped on overflow) drained each frame in `poll`. One final drain before `failWithCrash` SIGKILLs the child so anything queued between polls is preserved.
- Panel renders the captured tail under "Preview crashed" in a bounded child window.

After this change:
```
Preview crashed
Launcher / engine output:
labelle run: unknown flag '--'
```

The fix is independent of the CLI-side work — once the launcher upgrade lands, any future breakage in the spawn chain (engine init failure, missing binary, build error) still surfaces verbatim instead of being lost.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — all pass
- [x] `zig build gui-test` — 8/8 pass
- [x] Visual: ran against today's v1.37.0 CLI, captured stderr surfaces in the panel as expected (screenshot in #79's discussion).
- [ ] Reviewer: confirm the bounded child-window doesn't push the Stop button below the panel's auto-resize ceiling for typical stderr volumes.

## Out of scope

- A pre-flight `labelle version` check that refuses to spawn when the installed CLI is too old. Cheaper UX, but needs a concrete minimum-version threshold which we won't have until v1.38.0 actually ships. Tracked as a follow-up bullet on #79.

Closes a chunk of #79 (gui-side diagnostic surfacing). End-to-end preview-mode fix still gated on the labelle-cli release.