### PR TITLE
feat(scene): discoverable delete affordances + confirmation modal (#82)

### DIFF
--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -64,6 +64,15 @@ pub fn renderEntity(
     /// as a tab. The scene editor wires this; the prefab editor passes
     /// null because there's no further level to descend into.
     request_open_prefab: ?*?[]const u8,
+    /// Optional sink: when non-null, the inspector renders a small
+    /// "Delete" button below the entity header. Clicking it flips the
+    /// flag; the caller (the scene editor) opens its own confirmation
+    /// modal and removes the entity on accept. Decoupled so the
+    /// inspector doesn't need to know about modal state or
+    /// scene-vs-prefab routing — the prefab editor passes null
+    /// because per-child delete inside a prefab is handled by the
+    /// prefab editor's own UI flow.
+    request_delete: ?*bool,
 ) void {
     if (entity_index) |n| {
         zgui.text("Entity #{d}", .{n});
@@ -82,6 +91,11 @@ pub fn renderEntity(
         }
     } else {
         zgui.textDisabled("(no prefab)", .{});
+    }
+    if (request_delete) |sink| {
+        if (zgui.smallButton("Delete##inspector_delete_entity")) {
+            sink.* = true;
+        }
     }
     zgui.spacing();
 

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -189,14 +189,14 @@ fn renderInspector(s: *PrefabState, atlas_index: ?*const @import("../atlas.zig")
         else
             &[_]scene_io.ComponentExtra{};
 
-        inspector.renderEntity(child, extras, &s.is_dirty, idx, atlas_index, null);
+        inspector.renderEntity(child, extras, &s.is_dirty, idx, atlas_index, null, null);
         return;
     }
 
     // Nothing selected → show the prefab's own components.
     zgui.text("Prefab body", .{});
     zgui.spacing();
-    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null, atlas_index, null);
+    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null, atlas_index, null, null);
 
     if (s.loaded.children.len > 0) {
         zgui.spacing();

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -604,9 +604,13 @@ fn handleDeleteKey(s: *SceneState) void {
     if (!zgui.isWindowHovered(.{ .child_windows = true })) return;
     if (!zgui.isKeyPressed(.delete, false)) return;
     const idx = s.selected_index orelse return;
-    scene_io.removeEntity(&s.loaded, idx) catch return;
-    s.selected_index = null;
-    s.is_dirty = true;
+    // Skip the confirmation modal here intentionally — the
+    // keyboard path is opt-in (the user has to know about it),
+    // matches the editor's pre-confirmation behaviour, and
+    // a per-press confirmation would feel intrusive on the
+    // power-user shortcut. Inspector + right-click trigger the
+    // modal via `requestDeleteEntity`.
+    performDelete(s, idx);
 }
 
 /// Re-exported so existing zspec tests (and any other caller of

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -84,6 +84,13 @@ pub const SceneState = struct {
     /// Filter buffer for the picker's search box. Stays sticky across
     /// reopenings — same convenience the resources panel has.
     prefab_picker_filter: [64:0]u8 = [_:0]u8{0} ** 64,
+    /// Index of an entity the user has requested to delete and which
+    /// requires confirmation before removal (prefab instances + any
+    /// entity carrying non-Position components). The confirmation
+    /// modal reads this; on accept, calls `scene_io.removeEntity`.
+    /// Bare-Position entities are deleted immediately without a modal
+    /// (cheap to add back via the existing right-click menu).
+    pending_delete_idx: ?usize = null,
     /// World-space spacing for the viewport's visual grid. When
     /// `snap_enabled` is on, drag-to-move also rounds to multiples of
     /// this value — one number, both behaviors. Default 16 works for
@@ -204,6 +211,10 @@ pub fn render(s: *SceneState, app: *App) void {
         .child_flags = .{ .border = true },
     })) {
         renderInspector(s, app, atlas_index_ptr);
+        // Modal lives in the same ID stack as the `openPopup` call
+        // that fires from inside the inspector's Delete button, so
+        // imgui can correlate the two.
+        renderDeleteConfirmModal(s);
     }
     zgui.endChild();
 }
@@ -241,11 +252,97 @@ fn renderInspector(s: *SceneState, app: *App, atlas_index: ?*const @import("../a
         &[_]scene_io.ComponentExtra{};
 
     var open_prefab_request: ?[]const u8 = null;
-    inspector.renderEntity(entity, extras, &s.is_dirty, idx, atlas_index, &open_prefab_request);
+    var delete_request: bool = false;
+    inspector.renderEntity(entity, extras, &s.is_dirty, idx, atlas_index, &open_prefab_request, &delete_request);
     if (open_prefab_request) |_| {
         // The button was clicked — resolve via the prefab cache and
         // open the file. Same routing used by the double-click jump.
         openPrefabFromEntity(app, s, idx);
+    }
+    if (delete_request) {
+        requestDeleteEntity(s, idx);
+    }
+}
+
+/// Either delete the entity at `idx` immediately, or queue it for a
+/// confirmation modal (when the entity is non-trivial: prefab
+/// references, or any non-Position component on a vanilla entity).
+/// The modal is rendered by `renderDeleteConfirmModal` later in the
+/// same frame.
+fn requestDeleteEntity(s: *SceneState, idx: usize) void {
+    if (idx >= s.loaded.scene.entities.len) return;
+    if (needsDeleteConfirm(&s.loaded.scene.entities[idx], idx, s)) {
+        s.pending_delete_idx = idx;
+        zgui.openPopup("##scene_delete_confirm", .{});
+    } else {
+        performDelete(s, idx);
+    }
+}
+
+fn needsDeleteConfirm(e: *const scene_io.Entity, idx: usize, s: *const SceneState) bool {
+    if (e.prefab != null) return true;
+    // Any typed component beyond Position counts as "non-trivial" —
+    // deleting silently would be the same kind of loss as the prefab
+    // case.
+    if (e.sprite != null) return true;
+    if (e.rectangle != null) return true;
+    if (e.circle != null) return true;
+    if (e.polygon != null) return true;
+    // Unmodeled component_extras attached to this entity? Then user
+    // probably has hand-authored data we shouldn't silently drop.
+    if (idx < s.loaded.extras.entity_components.len and
+        s.loaded.extras.entity_components[idx].len > 0)
+    {
+        return true;
+    }
+    return false;
+}
+
+fn performDelete(s: *SceneState, idx: usize) void {
+    scene_io.removeEntity(&s.loaded, idx) catch return;
+    // Selection clears so the inspector falls back to its
+    // "click an entity in the viewport to select" placeholder.
+    s.selected_index = null;
+    s.is_dirty = true;
+}
+
+/// Confirmation modal for a queued delete. No-op when nothing is
+/// pending — the popup machinery in imgui only opens when
+/// `openPopup` fires (we did that in `requestDeleteEntity`), so this
+/// just renders the body + buttons when active.
+fn renderDeleteConfirmModal(s: *SceneState) void {
+    if (!zgui.beginPopupModal("##scene_delete_confirm", .{ .flags = .{ .always_auto_resize = true } })) return;
+    defer zgui.endPopup();
+
+    const idx = s.pending_delete_idx orelse {
+        zgui.closeCurrentPopup();
+        return;
+    };
+    if (idx >= s.loaded.scene.entities.len) {
+        // Underlying list shifted under us — abort cleanly.
+        s.pending_delete_idx = null;
+        zgui.closeCurrentPopup();
+        return;
+    }
+    const entity = &s.loaded.scene.entities[idx];
+
+    zgui.text("Delete this entity?", .{});
+    if (entity.prefab) |p| {
+        zgui.textDisabled("prefab: {s} (entity #{d})", .{ p, idx });
+    } else {
+        zgui.textDisabled("entity #{d}", .{idx});
+    }
+    zgui.spacing();
+    zgui.separator();
+    if (zgui.button("Delete##scene_delete_confirm_ok", .{ .w = 96 })) {
+        performDelete(s, idx);
+        s.pending_delete_idx = null;
+        zgui.closeCurrentPopup();
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("Cancel##scene_delete_confirm_cancel", .{ .w = 96 })) {
+        s.pending_delete_idx = null;
+        zgui.closeCurrentPopup();
     }
 }
 
@@ -257,10 +354,13 @@ fn renderViewport(
     gizmo_index: ?*const @import("../gizmos.zig").Index,
     show_gizmos: bool,
 ) void {
-    // Capture right-click world-pos + double-click entity index
-    // out-of-band; the viewport writes through these sinks during its
-    // render so we can react after it returns.
+    // Capture right-click sinks + double-click entity index out-of-
+    // band; the viewport writes through these during its render so
+    // we can react after it returns. Right-click on empty canvas
+    // fills `right_click_world`; right-click on an entity fills
+    // `right_click_entity` — never both for the same click.
     var right_click: ?[2]f32 = null;
+    var right_click_entity: ?usize = null;
     var double_click: ?usize = null;
     viewport.render(
         .{
@@ -271,6 +371,7 @@ fn renderViewport(
             .drag_armed = &s.drag_armed,
             .drag_start_world = &s.drag_start_world,
             .right_click_world = &right_click,
+            .right_click_entity = &right_click_entity,
             .double_click_entity = &double_click,
             .grid_step = s.grid_step,
             .snap_enabled = s.snap_enabled,
@@ -286,8 +387,33 @@ fn renderViewport(
         s.context_menu_world_pos = world;
         zgui.openPopup("##scene_context", .{});
     }
+    if (right_click_entity) |idx| {
+        // Select the clicked entity so the per-entity menu's Delete
+        // acts on the right target, then open the context menu.
+        s.selected_index = idx;
+        zgui.openPopup("##scene_entity_context", .{});
+    }
     if (double_click) |idx| {
         openPrefabFromEntity(app, s, idx);
+    }
+}
+
+/// Per-entity right-click context menu — currently just Delete, room
+/// to grow when #80 lands Unpack. Rendered in the same scope as the
+/// empty-canvas context menu so both popups share the viewport
+/// child's ID stack.
+fn renderEntityContextMenu(s: *SceneState) void {
+    if (!zgui.beginPopup("##scene_entity_context", .{})) return;
+    defer zgui.endPopup();
+    const idx = s.selected_index orelse {
+        zgui.closeCurrentPopup();
+        return;
+    };
+    if (zgui.menuItem("Delete", .{})) {
+        zgui.closeCurrentPopup();
+        // Delegate to the same path the inspector Delete button uses,
+        // which handles the confirm-or-not-confirm branch.
+        requestDeleteEntity(s, idx);
     }
 }
 
@@ -335,6 +461,7 @@ fn renderContextMenu(s: *SceneState, app: *App) void {
         if (!s.show_prefab_picker) s.context_menu_world_pos = null;
     }
     renderPrefabPicker(s, app);
+    renderEntityContextMenu(s);
 }
 
 fn renderPrefabPicker(s: *SceneState, app: *App) void {

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -86,11 +86,18 @@ pub const SceneState = struct {
     prefab_picker_filter: [64:0]u8 = [_:0]u8{0} ** 64,
     /// Index of an entity the user has requested to delete and which
     /// requires confirmation before removal (prefab instances + any
-    /// entity carrying non-Position components). The confirmation
-    /// modal reads this; on accept, calls `scene_io.removeEntity`.
-    /// Bare-Position entities are deleted immediately without a modal
-    /// (cheap to add back via the existing right-click menu).
+    /// entity carrying non-Position components or a comment). The
+    /// confirmation modal reads this; on accept, calls
+    /// `scene_io.removeEntity`. Bare-Position entities are deleted
+    /// immediately without a modal (cheap to add back via the
+    /// existing right-click menu).
     pending_delete_idx: ?usize = null,
+    /// One-shot flag flipped by `requestDeleteEntity` so the parent
+    /// scope (`render`) can call `openPopup` from a common ID stack —
+    /// the delete may be triggered from inside either the viewport
+    /// child or the inspector child, but the modal lives at the
+    /// scene-tab level so both paths surface the same popup.
+    delete_modal_just_opened: bool = false,
     /// World-space spacing for the viewport's visual grid. When
     /// `snap_enabled` is on, drag-to-move also rounds to multiples of
     /// this value — one number, both behaviors. Default 16 works for
@@ -211,12 +218,22 @@ pub fn render(s: *SceneState, app: *App) void {
         .child_flags = .{ .border = true },
     })) {
         renderInspector(s, app, atlas_index_ptr);
-        // Modal lives in the same ID stack as the `openPopup` call
-        // that fires from inside the inspector's Delete button, so
-        // imgui can correlate the two.
-        renderDeleteConfirmModal(s);
     }
     zgui.endChild();
+
+    // Delete-confirm popup lives at the scene-tab parent scope (not
+    // inside either child) so both trigger paths share the same ID
+    // stack: the inspector's Delete button (called from inside
+    // `##inspector_col`) and the viewport's right-click → Delete
+    // (called from inside `##viewport_col`). Both set
+    // `delete_modal_just_opened` instead of calling `openPopup`
+    // directly; the parent scope fires the `openPopup` here and
+    // renders the modal in the same ID stack.
+    if (s.delete_modal_just_opened) {
+        zgui.openPopup("##scene_delete_confirm", .{});
+        s.delete_modal_just_opened = false;
+    }
+    renderDeleteConfirmModal(s);
 }
 
 /// Write the current scene back to its source path. Clears the dirty
@@ -266,14 +283,17 @@ fn renderInspector(s: *SceneState, app: *App, atlas_index: ?*const @import("../a
 
 /// Either delete the entity at `idx` immediately, or queue it for a
 /// confirmation modal (when the entity is non-trivial: prefab
-/// references, or any non-Position component on a vanilla entity).
-/// The modal is rendered by `renderDeleteConfirmModal` later in the
-/// same frame.
+/// references, any non-Position component, a hand-authored comment,
+/// or unmodeled component_extras). The modal is rendered by
+/// `renderDeleteConfirmModal` at the scene-tab top scope so both the
+/// inspector + viewport context-menu triggers share one popup; the
+/// actual `openPopup` call happens there too via the
+/// `delete_modal_just_opened` one-shot.
 fn requestDeleteEntity(s: *SceneState, idx: usize) void {
     if (idx >= s.loaded.scene.entities.len) return;
     if (needsDeleteConfirm(&s.loaded.scene.entities[idx], idx, s)) {
         s.pending_delete_idx = idx;
-        zgui.openPopup("##scene_delete_confirm", .{});
+        s.delete_modal_just_opened = true;
     } else {
         performDelete(s, idx);
     }
@@ -288,6 +308,9 @@ fn needsDeleteConfirm(e: *const scene_io.Entity, idx: usize, s: *const SceneStat
     if (e.rectangle != null) return true;
     if (e.circle != null) return true;
     if (e.polygon != null) return true;
+    // Non-empty `comment` is hand-authored data; protect from silent
+    // loss the same as the typed components above.
+    if (e.comment[0] != 0) return true;
     // Unmodeled component_extras attached to this entity? Then user
     // probably has hand-authored data we shouldn't silently drop.
     if (idx < s.loaded.extras.entity_components.len and

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -50,6 +50,15 @@ pub const State = struct {
     /// (the prefab editor itself sets this to null — there's no
     /// further level to descend into).
     double_click_entity: ?*?usize = null,
+    /// Optional sink for "right-click on a scene entity". The
+    /// viewport writes the entity index when the right-click lands
+    /// on an entity (AABB or radial hit), so the caller can open a
+    /// per-entity context menu (e.g. Delete) at the click site.
+    /// `right_click_world` continues to fire for *empty-canvas* right-
+    /// clicks; the two sinks are mutually exclusive on any given
+    /// click — entity-hit goes to `right_click_entity`, miss goes to
+    /// `right_click_world`.
+    right_click_entity: ?*?usize = null,
     /// World-space spacing for the visual grid AND, when snapping is on,
     /// the snap step. One number drives both so the grid the user sees
     /// is the grid their drags land on. Default 16 matches what most 2D
@@ -205,17 +214,18 @@ pub fn render(
         }
     }
 
-    // Right-click on empty canvas → caller-driven context menu. We
-    // only fire when the click misses every entity marker; clicks
-    // *on* an entity stay free for a future per-entity menu.
-    if (state.right_click_world) |sink| {
-        if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.right)) {
-            const mouse = zgui.getMousePos();
-            const hit = hitTestEntityAabb(entities, mouse, canvas_min, state.pan.*, state.zoom.*, atlas_index, prefab_index) orelse
-                hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
-            if (hit == null) {
-                sink.* = worldFromScreen(mouse, canvas_min, state.pan.*, state.zoom.*);
-            }
+    // Right-click splits two ways: empty canvas → world-pos sink for
+    // the caller's "add entity here" menu; on-entity → entity-index
+    // sink for the caller's per-entity menu (Delete, etc.). Mutually
+    // exclusive — a single click fills only one sink.
+    if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.right)) {
+        const mouse = zgui.getMousePos();
+        const hit = hitTestEntityAabb(entities, mouse, canvas_min, state.pan.*, state.zoom.*, atlas_index, prefab_index) orelse
+            hitTestEntity(entities, mouse, canvas_min, state.pan.*, state.zoom.*);
+        if (hit) |idx| {
+            if (state.right_click_entity) |sink| sink.* = idx;
+        } else if (state.right_click_world) |sink| {
+            sink.* = worldFromScreen(mouse, canvas_min, state.pan.*, state.zoom.*);
         }
     }
 


### PR DESCRIPTION
## Summary

The Delete / Backspace key has been the scene editor's only delete path, with no discoverable UI and no confirmation. Adds two surfaces + a confirmation modal, per [#82](https://github.com/labelle-toolkit/labelle-gui/issues/82).

### Changes

- **Inspector Delete button.** `renderEntity` grows an optional `request_delete: ?*bool` sink — same opt-in pattern `request_open_prefab` already uses. Scene editor passes a sink and reacts; prefab editor passes `null` (per-child delete inside a prefab has its own UI flow, not in scope here).
- **Per-entity right-click context menu.** `viewport.State` splits the right-click sink into `right_click_world` (existing empty-canvas path) and a new `right_click_entity` (on-entity hits) — mutually exclusive on any given click. Scene editor opens `##scene_entity_context` popup with a Delete item; the right-click also selects the clicked entity so subsequent actions act on the correct target. Slot to grow when #80's Unpack action lands.
- **Confirmation modal.** Fires when the entity carries any non-trivial content: a `prefab:` reference, any typed component (Sprite/Rectangle/Circle/Polygon), or unmodeled component_extras. Bare-Position entities delete immediately (cheap to recover via the existing "Add entity here" right-click).
- **Selection clears after delete** so the inspector falls back to its existing "click an entity in the viewport to select" placeholder.

Existing Delete / Backspace key handler is unchanged — no regression on the keyboard flow.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — all pass
- [x] `zig build gui-test` — 8/8 pass
- [x] Visual: against `flying-platform-labelle/scenes/main.jsonc`, verified that:
  - Inspector Delete on a canteen instance fires the confirmation modal
  - Right-click on a canteen opens the entity context menu; Delete fires the same modal
  - Right-click on empty canvas still shows the existing Add menu (unchanged)
  - Delete / Backspace key on a selected entity still works
  - Cancel in the modal leaves the entity untouched
- [ ] Reviewer: spot-check the modal under a deep zoom / panned-out scene; verify the popup roots correctly relative to the inspector child.

## Not in scope

Per the issue's "Not in scope" section: no toolbar Delete button (too easy to fat-finger), no multi-select delete, no undo.