### PR TITLE
feat(inspector): read-only prefab contents tree (#86)

### DIFF
--- a/src/modules/inspector.zig
+++ b/src/modules/inspector.zig
@@ -25,6 +25,8 @@ const zgui = @import("zgui");
 
 const scene_io = @import("../scene_io.zig");
 const atlas = @import("../atlas.zig");
+const prefab_index = @import("../prefab_index.zig");
+const prefab_contents = @import("inspector/prefab_contents.zig");
 
 pub const InspectorSection = @import("inspector/section.zig").InspectorSection;
 
@@ -73,6 +75,13 @@ pub fn renderEntity(
     /// because per-child delete inside a prefab is handled by the
     /// prefab editor's own UI flow.
     request_delete: ?*bool,
+    /// Optional prefab cache. When the entity references a prefab and
+    /// this is non-null, the inspector renders a read-only
+    /// "Prefab contents" section listing every component on the
+    /// referenced prefab tree (issue #86). The scene editor wires its
+    /// `app.prefab_index`; the prefab editor passes null — there's no
+    /// need to display "contents of yourself" inside the prefab tab.
+    prefab_idx: ?*const prefab_index.Index,
 ) void {
     if (entity_index) |n| {
         zgui.text("Entity #{d}", .{n});
@@ -105,6 +114,10 @@ pub fn renderEntity(
                 s.render(entity, is_dirty, atlas_index);
             }
         }
+    }
+
+    if (entity.prefab) |p| {
+        if (prefab_idx) |idx| prefab_contents.render(p, idx);
     }
 
     if (component_extras.len > 0) {

--- a/src/modules/inspector/prefab_contents.zig
+++ b/src/modules/inspector/prefab_contents.zig
@@ -1,0 +1,142 @@
+//! Read-only "Prefab contents" section for the scene-editor inspector.
+//! When a scene entity references a prefab (e.g. `{ "prefab": "canteen" }`),
+//! the scene-side inspector only shows that entity's overridable surface
+//! (Position, Sprite, Comment). This section lets the user see *what's
+//! inside* the referenced prefab — every typed/extras component on the
+//! root, plus each child's components — without leaving the scene tab.
+//!
+//! Children that themselves reference prefabs recurse, depth-capped so
+//! accidental cycles can't hang the UI. Consecutive children sharing a
+//! prefab name collapse into a `name (prefab × N)` leaf to keep the
+//! panel readable on rooms with many `movement_node` / `seat` instances.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const scene_io = @import("../../scene_io.zig");
+const prefab_index = @import("../../prefab_index.zig");
+
+const max_depth: u8 = 5;
+
+/// Render the collapsing header + tree. Caller guarantees `prefab_name`
+/// is non-null on the entity; this function takes the name directly so
+/// the gating in `inspector.renderEntity` stays a single boolean check.
+pub fn render(prefab_name: []const u8, idx: *const prefab_index.Index) void {
+    if (!zgui.collapsingHeader("Prefab contents##prefab_contents_section", .{})) return;
+    renderNode(prefab_name, idx, 0, 1);
+}
+
+fn renderNode(name: []const u8, idx: *const prefab_index.Index, depth: u8, repeat_count: u32) void {
+    if (depth >= max_depth) {
+        zgui.bullet();
+        zgui.textDisabled("… (max depth reached at {s})", .{name});
+        return;
+    }
+
+    // Grouped repeats render as a non-expandable leaf — we don't want
+    // identical chairs to dominate the panel with N copies of the same
+    // body.
+    if (repeat_count > 1) {
+        zgui.bullet();
+        zgui.text("{s} (prefab × {d})", .{ name, repeat_count });
+        return;
+    }
+
+    const entry = idx.find(name) orelse {
+        zgui.bullet();
+        zgui.textDisabled("{s} (prefab not found in cache)", .{name});
+        return;
+    };
+
+    var label_buf: [256:0]u8 = undefined;
+    const label = std.fmt.bufPrintZ(&label_buf, "{s}", .{name}) catch return;
+    if (!zgui.treeNode(label)) return;
+    defer zgui.treePop();
+
+    renderComponents(&entry.entity, entry.component_extras);
+    renderChildren(entry.children, entry.children_extras, idx, depth + 1);
+}
+
+fn renderComponents(entity: *const scene_io.Entity, extras: []const scene_io.ComponentExtra) void {
+    if (entity.position) |p| {
+        zgui.bullet();
+        zgui.text("Position {{ x: {d:.0}, y: {d:.0} }}", .{ p.x, p.y });
+    }
+    if (entity.sprite) |s| {
+        const sprite_name = std.mem.sliceTo(&s.sprite_name, 0);
+        zgui.bullet();
+        zgui.text("Sprite \"{s}\"", .{sprite_name});
+    }
+    if (entity.rectangle) |r| {
+        zgui.bullet();
+        zgui.text("Rectangle {d:.0}×{d:.0}", .{ r.width, r.height });
+    }
+    if (entity.circle) |c| {
+        zgui.bullet();
+        zgui.text("Circle r={d:.0}", .{c.radius});
+    }
+    if (entity.polygon) |p| {
+        zgui.bullet();
+        zgui.text("Polygon {d} pts", .{p.point_count});
+    }
+    for (extras) |e| {
+        zgui.bullet();
+        zgui.text("{s}", .{e.name});
+    }
+}
+
+fn renderChildren(
+    children: []const scene_io.Entity,
+    children_extras: []const []const scene_io.ComponentExtra,
+    idx: *const prefab_index.Index,
+    depth: u8,
+) void {
+    if (children.len == 0) return;
+
+    var label_buf: [64:0]u8 = undefined;
+    const label = std.fmt.bufPrintZ(&label_buf, "children ({d})", .{children.len}) catch return;
+    if (!zgui.treeNode(label)) return;
+    defer zgui.treePop();
+
+    var i: usize = 0;
+    while (i < children.len) {
+        const child = &children[i];
+
+        if (child.prefab) |child_prefab| {
+            const run_end = consecutivePrefabRunEnd(children, i, child_prefab);
+            const count: u32 = @intCast(run_end - i);
+            renderNode(child_prefab, idx, depth, count);
+            i = run_end;
+        } else {
+            // No prefab ref — render the child's own components inline.
+            const child_extras = if (i < children_extras.len)
+                children_extras[i]
+            else
+                &[_]scene_io.ComponentExtra{};
+            var inline_label_buf: [64:0]u8 = undefined;
+            const inline_label = std.fmt.bufPrintZ(&inline_label_buf, "child #{d}", .{i}) catch {
+                i += 1;
+                continue;
+            };
+            if (zgui.treeNode(inline_label)) {
+                renderComponents(child, child_extras);
+                zgui.treePop();
+            }
+            i += 1;
+        }
+    }
+}
+
+/// Find the end index (exclusive) of the run of consecutive children
+/// starting at `start` whose `prefab` field equals `name`. Children
+/// without a prefab reference break the run. Pub so the central test
+/// file can exercise it without going through imgui.
+pub fn consecutivePrefabRunEnd(children: []const scene_io.Entity, start: usize, name: []const u8) usize {
+    var end = start + 1;
+    while (end < children.len) : (end += 1) {
+        const next_name = children[end].prefab orelse return end;
+        if (!std.mem.eql(u8, next_name, name)) return end;
+    }
+    return end;
+}
+

--- a/src/modules/inspector/prefab_contents.zig
+++ b/src/modules/inspector/prefab_contents.zig
@@ -23,10 +23,16 @@ const max_depth: u8 = 5;
 /// the gating in `inspector.renderEntity` stays a single boolean check.
 pub fn render(prefab_name: []const u8, idx: *const prefab_index.Index) void {
     if (!zgui.collapsingHeader("Prefab contents##prefab_contents_section", .{})) return;
-    renderNode(prefab_name, idx, 0, 1);
+    renderNode(prefab_name, idx, 0, 1, 0);
 }
 
-fn renderNode(name: []const u8, idx: *const prefab_index.Index, depth: u8, repeat_count: u32) void {
+/// `node_id` is appended as a hidden ImGui ID discriminator
+/// (`##{node_id}`) so siblings with the same prefab name get distinct
+/// tree-node identities — without it, non-consecutive children like
+/// `[seat, table, seat]` collide and expand/collapse in sync. The
+/// top-level call passes 0; recursive calls from `renderChildren` pass
+/// the child's loop index.
+fn renderNode(name: []const u8, idx: *const prefab_index.Index, depth: u8, repeat_count: u32, node_id: usize) void {
     if (depth >= max_depth) {
         zgui.bullet();
         zgui.textDisabled("… (max depth reached at {s})", .{name});
@@ -49,7 +55,7 @@ fn renderNode(name: []const u8, idx: *const prefab_index.Index, depth: u8, repea
     };
 
     var label_buf: [256:0]u8 = undefined;
-    const label = std.fmt.bufPrintZ(&label_buf, "{s}", .{name}) catch return;
+    const label = std.fmt.bufPrintZ(&label_buf, "{s}##{d}", .{ name, node_id }) catch return;
     if (!zgui.treeNode(label)) return;
     defer zgui.treePop();
 
@@ -105,7 +111,7 @@ fn renderChildren(
         if (child.prefab) |child_prefab| {
             const run_end = consecutivePrefabRunEnd(children, i, child_prefab);
             const count: u32 = @intCast(run_end - i);
-            renderNode(child_prefab, idx, depth, count);
+            renderNode(child_prefab, idx, depth, count, i);
             i = run_end;
         } else {
             // No prefab ref — render the child's own components inline.

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -189,14 +189,14 @@ fn renderInspector(s: *PrefabState, atlas_index: ?*const @import("../atlas.zig")
         else
             &[_]scene_io.ComponentExtra{};
 
-        inspector.renderEntity(child, extras, &s.is_dirty, idx, atlas_index, null, null);
+        inspector.renderEntity(child, extras, &s.is_dirty, idx, atlas_index, null, null, null);
         return;
     }
 
     // Nothing selected → show the prefab's own components.
     zgui.text("Prefab body", .{});
     zgui.spacing();
-    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null, atlas_index, null, null);
+    inspector.renderEntity(&s.loaded.entity, s.loaded.component_extras, &s.is_dirty, null, atlas_index, null, null, null);
 
     if (s.loaded.children.len > 0) {
         zgui.spacing();

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -270,7 +270,9 @@ fn renderInspector(s: *SceneState, app: *App, atlas_index: ?*const @import("../a
 
     var open_prefab_request: ?[]const u8 = null;
     var delete_request: bool = false;
-    inspector.renderEntity(entity, extras, &s.is_dirty, idx, atlas_index, &open_prefab_request, &delete_request);
+    const prefab_idx_ptr: ?*const @import("../prefab_index.zig").Index =
+        if (app.prefab_index) |*pi| pi else null;
+    inspector.renderEntity(entity, extras, &s.is_dirty, idx, atlas_index, &open_prefab_request, &delete_request, prefab_idx_ptr);
     if (open_prefab_request) |_| {
         // The button was clicked — resolve via the prefab cache and
         // open the file. Same routing used by the double-click jump.

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -17,6 +17,7 @@ const preview = @import("preview.zig");
 const flow_projector = @import("flows/projector.zig");
 const flow_types = @import("flows/types.zig");
 const prefs = @import("prefs.zig");
+const prefab_contents = @import("modules/inspector/prefab_contents.zig");
 const io_global = @import("io_global.zig");
 
 /// Wall-clock seconds since the Unix epoch; replacement for the
@@ -2898,5 +2899,34 @@ pub const PreferencesTests = struct {
 
         const loaded = prefs.loadFromPath(std.testing.allocator, path);
         try expect.equal(loaded.font_scale, prefs.default_font_scale);
+    }
+};
+
+pub const PrefabContentsTests = struct {
+    test "consecutivePrefabRunEnd groups consecutive same-prefab children" {
+        const children = [_]scene_io.Entity{
+            .{ .prefab = "seat" },
+            .{ .prefab = "seat" },
+            .{ .prefab = "seat" },
+            .{ .prefab = "table" },
+        };
+        try expect.equal(prefab_contents.consecutivePrefabRunEnd(&children, 0, "seat"), 3);
+        try expect.equal(prefab_contents.consecutivePrefabRunEnd(&children, 3, "table"), 4);
+    }
+
+    test "consecutivePrefabRunEnd stops at a child without a prefab" {
+        const children = [_]scene_io.Entity{
+            .{ .prefab = "seat" },
+            .{ .prefab = null },
+            .{ .prefab = "seat" },
+        };
+        try expect.equal(prefab_contents.consecutivePrefabRunEnd(&children, 0, "seat"), 1);
+    }
+
+    test "consecutivePrefabRunEnd returns end of slice for a single trailing run" {
+        const children = [_]scene_io.Entity{
+            .{ .prefab = "only" },
+        };
+        try expect.equal(prefab_contents.consecutivePrefabRunEnd(&children, 0, "only"), 1);
     }
 };


### PR DESCRIPTION
## Summary

Adds a read-only **Prefab contents** section to the scene-editor inspector. When the selected entity references a prefab, the user sees every component on the prefab tree — root + children + nested prefab refs — without leaving the scene tab. Resolves [#86](https://github.com/labelle-toolkit/labelle-gui/issues/86).

### Changes

- **`src/modules/inspector/prefab_contents.zig`** — new file. Resolves the prefab body via the existing `prefab_index` cache and walks it. Recursion depth-capped at 5 to defend against accidental cycles. Consecutive children sharing a prefab name collapse to `name (prefab × N)` so a room with 8 `movement_node`s stays readable; children without a prefab ref render inline as `child #N` with their own components.
- **`src/modules/inspector.zig`** — `renderEntity` gains an optional `prefab_idx: ?*const prefab_index.Index` parameter, gated the same way `request_open_prefab` is. New section paints after the existing typed-component blocks and before `Other components (N)`, so the editable surface stays on top.
- **Call-site updates.** Scene editor (`modules/scene.zig`) passes `app.prefab_index`; prefab editor (`modules/prefab.zig`, both call sites) passes `null` — no need to display "contents of yourself" inside the prefab tab.
- **Tests.** `PrefabContentsTests` covers the `consecutivePrefabRunEnd` grouping helper (same-name runs, breaks on non-prefab children, single-element trailing run).

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — 178/178 (3 new in `PrefabContentsTests`)
- [x] `zig build gui-test` — 8/8
- [x] Visual: against `flying-platform-labelle/scenes/main.jsonc`, verified the section appears under a `canteen` selection and expands to show `Room`, `Sprite "canteen_bg"`, `children (7)` with named child rows for `fridge`/`refectory_table` and `child #N` rows for inline children carrying `Storage`/`ClosestMovementNode`/`PendingRepath`.
- [ ] Reviewer: spot-check on a prefab with deeply nested children (≥3 levels) and on one where a `prefab:` ref points to a name that's been renamed / deleted (should render the `(prefab not found in cache)` fallback row, not crash).

## Not in scope

- **Grouping inline children by component shape.** Today only consecutive children with identical `prefab:` names collapse to `× N`. Many real scenes carry repeated *inline* children with the same component shape (e.g. four `Storage + ClosestMovementNode + PendingRepath` movement-node entries that aren't authored as a `movement_node` prefab). Bundling those would be a separate readability pass — file a follow-up if it's worth doing.
- **Edit affordances.** Strictly read-only; the existing "Edit prefab" jump button covers the edit path.
- **Hierarchy panel-style navigation.** That's #80's surface — interactive, with selection/reorder/right-click. This section is a summary, intentionally smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)