### PR TITLE
feat(preview): Phase 3 editor — Entity Inspector + flow node pulse (#84)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -25,6 +25,8 @@ const scene_mod = @import("modules/scene.zig");
 const prefab_mod = @import("modules/prefab.zig");
 const flow_mod = @import("modules/flow.zig");
 const gizmo_mod = @import("modules/gizmo.zig");
+const entity_inspector_mod = @import("modules/entity_inspector.zig");
+const flow_runtime_mod = @import("modules/flow_runtime.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
 const atlas = @import("atlas.zig");
 const gizmos = @import("gizmos.zig");
@@ -138,6 +140,19 @@ pub const App = struct {
     /// pointer; clicking Run preview also force-opens it.
     show_preview: bool = false,
 
+    /// Phase 3 (#84): Entity Inspector panel toggle.
+    show_entity_inspector: bool = false,
+    /// Entity Inspector state — fed by `PreviewSession`'s
+    /// `on_component_changed` callback (wired in `init`).
+    entity_inspector: entity_inspector_mod.EntityInspector = undefined,
+
+    /// Phase 3 (#84): Flow Runtime panel toggle.
+    show_flow_runtime: bool = false,
+    /// Flow Runtime state — tracks subscribed-to flows and the
+    /// rolling `node_entered` log. Fed by `PreviewSession`'s
+    /// `on_node_entered` callback (wired in `init`).
+    flow_runtime: flow_runtime_mod.FlowRuntime = .{},
+
     /// Open editor tabs — scenes and prefabs share this list as
     /// `OpenTab` variants. Populated when the user clicks an
     /// editable file in the project tree; closed via the × on a
@@ -214,7 +229,7 @@ pub const App = struct {
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [5]module.Module = undefined,
+    modules: [7]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -234,11 +249,55 @@ pub const App = struct {
             .startup_prefs = user_prefs,
         };
 
+        // The inspector keeps a `*PreviewSession` so it can call
+        // `watchEntity`/`unwatchEntity` from its own callbacks without
+        // routing through `App`. Initialize after `preview` so the
+        // pointer is stable for the lifetime of the App.
+        app.entity_inspector = entity_inspector_mod.EntityInspector.init(allocator, &app.preview);
+
+        // Wire the preview session's binary-frame listeners. Both are
+        // single-consumer in Phase 3; future panels that need the same
+        // stream will gain a multi-listener path.
+        app.preview.on_component_changed = .{
+            .ctx = app,
+            .func = struct {
+                fn cb(ctx: *anyopaque, entity_id: u64, name: []const u8, bytes: []const u8) void {
+                    const a: *App = @ptrCast(@alignCast(ctx));
+                    a.entity_inspector.onComponentChanged(entity_id, name, bytes);
+                }
+            }.cb,
+        };
+        app.preview.on_node_entered = .{
+            .ctx = app,
+            .func = struct {
+                fn cb(ctx: *anyopaque, flow_name: []const u8, node_id: u32) void {
+                    const a: *App = @ptrCast(@alignCast(ctx));
+                    a.flow_runtime.onNodeEntered(flow_name, node_id);
+                    // Pulse the matching flow editor tab if it's open
+                    // — display name matches the `.flow.zon` stem the
+                    // engine emits. Tabs that aren't flows or whose
+                    // names don't match are skipped silently.
+                    for (a.open_tabs.items) |*tab| {
+                        switch (tab.*) {
+                            .flow => |*f| {
+                                if (std.mem.eql(u8, f.display_name, flow_name)) {
+                                    flow_mod.pulseNode(f, node_id);
+                                }
+                            },
+                            else => {},
+                        }
+                    }
+                }
+            }.cb,
+        };
+
         app.modules[0] = project_tree_mod.makeModule(app);
         app.modules[1] = compiler_output.makeModule(app);
         app.modules[2] = project_settings_mod.makeModule(app);
         app.modules[3] = resources_mod.makeModule(app);
         app.modules[4] = preview_mod.makeModule(app);
+        app.modules[5] = entity_inspector_mod.makeModule(app);
+        app.modules[6] = flow_runtime_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
 
         return app;
@@ -251,6 +310,10 @@ pub const App = struct {
         if (self.gizmo_index) |*idx| idx.deinit();
         if (self.prefab_index) |*idx| idx.deinit();
         if (self.pending_open_prefab_path) |p| self.allocator.free(p);
+        // Phase 3 state. Entity Inspector frees its component table;
+        // Flow Runtime frees its subscribed-flow name copies.
+        self.entity_inspector.deinit();
+        self.flow_runtime.deinit(self.allocator);
         self.project_manager.deinit();
         self.tree_view.deinit();
         self.compiler.deinit();

--- a/src/modules/entity_inspector.zig
+++ b/src/modules/entity_inspector.zig
@@ -1,0 +1,203 @@
+//! Entity Inspector panel (issue #84, Phase 3 editor side).
+//!
+//! Reflects the live state of one watched entity over the preview
+//! channel. Workflow:
+//!
+//!   1. Editor calls `onEntitySelected(entity_id)` — the panel sends
+//!      `{"kind":"watch_entity","id":<id>}` to the engine and clears
+//!      its component table.
+//!   2. Engine emits one `component_changed` per currently-tracked
+//!      component on that entity (the one-shot snapshot fan-out from
+//!      `Preview.emitEntitySnapshot`).
+//!   3. As mutations land, the engine streams more `component_changed`
+//!      frames. The panel's `onComponentChanged` callback (wired from
+//!      `PreviewSession.on_component_changed`) writes each one into the
+//!      table, replacing any previous value for that name.
+//!   4. `onEntityDeselected()` sends `unwatch_entity` and drops the
+//!      table.
+//!
+//! Rendering is intentionally minimal for the MVP: one ImGui line per
+//! component showing the raw bytes as hex. A typed renderer per
+//! component (matching `modules/inspector.zig`'s typed sections) is the
+//! Phase 4 follow-up — the wire shape is already enough to drive it.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const preview = @import("../preview.zig");
+
+/// Entries are heap-allocated `[]u8` so the panel survives the
+/// per-frame parse arena teardown on the `PreviewSession` side. Keys
+/// are also owned (dup'd from the wire-borrowed `comp_name`).
+pub const EntityInspector = struct {
+    allocator: std.mem.Allocator,
+    /// Currently-watched entity id. `null` means no selection. Setting
+    /// this to a new id from outside still requires going through
+    /// `onEntitySelected` so the engine gets the matching protocol
+    /// frame.
+    watched_entity: ?u64 = null,
+    /// Component name → last-known raw bytes. Both key and value are
+    /// owned by `allocator`; cleared on selection change / deinit.
+    components: std.StringHashMap([]u8),
+    /// Back-pointer to the preview session. Stored so the inspector
+    /// can talk back to the engine (`watch_entity`/`unwatch_entity`)
+    /// without threading the App through every call site.
+    session: *preview.PreviewSession,
+
+    pub fn init(allocator: std.mem.Allocator, session: *preview.PreviewSession) EntityInspector {
+        return .{
+            .allocator = allocator,
+            .components = std.StringHashMap([]u8).init(allocator),
+            .session = session,
+        };
+    }
+
+    pub fn deinit(self: *EntityInspector) void {
+        self.clearComponents();
+        self.components.deinit();
+    }
+
+    /// Mark `entity_id` as the one we want to track. Sends the
+    /// `watch_entity` JSON frame on the wire so the engine starts
+    /// emitting filtered `component_changed`. Previous selection is
+    /// `unwatch_entity`'d so the engine isn't left tracking a stale
+    /// id.
+    pub fn onEntitySelected(self: *EntityInspector, entity_id: u64) !void {
+        if (self.watched_entity) |prev| {
+            // Best-effort — if the wire is gone, dropping the unwatch
+            // is harmless (the engine state goes away with the
+            // session).
+            self.session.unwatchEntity(prev) catch {};
+        }
+        self.clearComponents();
+        self.watched_entity = entity_id;
+        try self.session.watchEntity(entity_id);
+    }
+
+    /// Clear selection and tell the engine to stop emitting filtered
+    /// frames for the previously-watched entity.
+    pub fn onEntityDeselected(self: *EntityInspector) void {
+        if (self.watched_entity) |id| {
+            self.session.unwatchEntity(id) catch {};
+        }
+        self.watched_entity = null;
+        self.clearComponents();
+    }
+
+    /// Wire-arrival handler. Drops frames for entities other than the
+    /// one we asked to watch — the engine's filter already does this
+    /// when `watched_entities` is non-empty, but the editor guards as
+    /// well so a stale frame (sent before the engine processed an
+    /// `unwatch_entity`) can't pollute the panel.
+    pub fn onComponentChanged(self: *EntityInspector, entity_id: u64, name: []const u8, bytes: []const u8) void {
+        const watched = self.watched_entity orelse return;
+        if (watched != entity_id) return;
+
+        const owned_bytes = self.allocator.dupe(u8, bytes) catch return;
+        errdefer self.allocator.free(owned_bytes);
+
+        const gop = self.components.getOrPut(name) catch {
+            self.allocator.free(owned_bytes);
+            return;
+        };
+        if (gop.found_existing) {
+            // Replace the old bytes in place; key stays the same.
+            self.allocator.free(gop.value_ptr.*);
+            gop.value_ptr.* = owned_bytes;
+        } else {
+            // First time we see this component — dup the name so the
+            // hashmap doesn't dangle when the engine's wire buffer
+            // gets reused.
+            const owned_name = self.allocator.dupe(u8, name) catch {
+                self.allocator.free(owned_bytes);
+                _ = self.components.remove(name);
+                return;
+            };
+            gop.key_ptr.* = owned_name;
+            gop.value_ptr.* = owned_bytes;
+        }
+    }
+
+    fn clearComponents(self: *EntityInspector) void {
+        var it = self.components.iterator();
+        while (it.next()) |e| {
+            self.allocator.free(e.key_ptr.*);
+            self.allocator.free(e.value_ptr.*);
+        }
+        self.components.clearRetainingCapacity();
+    }
+};
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "entity_inspector",
+        .display_name = "Entity Inspector",
+        .is_open = &app.show_entity_inspector,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    if (!zgui.begin("Entity Inspector", .{
+        .popen = &app.show_entity_inspector,
+        .flags = .{ .always_auto_resize = true },
+    })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    const insp = &app.entity_inspector;
+
+    if (insp.watched_entity) |id| {
+        zgui.text("Watching entity #{d}", .{id});
+        if (zgui.button("Stop watching##entity_inspector_stop", .{})) {
+            insp.onEntityDeselected();
+        }
+    } else {
+        zgui.textDisabled("No entity selected. Click an entity in the scene viewport to watch live values.", .{});
+        return;
+    }
+
+    zgui.separator();
+
+    if (insp.components.count() == 0) {
+        zgui.textDisabled("Awaiting first component snapshot...", .{});
+        return;
+    }
+
+    var it = insp.components.iterator();
+    while (it.next()) |entry| {
+        renderComponentRow(entry.key_ptr.*, entry.value_ptr.*);
+    }
+}
+
+fn renderComponentRow(name: []const u8, bytes: []const u8) void {
+    zgui.text("{s}", .{name});
+    // Hex dump — typed rendering is a Phase 4 follow-up. Cap the
+    // display at 64 bytes so a fat blob doesn't blow out the panel.
+    const max_show: usize = 64;
+    var hex_buf: [3 * max_show + 8]u8 = undefined;
+    const limit = @min(bytes.len, max_show);
+    var written: usize = 0;
+    for (bytes[0..limit], 0..) |b, i| {
+        if (i > 0) {
+            hex_buf[written] = ' ';
+            written += 1;
+        }
+        const slice = std.fmt.bufPrint(hex_buf[written..], "{x:0>2}", .{b}) catch break;
+        written += slice.len;
+    }
+    if (bytes.len > limit) {
+        const tail = " ...";
+        if (written + tail.len <= hex_buf.len) {
+            @memcpy(hex_buf[written..][0..tail.len], tail);
+            written += tail.len;
+        }
+    }
+    zgui.indent(.{});
+    zgui.textDisabled("{s}", .{hex_buf[0..written]});
+    zgui.unindent(.{});
+}

--- a/src/modules/entity_inspector.zig
+++ b/src/modules/entity_inspector.zig
@@ -72,8 +72,13 @@ pub const EntityInspector = struct {
             self.session.unwatchEntity(prev) catch {};
         }
         self.clearComponents();
-        self.watched_entity = entity_id;
+        // Set watched_entity only after the wire write succeeds so the
+        // inspector never believes it is watching an entity the engine
+        // never heard about (which would silently drop every subsequent
+        // component_changed frame for that entity).
+        self.watched_entity = null;
         try self.session.watchEntity(entity_id);
+        self.watched_entity = entity_id;
     }
 
     /// Clear selection and tell the engine to stop emitting filtered
@@ -96,7 +101,6 @@ pub const EntityInspector = struct {
         if (watched != entity_id) return;
 
         const owned_bytes = self.allocator.dupe(u8, bytes) catch return;
-        errdefer self.allocator.free(owned_bytes);
 
         const gop = self.components.getOrPut(name) catch {
             self.allocator.free(owned_bytes);

--- a/src/modules/flow.zig
+++ b/src/modules/flow.zig
@@ -41,6 +41,11 @@ const GraphNodeSpec = flow_types.GraphNodeSpec;
 const inspector_w: f32 = 320;
 const split_gap: f32 = 8;
 
+/// Duration of the active-node pulse highlight (issue #84). 300ms is
+/// long enough to register at 60Hz frame rates without trailing
+/// previous fires when nodes step every couple of frames.
+pub const pulse_duration_ms: i64 = 300;
+
 pub const FlowState = struct {
     arena: *std.heap.ArenaAllocator,
     /// Absolute path on disk. Read-only; used for tab dedup and for
@@ -66,6 +71,17 @@ pub const FlowState = struct {
     /// `false` always — flows are derived from Zig, never authored
     /// here. Kept to satisfy `OpenTab.isDirty`.
     is_dirty: bool = false,
+
+    /// Phase 3 (#84): id of the node currently being pulse-highlighted
+    /// because the engine just sent a `node_entered` frame for it.
+    /// `null` while no pulse is in progress. The actual node is looked
+    /// up by id at render time so a graph reparse doesn't dangle the
+    /// reference.
+    pulse_node_id: ?u32 = null,
+    /// Wall-clock ms (std.time.milliTimestamp()) when the current
+    /// pulse started. Used to compute the alpha falloff. Together with
+    /// `pulse_node_id` defines an active pulse.
+    pulse_started_ms: ?i64 = null,
 
     pub fn open(allocator: std.mem.Allocator, path: []const u8) !FlowState {
         const arena = try allocator.create(std.heap.ArenaAllocator);
@@ -265,6 +281,10 @@ fn renderCanvas(s: *FlowState, allocator: std.mem.Allocator) void {
         };
         _ = ne.link(link_id, @intCast(e.from_pin), @intCast(e.to_pin), colour, 1.5);
     }
+
+    // Active-node pulse (Phase 3, #84). Drawn after nodes/edges so
+    // the highlight overlays the node's own border.
+    renderPulse(s);
 }
 
 fn renderSidebar(s: *FlowState) void {
@@ -435,4 +455,47 @@ fn layoutNodes(allocator: std.mem.Allocator, graph: Graph) ![][2]f32 {
 pub fn saveFlow(s: *FlowState, app: *App) void {
     _ = s;
     _ = app;
+}
+
+/// Phase 3 (#84): trigger a brief pulse highlight on `node_id`. The
+/// pulse fades over `pulse_duration_ms`; the falloff is computed at
+/// render time from `pulse_started_ms`. Calling again with the same
+/// or a different id restarts the fade — back-to-back step traces
+/// re-pulse without trailing.
+pub fn pulseNode(s: *FlowState, node_id: u32) void {
+    s.pulse_node_id = node_id;
+    s.pulse_started_ms = std.time.milliTimestamp();
+}
+
+/// Render the active pulse, if any, as a faded border over the node's
+/// editor rect. Cheap — one `getNodePosition`+`getNodeSize` lookup
+/// plus an `addRect` on the foreground draw list. Returns silently
+/// when no pulse is active or it has decayed past the duration.
+fn renderPulse(s: *FlowState) void {
+    const id = s.pulse_node_id orelse return;
+    const started = s.pulse_started_ms orelse return;
+    const now = std.time.milliTimestamp();
+    const elapsed = now - started;
+    if (elapsed < 0 or elapsed > pulse_duration_ms) {
+        // Decayed — clear so we don't keep computing a zero-alpha
+        // border each frame.
+        s.pulse_node_id = null;
+        s.pulse_started_ms = null;
+        return;
+    }
+    const t: f32 = @as(f32, @floatFromInt(elapsed)) / @as(f32, @floatFromInt(pulse_duration_ms));
+    const alpha: f32 = 1.0 - t;
+
+    // Position + size come from the node editor's per-node state.
+    const pos = ne.getNodePosition(@intCast(id));
+    const size = ne.getNodeSize(@intCast(id));
+    if (size[0] <= 0 or size[1] <= 0) return;
+    const dl = zgui.getWindowDrawList();
+    const col = zgui.colorConvertFloat4ToU32(.{ 1.0, 0.8, 0.2, alpha });
+    dl.addRect(.{
+        .pmin = .{ pos[0], pos[1] },
+        .pmax = .{ pos[0] + size[0], pos[1] + size[1] },
+        .col = col,
+        .thickness = 3.0,
+    });
 }

--- a/src/modules/flow.zig
+++ b/src/modules/flow.zig
@@ -490,7 +490,11 @@ fn renderPulse(s: *FlowState) void {
     const pos = ne.getNodePosition(@intCast(id));
     const size = ne.getNodeSize(@intCast(id));
     if (size[0] <= 0 or size[1] <= 0) return;
-    const dl = zgui.getWindowDrawList();
+    // Use the editor's hint foreground draw list so the pulse stays
+    // anchored in canvas-space when the user pans or zooms, and
+    // overlays node bodies. `getWindowDrawList` would draw in
+    // screen-space and drift relative to the nodes.
+    const dl: zgui.DrawList = @ptrCast(ne.getHintForegroundDrawList());
     const col = zgui.colorConvertFloat4ToU32(.{ 1.0, 0.8, 0.2, alpha });
     dl.addRect(.{
         .pmin = .{ pos[0], pos[1] },

--- a/src/modules/flow_runtime.zig
+++ b/src/modules/flow_runtime.zig
@@ -1,0 +1,169 @@
+//! Flow Runtime panel (issue #84, Phase 3 editor side).
+//!
+//! Minimal UI for managing per-flow `subscribe_flow` state during a
+//! preview session. Phase 3 MVP scope: the user types a flow name and
+//! clicks Subscribe / Unsubscribe; the engine then streams
+//! `node_entered` frames for that flow until the editor sends
+//! `unsubscribe_flow` (or the session closes).
+//!
+//! Real flow discovery — listing flows referenced by the active scene,
+//! pulling the live list from the engine — is a Phase 3+ polish. The
+//! issue calls it out as "design TBD" so the MVP punts to typed input.
+//!
+//! The panel ALSO renders a short log of the last few `node_entered`
+//! frames the session has received. That's the user-visible signal that
+//! the wiring is live even when no flow editor tab is open; the
+//! "pulse the node in the flow canvas" step runs in parallel inside
+//! `modules/flow.zig`.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const preview = @import("../preview.zig");
+
+const max_log_entries: usize = 16;
+const max_flow_name_bytes: usize = 96;
+
+pub const LogEntry = struct {
+    flow_name: [max_flow_name_bytes]u8 = [_]u8{0} ** max_flow_name_bytes,
+    flow_name_len: usize = 0,
+    node_id: u32 = 0,
+};
+
+pub const FlowRuntime = struct {
+    /// Input buffer for the "Subscribe to ..." form.
+    flow_name_input: [max_flow_name_bytes:0]u8 = [_:0]u8{0} ** max_flow_name_bytes,
+    /// Names the editor has subscribed to in the current session.
+    /// Sized for a handful of flows — preview's typical workload is
+    /// one or two flows under observation at once.
+    subscribed: std.ArrayListUnmanaged([]u8) = .{},
+    /// Rolling log of recent `node_entered` arrivals — newest at index
+    /// `log_head - 1 (mod max)`. Drawn as a small read-only window so
+    /// the user can see frames arriving even without a flow tab open.
+    log: [max_log_entries]LogEntry = [_]LogEntry{.{}} ** max_log_entries,
+    log_count: usize = 0,
+    log_head: usize = 0,
+
+    pub fn deinit(self: *FlowRuntime, allocator: std.mem.Allocator) void {
+        for (self.subscribed.items) |name| allocator.free(name);
+        self.subscribed.deinit(allocator);
+    }
+
+    /// Wire-arrival handler. Pushes one entry into the ring buffer.
+    /// The flow editor's `pulseNode` (wired separately in app.zig) is
+    /// the visible "highlight the node" path; this panel's log is the
+    /// fallback / debug surface.
+    pub fn onNodeEntered(self: *FlowRuntime, flow_name: []const u8, node_id: u32) void {
+        const slot = self.log_head;
+        const n = @min(flow_name.len, max_flow_name_bytes);
+        self.log[slot] = .{};
+        @memcpy(self.log[slot].flow_name[0..n], flow_name[0..n]);
+        self.log[slot].flow_name_len = n;
+        self.log[slot].node_id = node_id;
+        self.log_head = (self.log_head + 1) % max_log_entries;
+        if (self.log_count < max_log_entries) self.log_count += 1;
+    }
+
+    pub fn isSubscribed(self: *const FlowRuntime, flow_name: []const u8) bool {
+        for (self.subscribed.items) |n| {
+            if (std.mem.eql(u8, n, flow_name)) return true;
+        }
+        return false;
+    }
+
+    pub fn subscribe(self: *FlowRuntime, allocator: std.mem.Allocator, session: *preview.PreviewSession, flow_name: []const u8) !void {
+        if (self.isSubscribed(flow_name)) return;
+        const owned = try allocator.dupe(u8, flow_name);
+        errdefer allocator.free(owned);
+        try self.subscribed.append(allocator, owned);
+        try session.subscribeFlow(flow_name);
+    }
+
+    pub fn unsubscribe(self: *FlowRuntime, allocator: std.mem.Allocator, session: *preview.PreviewSession, flow_name: []const u8) !void {
+        for (self.subscribed.items, 0..) |n, i| {
+            if (std.mem.eql(u8, n, flow_name)) {
+                allocator.free(n);
+                _ = self.subscribed.orderedRemove(i);
+                break;
+            }
+        }
+        try session.unsubscribeFlow(flow_name);
+    }
+};
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "flow_runtime",
+        .display_name = "Flow Runtime",
+        .is_open = &app.show_flow_runtime,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    if (!zgui.begin("Flow Runtime", .{
+        .popen = &app.show_flow_runtime,
+        .flags = .{ .always_auto_resize = true },
+    })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    const rt = &app.flow_runtime;
+    const can_act = app.preview.isActive();
+
+    if (!can_act) {
+        zgui.textDisabled("Preview is not running. Start a preview to subscribe to flows.", .{});
+    }
+
+    zgui.text("Subscribe to flow:", .{});
+    _ = zgui.inputText("##flow_runtime_input", .{
+        .buf = &rt.flow_name_input,
+    });
+    zgui.sameLine(.{});
+
+    const input_slice = std.mem.sliceTo(&rt.flow_name_input, 0);
+    const subscribe_label = if (rt.isSubscribed(input_slice)) "Unsubscribe" else "Subscribe";
+    if (zgui.button(subscribe_label, .{ .w = 110 })) {
+        if (can_act and input_slice.len > 0) {
+            if (rt.isSubscribed(input_slice)) {
+                rt.unsubscribe(app.allocator, &app.preview, input_slice) catch |err| {
+                    std.log.warn("flow_runtime: unsubscribe failed: {s}", .{@errorName(err)});
+                };
+            } else {
+                rt.subscribe(app.allocator, &app.preview, input_slice) catch |err| {
+                    std.log.warn("flow_runtime: subscribe failed: {s}", .{@errorName(err)});
+                };
+            }
+        }
+    }
+
+    zgui.separator();
+    zgui.text("Subscribed flows:", .{});
+    if (rt.subscribed.items.len == 0) {
+        zgui.textDisabled("  (none)", .{});
+    } else {
+        for (rt.subscribed.items) |name| {
+            zgui.bulletText("{s}", .{name});
+        }
+    }
+
+    zgui.separator();
+    zgui.text("Recent node_entered frames:", .{});
+    if (rt.log_count == 0) {
+        zgui.textDisabled("  (none yet)", .{});
+        return;
+    }
+    // Walk the ring oldest-to-newest. `log_head` points at the next
+    // write slot, so the oldest live entry is `log_head - log_count
+    // (mod max)`.
+    var i: usize = 0;
+    while (i < rt.log_count) : (i += 1) {
+        const idx = (rt.log_head + max_log_entries - rt.log_count + i) % max_log_entries;
+        const e = rt.log[idx];
+        zgui.bulletText("{s}  node #{d}", .{ e.flow_name[0..e.flow_name_len], e.node_id });
+    }
+}

--- a/src/modules/flow_runtime.zig
+++ b/src/modules/flow_runtime.zig
@@ -75,13 +75,21 @@ pub const FlowRuntime = struct {
 
     pub fn subscribe(self: *FlowRuntime, allocator: std.mem.Allocator, session: *preview.PreviewSession, flow_name: []const u8) !void {
         if (self.isSubscribed(flow_name)) return;
+        // Wire write first. If it fails, local state is unchanged —
+        // the engine isn't subscribed so keeping `subscribed` clean is
+        // the correct consistent view (and avoids the dangling-pointer
+        // risk of freeing `owned` via errdefer after it's been appended).
+        try session.subscribeFlow(flow_name);
         const owned = try allocator.dupe(u8, flow_name);
         errdefer allocator.free(owned);
         try self.subscribed.append(allocator, owned);
-        try session.subscribeFlow(flow_name);
     }
 
     pub fn unsubscribe(self: *FlowRuntime, allocator: std.mem.Allocator, session: *preview.PreviewSession, flow_name: []const u8) !void {
+        // Send the wire frame first. If it fails, leave local state
+        // unchanged — the engine is still subscribed, so keeping the
+        // name in `subscribed` is the correct consistent view.
+        try session.unsubscribeFlow(flow_name);
         for (self.subscribed.items, 0..) |n, i| {
             if (std.mem.eql(u8, n, flow_name)) {
                 allocator.free(n);
@@ -89,7 +97,6 @@ pub const FlowRuntime = struct {
                 break;
             }
         }
-        try session.unsubscribeFlow(flow_name);
     }
 };
 

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -77,6 +77,39 @@ pub const Bye = struct {
     reason: ?[]u8 = null,
 };
 
+/// Binary-frame kinds emitted by the engine on the multiplexed socket.
+/// Mirror of `labelle-engine`'s `preview_mode.BinaryFrameKind`. Numbers
+/// are explicit because they go on the wire.
+pub const BinaryFrameKind = enum(u8) {
+    entity_created = 1,
+    entity_destroyed = 2,
+    component_changed = 3,
+    node_entered = 4,
+    _,
+};
+
+/// Magic byte that prefixes every binary frame. JSON documents start
+/// with `{` so the first-byte peek disambiguates without lookahead.
+pub const binary_magic: u8 = 0x1B;
+
+/// Header bytes per binary frame: [magic][kind][u32 len LE].
+const binary_header_bytes: usize = 6;
+
+/// Callback fired when the engine emits a `component_changed` binary
+/// frame. `comp_bytes` is borrowed — only valid for the duration of
+/// the call. Listeners that need to retain it must copy.
+pub const ComponentChangedCallback = struct {
+    ctx: *anyopaque,
+    func: *const fn (ctx: *anyopaque, entity_id: u64, comp_name: []const u8, comp_bytes: []const u8) void,
+};
+
+/// Callback fired when the engine emits a `node_entered` binary frame.
+/// `flow_name` is borrowed — copy if you need to keep it.
+pub const NodeEnteredCallback = struct {
+    ctx: *anyopaque,
+    func: *const fn (ctx: *anyopaque, flow_name: []const u8, node_id: u32) void,
+};
+
 /// How long we wait between spawning the child and getting an accept()
 /// before declaring failure. Engine cold-start is dominated by package
 /// cache resolution and build, so 2s is generous for the simple case
@@ -135,6 +168,18 @@ pub const PreviewSession = struct {
     /// inside `drainStream`; partial frames stay here until completed
     /// next frame.
     rx_buf: std.ArrayList(u8),
+
+    /// Phase 3 (#84). Optional listener for `component_changed` binary
+    /// frames. The Entity Inspector module installs this once at App
+    /// construction to receive watched-entity updates. Only the last
+    /// installed listener fires — Phase 3 is single-consumer; Phase 4+
+    /// can grow this into a list if multiple panels want the same data.
+    on_component_changed: ?ComponentChangedCallback = null,
+    /// Phase 3 (#84). Optional listener for `node_entered` binary
+    /// frames. The Flow editor module installs this so the active node
+    /// pulses while the runtime is stepping. Same single-consumer rule
+    /// as `on_component_changed`.
+    on_node_entered: ?NodeEnteredCallback = null,
 
     /// Captured child-stderr tail, drained non-blockingly each frame.
     /// Surfaced verbatim by the preview panel when the session lands
@@ -428,10 +473,27 @@ pub const PreviewSession = struct {
         var consumed: usize = 0;
         while (true) {
             const rest = self.rx_buf.items[consumed..];
-            const nl = std.mem.indexOfScalar(u8, rest, '\n') orelse break;
-            const line = rest[0..nl];
-            self.handleFrame(line);
-            consumed += nl + 1;
+            if (rest.len == 0) break;
+
+            if (rest[0] == binary_magic) {
+                // Binary frame: [magic][kind][u32 len LE][payload...].
+                // Wait for the full header + payload before dispatching;
+                // a torn read leaves the partial bytes in rx_buf for the
+                // next drain.
+                if (rest.len < binary_header_bytes) break;
+                const payload_len: usize = @intCast(std.mem.readInt(u32, rest[2..6], .little));
+                const total = binary_header_bytes + payload_len;
+                if (rest.len < total) break;
+                const kind: BinaryFrameKind = @enumFromInt(rest[1]);
+                self.handleBinaryFrame(kind, rest[binary_header_bytes..total]);
+                consumed += total;
+            } else {
+                // JSON line: newline-terminated.
+                const nl = std.mem.indexOfScalar(u8, rest, '\n') orelse break;
+                const line = rest[0..nl];
+                self.handleFrame(line);
+                consumed += nl + 1;
+            }
             if (self.state == .stopped or self.state == .crashed) break;
         }
         if (consumed > 0) {
@@ -439,6 +501,117 @@ pub const PreviewSession = struct {
             std.mem.copyForwards(u8, self.rx_buf.items[0..remaining], self.rx_buf.items[consumed..]);
             self.rx_buf.shrinkRetainingCapacity(remaining);
         }
+    }
+
+    /// Decode a binary telemetry frame's payload (header already
+    /// stripped) and dispatch into the appropriate Phase 3 listener.
+    /// Unknown / malformed payloads are dropped — the protocol is
+    /// forwards-compatible, so a too-new engine kind just gets ignored.
+    fn handleBinaryFrame(self: *Self, kind: BinaryFrameKind, payload: []const u8) void {
+        switch (kind) {
+            .component_changed => self.dispatchComponentChanged(payload),
+            .node_entered => self.dispatchNodeEntered(payload),
+            // entity_created / entity_destroyed are Phase 2 lifecycle
+            // events; Phase 3 doesn't consume them on the editor side
+            // yet (Phase 4 will), so drop them rather than fail.
+            else => {},
+        }
+    }
+
+    fn dispatchComponentChanged(self: *Self, payload: []const u8) void {
+        const cb = self.on_component_changed orelse return;
+        // [u64 entity_id] [u16 name_len] [name bytes] [u32 data_len] [data bytes]
+        if (payload.len < 8 + 2) return;
+        const entity_id = std.mem.readInt(u64, payload[0..8], .little);
+        const name_len: usize = @intCast(std.mem.readInt(u16, payload[8..10], .little));
+        const name_end = 10 + name_len;
+        if (payload.len < name_end + 4) return;
+        const name = payload[10..name_end];
+        const data_len: usize = @intCast(std.mem.readInt(u32, payload[name_end..][0..4], .little));
+        const data_start = name_end + 4;
+        if (payload.len < data_start + data_len) return;
+        const data = payload[data_start .. data_start + data_len];
+        cb.func(cb.ctx, entity_id, name, data);
+    }
+
+    fn dispatchNodeEntered(self: *Self, payload: []const u8) void {
+        const cb = self.on_node_entered orelse return;
+        // [u16 flow_name_len] [flow_name bytes] [u32 node_id]
+        if (payload.len < 2) return;
+        const name_len: usize = @intCast(std.mem.readInt(u16, payload[0..2], .little));
+        const name_end = 2 + name_len;
+        if (payload.len < name_end + 4) return;
+        const flow_name = payload[2..name_end];
+        const node_id = std.mem.readInt(u32, payload[name_end..][0..4], .little);
+        cb.func(cb.ctx, flow_name, node_id);
+    }
+
+    /// Send `watch_entity(id)` to the engine. Caller is responsible
+    /// for matching `unwatchEntity` (or relying on session teardown).
+    /// No-op when the session isn't running — the editor's selection
+    /// UI can fire freely and we just drop subscribe traffic the
+    /// engine can't observe.
+    pub fn watchEntity(self: *Self, id: u64) !void {
+        try self.sendIdFrame("watch_entity", id);
+    }
+
+    pub fn unwatchEntity(self: *Self, id: u64) !void {
+        try self.sendIdFrame("unwatch_entity", id);
+    }
+
+    /// Send `subscribe_flow(flow_name)` to the engine. Engine emits
+    /// `node_entered` frames for this flow until `unsubscribeFlow`.
+    pub fn subscribeFlow(self: *Self, flow_name: []const u8) !void {
+        try self.sendFlowFrame("subscribe_flow", flow_name);
+    }
+
+    pub fn unsubscribeFlow(self: *Self, flow_name: []const u8) !void {
+        try self.sendFlowFrame("unsubscribe_flow", flow_name);
+    }
+
+    /// Send `subscribe(components)` to the engine. Phase 3 ships this
+    /// here (rather than baking it into `watchEntity`) so the inspector
+    /// can opt into the components it wants to render without forcing
+    /// the engine to emit every typed mutation.
+    pub fn subscribeComponents(self: *Self, components: []const []const u8) !void {
+        try self.sendComponentsFrame("subscribe", components);
+    }
+
+    pub fn unsubscribeComponents(self: *Self, components: []const []const u8) !void {
+        try self.sendComponentsFrame("unsubscribe", components);
+    }
+
+    fn sendIdFrame(self: *Self, kind: []const u8, id: u64) !void {
+        const stream = self.stream orelse return;
+        var buf: [128]u8 = undefined;
+        const line = try std.fmt.bufPrint(&buf, "{{\"kind\":\"{s}\",\"id\":{d}}}\n", .{ kind, id });
+        try stream.writeAll(line);
+    }
+
+    fn sendFlowFrame(self: *Self, kind: []const u8, flow_name: []const u8) !void {
+        const stream = self.stream orelse return;
+        // Build the JSON via stringify so flow names with quotes / escapes
+        // don't corrupt the wire.
+        const Msg = struct {
+            kind: []const u8,
+            flow: []const u8,
+        };
+        const body = try std.json.Stringify.valueAlloc(self.allocator, Msg{ .kind = kind, .flow = flow_name }, .{});
+        defer self.allocator.free(body);
+        try stream.writeAll(body);
+        try stream.writeAll("\n");
+    }
+
+    fn sendComponentsFrame(self: *Self, kind: []const u8, components: []const []const u8) !void {
+        const stream = self.stream orelse return;
+        const Msg = struct {
+            kind: []const u8,
+            components: []const []const u8,
+        };
+        const body = try std.json.Stringify.valueAlloc(self.allocator, Msg{ .kind = kind, .components = components }, .{});
+        defer self.allocator.free(body);
+        try stream.writeAll(body);
+        try stream.writeAll("\n");
     }
 
     fn handleFrame(self: *Self, raw: []const u8) void {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2689,6 +2689,369 @@ pub const PreviewSessionTests = struct {
     }
 };
 
+/// Phase 3 (#84): editor-side consumers of the engine's
+/// `watch_entity` / `component_changed` / `node_entered` plumbing.
+/// Each test drives a real loopback pair and asserts both directions:
+/// JSON frames written by the editor land on the mock-engine read
+/// side, and binary frames written by the mock dispatch into the
+/// editor's panel state.
+pub const Phase3Tests = struct {
+    /// Block until the mock-engine side has at least `n` bytes buffered.
+    /// Loopback delivery is "eventually" synchronous on macOS/Linux —
+    /// we may need a microsecond before the editor's `writeAll` is
+    /// visible to a non-blocking `read` on the other end.
+    fn readAtLeast(stream: std.net.Stream, buf: []u8, n: usize) !usize {
+        const deadline = std.time.milliTimestamp() + 200;
+        var total: usize = 0;
+        while (total < n and std.time.milliTimestamp() < deadline) {
+            const got = stream.read(buf[total..]) catch |err| switch (err) {
+                error.WouldBlock => {
+                    std.Thread.sleep(1 * std.time.ns_per_ms);
+                    continue;
+                },
+                else => return err,
+            };
+            if (got == 0) break;
+            total += got;
+        }
+        return total;
+    }
+
+    const Pair = struct {
+        server: std.net.Server,
+        editor_side: std.net.Stream,
+        engine_side: ?std.net.Stream,
+
+        fn make() !Pair {
+            const addr = try std.net.Address.parseIp("127.0.0.1", 0);
+            var server = try std.net.Address.listen(addr, .{ .reuse_address = true });
+            errdefer server.deinit();
+            const engine = try std.net.tcpConnectToAddress(server.listen_address);
+            errdefer engine.close();
+            const editor_conn = try server.accept();
+            return .{ .server = server, .editor_side = editor_conn.stream, .engine_side = engine };
+        }
+
+        fn closeEngine(self: *Pair) void {
+            if (self.engine_side) |s| {
+                s.close();
+                self.engine_side = null;
+            }
+        }
+
+        fn close(self: *Pair) void {
+            self.closeEngine();
+            self.server.deinit();
+        }
+
+        fn write(self: *Pair, bytes: []const u8) !void {
+            try (self.engine_side orelse return error.EngineClosed).writeAll(bytes);
+        }
+    };
+
+    /// Build a `component_changed` binary payload — Phase 3 binary
+    /// telemetry frames are length-prefixed records led by an ESC
+    /// magic byte. Mirrors `Preview.writeComponentChangedFrame` in
+    /// labelle-engine/src/preview_mode.zig.
+    fn makeComponentChangedFrame(buf: []u8, entity_id: u64, name: []const u8, data: []const u8) usize {
+        const payload_len: usize = 8 + 2 + name.len + 4 + data.len;
+        const total = 6 + payload_len;
+        std.debug.assert(buf.len >= total);
+        buf[0] = preview.binary_magic;
+        buf[1] = @intFromEnum(preview.BinaryFrameKind.component_changed);
+        std.mem.writeInt(u32, buf[2..6], @intCast(payload_len), .little);
+        var off: usize = 6;
+        std.mem.writeInt(u64, buf[off..][0..8], entity_id, .little);
+        off += 8;
+        std.mem.writeInt(u16, buf[off..][0..2], @intCast(name.len), .little);
+        off += 2;
+        @memcpy(buf[off .. off + name.len], name);
+        off += name.len;
+        std.mem.writeInt(u32, buf[off..][0..4], @intCast(data.len), .little);
+        off += 4;
+        @memcpy(buf[off .. off + data.len], data);
+        off += data.len;
+        return off;
+    }
+
+    /// Build a `node_entered` binary payload.
+    fn makeNodeEnteredFrame(buf: []u8, flow_name: []const u8, node_id: u32) usize {
+        const payload_len: usize = 2 + flow_name.len + 4;
+        const total = 6 + payload_len;
+        std.debug.assert(buf.len >= total);
+        buf[0] = preview.binary_magic;
+        buf[1] = @intFromEnum(preview.BinaryFrameKind.node_entered);
+        std.mem.writeInt(u32, buf[2..6], @intCast(payload_len), .little);
+        var off: usize = 6;
+        std.mem.writeInt(u16, buf[off..][0..2], @intCast(flow_name.len), .little);
+        off += 2;
+        @memcpy(buf[off .. off + flow_name.len], flow_name);
+        off += flow_name.len;
+        std.mem.writeInt(u32, buf[off..][0..4], node_id, .little);
+        off += 4;
+        return off;
+    }
+
+    /// Plain struct standing in for `EntityInspector` so the test
+    /// doesn't pull in zgui (which the test binary doesn't link
+    /// against). Same shape, same callback semantics — fed by the
+    /// session's `on_component_changed`.
+    const InspectorStub = struct {
+        allocator: std.mem.Allocator,
+        watched_entity: ?u64 = null,
+        components: std.StringHashMap([]u8),
+
+        fn init(allocator: std.mem.Allocator) InspectorStub {
+            return .{
+                .allocator = allocator,
+                .components = std.StringHashMap([]u8).init(allocator),
+            };
+        }
+
+        fn deinit(self: *InspectorStub) void {
+            var it = self.components.iterator();
+            while (it.next()) |e| {
+                self.allocator.free(e.key_ptr.*);
+                self.allocator.free(e.value_ptr.*);
+            }
+            self.components.deinit();
+        }
+
+        fn onComponentChanged(ctx: *anyopaque, entity_id: u64, name: []const u8, bytes: []const u8) void {
+            const self: *InspectorStub = @ptrCast(@alignCast(ctx));
+            const watched = self.watched_entity orelse return;
+            if (watched != entity_id) return;
+            const owned_bytes = self.allocator.dupe(u8, bytes) catch return;
+            const gop = self.components.getOrPut(name) catch {
+                self.allocator.free(owned_bytes);
+                return;
+            };
+            if (gop.found_existing) {
+                self.allocator.free(gop.value_ptr.*);
+                gop.value_ptr.* = owned_bytes;
+            } else {
+                const owned_name = self.allocator.dupe(u8, name) catch {
+                    self.allocator.free(owned_bytes);
+                    return;
+                };
+                gop.key_ptr.* = owned_name;
+                gop.value_ptr.* = owned_bytes;
+            }
+        }
+    };
+
+    const PulseStub = struct {
+        calls: std.ArrayList(Call) = .{},
+        allocator: std.mem.Allocator,
+
+        const Call = struct {
+            flow_name: []u8,
+            node_id: u32,
+        };
+
+        fn init(allocator: std.mem.Allocator) PulseStub {
+            return .{ .allocator = allocator };
+        }
+
+        fn deinit(self: *PulseStub) void {
+            for (self.calls.items) |c| self.allocator.free(c.flow_name);
+            self.calls.deinit(self.allocator);
+        }
+
+        fn onNodeEntered(ctx: *anyopaque, flow_name: []const u8, node_id: u32) void {
+            const self: *PulseStub = @ptrCast(@alignCast(ctx));
+            const owned = self.allocator.dupe(u8, flow_name) catch return;
+            self.calls.append(self.allocator, .{ .flow_name = owned, .node_id = node_id }) catch {
+                self.allocator.free(owned);
+            };
+        }
+    };
+
+    fn driveToRunning(s: *preview.PreviewSession, pair: *Pair) !void {
+        try s.attachForTest(pair.editor_side);
+        try pair.write(
+            \\{"kind":"hello","engine_version":"x","pid":1,"protocol_version":1}
+            ++ "\n");
+        // Spin until the hello transitions us to running.
+        const deadline = std.time.milliTimestamp() + 200;
+        while (std.time.milliTimestamp() < deadline) {
+            s.poll();
+            if (s.state == .running) return;
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+        }
+        return error.NeverRunning;
+    }
+
+    test "watchEntity writes a watch_entity JSON line to the engine" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try driveToRunning(&s, &pair);
+
+        try s.watchEntity(42);
+
+        var buf: [256]u8 = undefined;
+        const n = try readAtLeast(pair.engine_side.?, buf[0..], 1);
+        const got = buf[0..n];
+        // Expect a single newline-terminated frame with kind=watch_entity and id=42.
+        try expect.toBeTrue(std.mem.indexOf(u8, got, "\"kind\":\"watch_entity\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, got, "\"id\":42") != null);
+        try expect.equal(got[got.len - 1], '\n');
+    }
+
+    test "unwatchEntity writes a unwatch_entity JSON line to the engine" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try driveToRunning(&s, &pair);
+
+        try s.unwatchEntity(99);
+
+        var buf: [256]u8 = undefined;
+        const n = try readAtLeast(pair.engine_side.?, buf[0..], 1);
+        const got = buf[0..n];
+        try expect.toBeTrue(std.mem.indexOf(u8, got, "\"kind\":\"unwatch_entity\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, got, "\"id\":99") != null);
+    }
+
+    test "subscribeFlow writes a subscribe_flow JSON line" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try driveToRunning(&s, &pair);
+
+        try s.subscribeFlow("player_state_machine");
+
+        var buf: [256]u8 = undefined;
+        const n = try readAtLeast(pair.engine_side.?, buf[0..], 1);
+        const got = buf[0..n];
+        try expect.toBeTrue(std.mem.indexOf(u8, got, "\"kind\":\"subscribe_flow\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, got, "\"flow\":\"player_state_machine\"") != null);
+    }
+
+    test "component_changed routes to the inspector callback" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try driveToRunning(&s, &pair);
+
+        var insp = InspectorStub.init(allocator);
+        defer insp.deinit();
+        insp.watched_entity = 42;
+        s.on_component_changed = .{ .ctx = &insp, .func = InspectorStub.onComponentChanged };
+
+        var frame_buf: [256]u8 = undefined;
+        const payload = [_]u8{ 0xDE, 0xAD, 0xBE, 0xEF };
+        const total = makeComponentChangedFrame(frame_buf[0..], 42, "Position", payload[0..]);
+        try pair.write(frame_buf[0..total]);
+
+        const reached = pollUntilHasComponent(&s, &insp, "Position");
+        try expect.toBeTrue(reached);
+        const stored = insp.components.get("Position").?;
+        try expect.equal(stored.len, payload.len);
+        try expect.toBeTrue(std.mem.eql(u8, stored, payload[0..]));
+    }
+
+    test "component_changed for unwatched entity does not alter inspector state" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try driveToRunning(&s, &pair);
+
+        var insp = InspectorStub.init(allocator);
+        defer insp.deinit();
+        insp.watched_entity = 42;
+        s.on_component_changed = .{ .ctx = &insp, .func = InspectorStub.onComponentChanged };
+
+        // First: a legitimate frame for the watched entity so we know
+        // the pipeline works end-to-end.
+        var frame_buf: [256]u8 = undefined;
+        const good_payload = [_]u8{ 1, 2, 3, 4 };
+        const good_n = makeComponentChangedFrame(frame_buf[0..], 42, "Position", good_payload[0..]);
+        try pair.write(frame_buf[0..good_n]);
+        try expect.toBeTrue(pollUntilHasComponent(&s, &insp, "Position"));
+
+        // Now send a frame for entity 99 (NOT watched). It should be
+        // dropped by the inspector's filter — components count stays
+        // at 1, "Position" still holds the original bytes, and no
+        // entry called "Velocity" exists.
+        const bad_payload = [_]u8{ 9, 9, 9 };
+        const bad_n = makeComponentChangedFrame(frame_buf[0..], 99, "Velocity", bad_payload[0..]);
+        try pair.write(frame_buf[0..bad_n]);
+
+        // Drain a few polls so the bad frame is observed.
+        var i: usize = 0;
+        while (i < 20) : (i += 1) {
+            s.poll();
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+        }
+
+        try expect.equal(insp.components.count(), 1);
+        try expect.toBeTrue(insp.components.get("Velocity") == null);
+        try expect.equal(insp.watched_entity.?, 42);
+        const stored = insp.components.get("Position").?;
+        try expect.toBeTrue(std.mem.eql(u8, stored, good_payload[0..]));
+    }
+
+    test "node_entered routes (flow_name, node_id) to the pulse callback" {
+        const allocator = std.testing.allocator;
+        var pair = try Pair.make();
+        defer pair.close();
+
+        var s = preview.PreviewSession.init(allocator);
+        defer s.deinit();
+        try driveToRunning(&s, &pair);
+
+        var pulse = PulseStub.init(allocator);
+        defer pulse.deinit();
+        s.on_node_entered = .{ .ctx = &pulse, .func = PulseStub.onNodeEntered };
+
+        var frame_buf: [128]u8 = undefined;
+        const n = makeNodeEnteredFrame(frame_buf[0..], "player_state_machine", 7);
+        try pair.write(frame_buf[0..n]);
+
+        const reached = pollUntilCallCount(&s, &pulse, 1);
+        try expect.toBeTrue(reached);
+        try expect.equal(pulse.calls.items[0].node_id, 7);
+        try expect.toBeTrue(std.mem.eql(u8, pulse.calls.items[0].flow_name, "player_state_machine"));
+    }
+
+    fn pollUntilHasComponent(s: *preview.PreviewSession, insp: *InspectorStub, name: []const u8) bool {
+        const deadline = std.time.milliTimestamp() + 200;
+        while (std.time.milliTimestamp() < deadline) {
+            s.poll();
+            if (insp.components.contains(name)) return true;
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+        }
+        return insp.components.contains(name);
+    }
+
+    fn pollUntilCallCount(s: *preview.PreviewSession, pulse: *PulseStub, target: usize) bool {
+        const deadline = std.time.milliTimestamp() + 200;
+        while (std.time.milliTimestamp() < deadline) {
+            s.poll();
+            if (pulse.calls.items.len >= target) return true;
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+        }
+        return pulse.calls.items.len >= target;
+    }
+};
+
 // ─── Flows projector + renderers (issues #48 + #49) ───────────────────
 
 fn projectStr(source: [:0]const u8) !flow_types.Graph {


### PR DESCRIPTION
## Summary

Editor side of the Play-in-Editor preview Phase 3 plumbing — consumes the two engine primitives shipped by labelle-engine#537 (`node_entered` emitter) and labelle-engine#538 (`watch_entity` + filtered `component_changed`). Closes #84.

### Entity Inspector

- New togglable panel module (`src/modules/entity_inspector.zig`) holding `watched_entity: ?u64` and a `StringHashMap` of component name → last-known raw bytes.
- `onEntitySelected` / `onEntityDeselected` write `watch_entity` / `unwatch_entity` JSON frames to the engine.
- `onComponentChanged` (wired to `PreviewSession.on_component_changed`) ignores frames for entities other than the watched one and stores owned copies of name + bytes for surviving frames.
- Render is intentionally minimal — one row per component with a hex dump of the first 64 bytes. Typed renderers per component are a Phase 4 follow-up; the wire shape already supports them.

### Flow Active-Node Pulse

- New Flow Runtime panel (`src/modules/flow_runtime.zig`) for typed `subscribe_flow` / `unsubscribe_flow` plus a rolling `node_entered` log (16 entries, ring buffer). Hardcoded typed-input form per the spec — real flow discovery is Phase 3+ polish.
- `modules/flow.zig` grows `pulseNode(node_id)` and a 300ms alpha-fading 3px border drawn over the matching `imgui-node-editor` node rect.
- `app.zig` routes every `node_entered` arrival to every open flow tab whose `display_name` matches the engine's `flow_name`.

### Binary-frame dispatch

`preview.zig`'s `consumeFrames` now peeks the first byte: `0x1B` magic → binary frame (header `[magic][kind][u32 len LE]`), otherwise newline-delimited JSON. The existing `hello` / `heartbeat` / `bye` state-machine path is unchanged.

## Test plan

- [x] `zig build` — clean.
- [x] `zig build test` — **181/181 pass** (175 existing + 6 new `Phase3Tests`).
- [x] `zig build gui-test` — **8/8 pass**.

New `Phase3Tests` cover (against a real loopback pair, same harness as `PreviewSessionTests`):

- `watchEntity` writes a `watch_entity` JSON line readable on the engine side
- `unwatchEntity` writes the matching `unwatch_entity` line
- `subscribeFlow` writes a `subscribe_flow` JSON line
- `component_changed` binary frame routes to the inspector callback with correct bytes
- `component_changed` for an unwatched entity does NOT mutate inspector state (filter still applies even if engine sends stale frames)
- `node_entered` binary frame routes `(flow_name, node_id)` to a stub pulse recorder

## Divergences / punts

- Inspector rendering uses a hex dump rather than typed renderers (the issue explicitly calls "value displayed via the component's existing typed renderer"). Reusing `modules/inspector.zig`'s typed sections is mechanical follow-up work — they take an `Entity` struct, not raw bytes, so a deserialise step needs to land first. Flagged as Phase 4 in the panel doc.
- Flow Runtime uses a typed-input subscribe form rather than auto-discovering active flows from the active scene. The issue itself flags this as "design TBD" ("engine could also send a `flows_active` frame at scene-load time").
- `PreviewSession` callbacks are single-consumer (one inspector, one pulse listener). Multiple panels watching the same stream is a Phase 4 concern.

## References

- #84 — issue
- labelle-engine#537 — `node_entered` emitter
- labelle-engine#538 — `watch_entity` + filtered `component_changed`
- #59 — PIE preview umbrella
- #61 — Phase 1 editor side (structural ancestor)