### PR TITLE
feat(flows): flow_io.zig parser + writer for .flow.zon (#47)

### DIFF
--- a/src/flows/flow_io.zig
+++ b/src/flows/flow_io.zig
@@ -221,10 +221,11 @@ pub fn renderFlowZon(allocator: std.mem.Allocator, loaded: LoadedFlow) ![]u8 {
     try writeEvent(w, loaded.flow.event);
     try w.writeAll(",\n");
 
-    // Sort nodes by id for stable output. The sort lives in a
-    // scratch slice so we don't mutate the caller's data.
-    const scratch_alloc = loaded.arena.allocator();
-    const sorted_nodes = try scratch_alloc.dupe(Node, loaded.flow.nodes);
+    // Sort nodes by id for stable output. Use caller's allocator for
+    // the scratch slices so the LoadedFlow's arena stays unmodified
+    // across multiple render calls (mirrors renderGizmoZon's pattern).
+    const sorted_nodes = try allocator.dupe(Node, loaded.flow.nodes);
+    defer allocator.free(sorted_nodes);
     std.mem.sort(Node, sorted_nodes, {}, lessThanNode);
 
     try w.writeAll("    .nodes = .{\n");
@@ -235,7 +236,8 @@ pub fn renderFlowZon(allocator: std.mem.Allocator, loaded: LoadedFlow) ![]u8 {
     }
     try w.writeAll("    },\n");
 
-    const sorted_links = try scratch_alloc.dupe(Link, loaded.flow.links);
+    const sorted_links = try allocator.dupe(Link, loaded.flow.links);
+    defer allocator.free(sorted_links);
     std.mem.sort(Link, sorted_links, {}, lessThanLink);
 
     try w.writeAll("    .links = .{\n");

--- a/src/flows/flow_io.zig
+++ b/src/flows/flow_io.zig
@@ -1,0 +1,336 @@
+//! Read/write loader for the Flow editor (`.flow.zon` files).
+//!
+//! Flows are authored, hand-edited, on-disk files that describe a
+//! graph of nodes wired together by pins. A later issue (#50) will
+//! consume `Flow` and emit a Zig source file; for now this module is
+//! the authoritative parser + writer that the editor speaks to.
+//!
+//! File schema (see issue #46) — canonical field order is
+//! `.event`, `.nodes`, `.links`:
+//!
+//! ```zon
+//! .{
+//!     .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+//!     .nodes = .{
+//!         .{ .id = 1, .pos = .{120, 80}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+//!     },
+//!     .links = .{
+//!         .{ .from = .{ .node = 1, .pin = "x" }, .to = .{ .node = 2, .pin = "a" } },
+//!     },
+//! }
+//! ```
+//!
+//! Ownership pattern mirrors `gizmo_io.LoadedGizmo`: a heap-allocated
+//! arena owns every slice the `Flow` references, and the caller frees
+//! both via `LoadedFlow.deinit()`.
+//!
+//! `NodeKind` is intentionally narrow in v1 — just enough variants
+//! to cover the issue sketch plus the obvious primitives a forward
+//! codegen pass needs (Identifier / Literal / Call). Growing the
+//! union is deliberate follow-up work and lands in lockstep with
+//! whatever consumer needs the new shape.
+
+const std = @import("std");
+
+/// Tagged event entry point for a flow. Each variant names the
+/// runtime hook the generated function will be wired into and the
+/// names the codegen step should use for hook arguments. Defaults
+/// match the canonical Zig identifiers (`dt`, `entity`) so freshly
+/// authored flows render compactly.
+pub const Event = union(enum) {
+    OnUpdate: struct { arg_dt: []const u8 = "dt" },
+    OnCreate: struct { arg_entity: []const u8 = "entity" },
+    OnDestroy: struct { arg_entity: []const u8 = "entity" },
+};
+
+/// Binary operator for `NodeKind.BinOp`. Extending this is a
+/// follow-up: once the codegen pass lands (#50) we'll know which
+/// operators the renderer actually emits and can grow the set.
+pub const BinOpKind = enum { add, sub, mul, div };
+
+/// On-disk position. `.{120, 80}` in ZON parses straight into a
+/// two-element array literal, which `std.zon.parse` happily coerces
+/// into `[2]f32`. Index 0 is x, index 1 is y. Keeping it as a raw
+/// array (rather than a named struct) is the "tuple trick" the
+/// schema doc calls out — it round-trips byte-equivalent to the
+/// hand-authored form.
+pub const Pos = [2]f32;
+
+/// Kind discriminator for a flow node. The variant body holds the
+/// per-kind payload; pins are described separately by `Link`s.
+///
+/// v1 coverage:
+///   - GetComponent / SetField — read and write ECS state
+///   - BinOp                  — arithmetic combinator
+///   - Literal                — verbatim Zig expression text
+///                              (typed literals are a later issue)
+///   - Identifier             — bare name reference
+///   - Call                   — invoke a function by name
+///
+/// Adding variants is intentional follow-up work; each one should
+/// land with the editor UI that authors it and the codegen path
+/// that consumes it.
+pub const NodeKind = union(enum) {
+    GetComponent: struct { type: []const u8 },
+    SetField: struct { target: []const u8 },
+    BinOp: struct { op: BinOpKind },
+    Literal: struct { value: []const u8 },
+    Identifier: struct { name: []const u8 },
+    Call: struct { callee: []const u8 },
+};
+
+/// One node in a flow graph. `id` is the on-disk source of truth —
+/// the editor picks the next unused `u32` (max + 1) when creating
+/// nodes and the parser preserves whatever shows up. ID `0` is
+/// reserved for "unassigned" and rejected by `parseFlow`.
+pub const Node = struct {
+    id: u32,
+    pos: Pos,
+    kind: NodeKind,
+};
+
+/// One end of a `Link`. References a node by `id` and names the pin
+/// on that node as a string (pins aren't enumerated structurally —
+/// each `NodeKind` documents its pin set in the renderer).
+pub const PinRef = struct {
+    node: u32,
+    pin: []const u8,
+};
+
+/// A directed connection between two pins. Cycles are *not* checked
+/// here — that's a concern for the codegen pass, which can produce
+/// a better diagnostic with full context.
+pub const Link = struct {
+    from: PinRef,
+    to: PinRef,
+};
+
+/// A fully parsed flow. Every slice is owned by the surrounding
+/// `LoadedFlow.arena`.
+pub const Flow = struct {
+    event: Event,
+    nodes: []Node,
+    links: []Link,
+};
+
+/// Parsed flow plus the arena that owns its memory. Caller frees
+/// via `LoadedFlow.deinit()`.
+pub const LoadedFlow = struct {
+    arena: *std.heap.ArenaAllocator,
+    flow: Flow,
+
+    pub fn deinit(self: *LoadedFlow) void {
+        const child_alloc = self.arena.child_allocator;
+        self.arena.deinit();
+        child_alloc.destroy(self.arena);
+    }
+};
+
+pub const ParseError = error{
+    /// Two nodes share the same `id` value. IDs must be unique.
+    DuplicateNodeId,
+    /// A node has `id == 0`, which is reserved for "unassigned".
+    InvalidNodeId,
+    /// A link references a `from.node` or `to.node` that has no
+    /// matching `Node.id` in the file.
+    DanglingLink,
+};
+
+/// Read `path` as ZON and parse it into a `LoadedFlow`. 16 MiB cap
+/// matches `gizmo_io` — these files are tiny.
+pub fn loadFromFile(allocator: std.mem.Allocator, path: []const u8) !LoadedFlow {
+    const raw = try std.fs.cwd().readFileAlloc(allocator, path, 16 * 1024 * 1024);
+    defer allocator.free(raw);
+    return parseFlow(allocator, raw);
+}
+
+/// Parse a flow's ZON source into a `LoadedFlow`. Tolerant of
+/// unknown fields (`ignore_unknown_fields = true`) so future schema
+/// additions don't break older clients. Validates ID uniqueness,
+/// `id != 0`, and that every `Link.from.node` / `Link.to.node`
+/// resolves to a real node — returns one of the typed `ParseError`
+/// variants on failure so the editor can surface a useful message.
+pub fn parseFlow(allocator: std.mem.Allocator, raw: []const u8) !LoadedFlow {
+    const arena = try allocator.create(std.heap.ArenaAllocator);
+    errdefer allocator.destroy(arena);
+    arena.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+
+    const arena_alloc = arena.allocator();
+
+    // `std.zon.parse.fromSlice` needs a sentinel-terminated slice for
+    // its tokenizer. Copy into the arena so the parsed string slices
+    // borrow lifetime from us.
+    const source = try arena_alloc.dupeZ(u8, raw);
+
+    var diag: std.zon.parse.Diagnostics = .{};
+    defer diag.deinit(arena_alloc);
+    const parsed = try std.zon.parse.fromSlice(Flow, arena_alloc, source, &diag, .{
+        .ignore_unknown_fields = true,
+    });
+
+    try validate(parsed);
+
+    return .{
+        .arena = arena,
+        .flow = parsed,
+    };
+}
+
+fn validate(flow: Flow) ParseError!void {
+    // Unique-ID + non-zero-ID check. O(n^2) is fine — flows are
+    // hand-authored and stay small. If that ever stops being true,
+    // sort `nodes` by `id` and scan in linear time.
+    for (flow.nodes, 0..) |n, i| {
+        if (n.id == 0) return error.InvalidNodeId;
+        for (flow.nodes[i + 1 ..]) |m| {
+            if (m.id == n.id) return error.DuplicateNodeId;
+        }
+    }
+
+    // Every link endpoint must resolve to an existing node.
+    for (flow.links) |l| {
+        if (!hasNode(flow.nodes, l.from.node)) return error.DanglingLink;
+        if (!hasNode(flow.nodes, l.to.node)) return error.DanglingLink;
+    }
+}
+
+fn hasNode(nodes: []const Node, id: u32) bool {
+    for (nodes) |n| {
+        if (n.id == id) return true;
+    }
+    return false;
+}
+
+/// Render a `LoadedFlow` back to ZON source. Canonical field order
+/// is `.event`, `.nodes`, `.links`. Nodes are emitted sorted by
+/// `id`; links are emitted sorted by `(from.node, from.pin, to.node,
+/// to.pin)`. Sorting is the easy way to get deterministic output
+/// from in-memory edits — the diff between a save and the previous
+/// save reflects the user's change, not insertion order. String
+/// values run through `std.zig.fmtString` so a `"` or `\` inside an
+/// identifier round-trips as valid ZON.
+pub fn renderFlowZon(allocator: std.mem.Allocator, loaded: LoadedFlow) ![]u8 {
+    var out: std.ArrayList(u8) = .{};
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+
+    try w.writeAll(".{\n");
+
+    try w.writeAll("    .event = ");
+    try writeEvent(w, loaded.flow.event);
+    try w.writeAll(",\n");
+
+    // Sort nodes by id for stable output. The sort lives in a
+    // scratch slice so we don't mutate the caller's data.
+    const scratch_alloc = loaded.arena.allocator();
+    const sorted_nodes = try scratch_alloc.dupe(Node, loaded.flow.nodes);
+    std.mem.sort(Node, sorted_nodes, {}, lessThanNode);
+
+    try w.writeAll("    .nodes = .{\n");
+    for (sorted_nodes) |n| {
+        try w.print("        .{{ .id = {d}, .pos = .{{{d}, {d}}}, .kind = ", .{ n.id, n.pos[0], n.pos[1] });
+        try writeNodeKind(w, n.kind);
+        try w.writeAll(" },\n");
+    }
+    try w.writeAll("    },\n");
+
+    const sorted_links = try scratch_alloc.dupe(Link, loaded.flow.links);
+    std.mem.sort(Link, sorted_links, {}, lessThanLink);
+
+    try w.writeAll("    .links = .{\n");
+    for (sorted_links) |l| {
+        try w.print(
+            "        .{{ .from = .{{ .node = {d}, .pin = \"{f}\" }}, .to = .{{ .node = {d}, .pin = \"{f}\" }} }},\n",
+            .{
+                l.from.node,
+                std.zig.fmtString(l.from.pin),
+                l.to.node,
+                std.zig.fmtString(l.to.pin),
+            },
+        );
+    }
+    try w.writeAll("    },\n");
+
+    try w.writeAll("}\n");
+    return out.toOwnedSlice(allocator);
+}
+
+fn lessThanNode(_: void, a: Node, b: Node) bool {
+    return a.id < b.id;
+}
+
+fn lessThanLink(_: void, a: Link, b: Link) bool {
+    if (a.from.node != b.from.node) return a.from.node < b.from.node;
+    const fp = std.mem.order(u8, a.from.pin, b.from.pin);
+    if (fp != .eq) return fp == .lt;
+    if (a.to.node != b.to.node) return a.to.node < b.to.node;
+    return std.mem.order(u8, a.to.pin, b.to.pin) == .lt;
+}
+
+fn writeEvent(w: anytype, ev: Event) !void {
+    switch (ev) {
+        .OnUpdate => |body| try w.print(
+            ".{{ .OnUpdate = .{{ .arg_dt = \"{f}\" }} }}",
+            .{std.zig.fmtString(body.arg_dt)},
+        ),
+        .OnCreate => |body| try w.print(
+            ".{{ .OnCreate = .{{ .arg_entity = \"{f}\" }} }}",
+            .{std.zig.fmtString(body.arg_entity)},
+        ),
+        .OnDestroy => |body| try w.print(
+            ".{{ .OnDestroy = .{{ .arg_entity = \"{f}\" }} }}",
+            .{std.zig.fmtString(body.arg_entity)},
+        ),
+    }
+}
+
+fn writeNodeKind(w: anytype, k: NodeKind) !void {
+    switch (k) {
+        .GetComponent => |b| try w.print(
+            ".{{ .GetComponent = .{{ .type = \"{f}\" }} }}",
+            .{std.zig.fmtString(b.type)},
+        ),
+        .SetField => |b| try w.print(
+            ".{{ .SetField = .{{ .target = \"{f}\" }} }}",
+            .{std.zig.fmtString(b.target)},
+        ),
+        .BinOp => |b| try w.print(
+            ".{{ .BinOp = .{{ .op = .{s} }} }}",
+            .{@tagName(b.op)},
+        ),
+        .Literal => |b| try w.print(
+            ".{{ .Literal = .{{ .value = \"{f}\" }} }}",
+            .{std.zig.fmtString(b.value)},
+        ),
+        .Identifier => |b| try w.print(
+            ".{{ .Identifier = .{{ .name = \"{f}\" }} }}",
+            .{std.zig.fmtString(b.name)},
+        ),
+        .Call => |b| try w.print(
+            ".{{ .Call = .{{ .callee = \"{f}\" }} }}",
+            .{std.zig.fmtString(b.callee)},
+        ),
+    }
+}
+
+/// Persist `loaded` to disk at `path`. Truncates any existing file.
+pub fn saveFlow(allocator: std.mem.Allocator, path: []const u8, loaded: LoadedFlow) !void {
+    const text = try renderFlowZon(allocator, loaded);
+    defer allocator.free(text);
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(text);
+}
+
+/// Strip the trailing `.flow.zon` double extension from a path's
+/// basename and return the stem. e.g.
+/// `"scripts/flows/move.flow.zon"` → `"move"`. Falls back to the
+/// raw basename when the suffix isn't present so the editor still
+/// has something to show.
+pub fn displayNameFromPath(path: []const u8) []const u8 {
+    const base = std.fs.path.basename(path);
+    const ext = ".flow.zon";
+    if (std.mem.endsWith(u8, base, ext)) return base[0 .. base.len - ext.len];
+    return base;
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -14,6 +14,7 @@ const atlas = @import("atlas.zig");
 const gizmo_io = @import("gizmo_io.zig");
 const gizmos = @import("gizmos.zig");
 const preview = @import("preview.zig");
+const flow_io = @import("flows/flow_io.zig");
 const flow_projector = @import("flows/projector.zig");
 const flow_types = @import("flows/types.zig");
 const prefs = @import("prefs.zig");
@@ -2320,6 +2321,252 @@ pub const GizmoIoTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, reparsed.gizmo.match[0], hostile));
         try expect.equal(reparsed.gizmo.exclude.len, 1);
         try expect.toBeTrue(std.mem.eql(u8, reparsed.gizmo.exclude[0], "Tab\there"));
+    }
+};
+
+pub const FlowIoTests = struct {
+    // The sketch from issue #46 — the canonical example a flow file
+    // looks like in v1. Used by the round-trip test below.
+    const sample_issue_46 =
+        \\.{
+        \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+        \\    .nodes = .{
+        \\        .{ .id = 1, .pos = .{120, 80}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+        \\        .{ .id = 2, .pos = .{280, 80}, .kind = .{ .BinOp = .{ .op = .add } } },
+        \\        .{ .id = 3, .pos = .{440, 80}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+        \\    },
+        \\    .links = .{
+        \\        .{ .from = .{ .node = 1, .pin = "x" }, .to = .{ .node = 2, .pin = "a" } },
+        \\    },
+        \\}
+        \\
+    ;
+
+    const minimal_on_update =
+        \\.{
+        \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+        \\    .nodes = .{},
+        \\    .links = .{},
+        \\}
+        \\
+    ;
+
+    test "parses minimal flow with OnUpdate event" {
+        const allocator = std.testing.allocator;
+        var loaded = try flow_io.parseFlow(allocator, minimal_on_update);
+        defer loaded.deinit();
+
+        try expect.equal(@as(std.meta.Tag(flow_io.Event), loaded.flow.event), .OnUpdate);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.flow.event.OnUpdate.arg_dt, "dt"));
+        try expect.equal(loaded.flow.nodes.len, 0);
+        try expect.equal(loaded.flow.links.len, 0);
+    }
+
+    test "parses each NodeKind variant" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+            \\        .{ .id = 3, .pos = .{0, 0}, .kind = .{ .BinOp = .{ .op = .mul } } },
+            \\        .{ .id = 4, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1.5" } } },
+            \\        .{ .id = 5, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "speed" } } },
+            \\        .{ .id = 6, .pos = .{0, 0}, .kind = .{ .Call = .{ .callee = "std.math.sin" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        var loaded = try flow_io.parseFlow(allocator, src);
+        defer loaded.deinit();
+
+        try expect.equal(loaded.flow.nodes.len, 6);
+        try expect.equal(@as(std.meta.Tag(flow_io.NodeKind), loaded.flow.nodes[0].kind), .GetComponent);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.flow.nodes[0].kind.GetComponent.type, "Position"));
+        try expect.equal(@as(std.meta.Tag(flow_io.NodeKind), loaded.flow.nodes[1].kind), .SetField);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.flow.nodes[1].kind.SetField.target, "Position.x"));
+        try expect.equal(@as(std.meta.Tag(flow_io.NodeKind), loaded.flow.nodes[2].kind), .BinOp);
+        try expect.equal(loaded.flow.nodes[2].kind.BinOp.op, .mul);
+        try expect.equal(@as(std.meta.Tag(flow_io.NodeKind), loaded.flow.nodes[3].kind), .Literal);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.flow.nodes[3].kind.Literal.value, "1.5"));
+        try expect.equal(@as(std.meta.Tag(flow_io.NodeKind), loaded.flow.nodes[4].kind), .Identifier);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.flow.nodes[4].kind.Identifier.name, "speed"));
+        try expect.equal(@as(std.meta.Tag(flow_io.NodeKind), loaded.flow.nodes[5].kind), .Call);
+        try expect.toBeTrue(std.mem.eql(u8, loaded.flow.nodes[5].kind.Call.callee, "std.math.sin"));
+    }
+
+    test "parses each Event variant" {
+        const allocator = std.testing.allocator;
+
+        const on_create =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "self" } },
+            \\    .nodes = .{},
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        var l1 = try flow_io.parseFlow(allocator, on_create);
+        defer l1.deinit();
+        try expect.equal(@as(std.meta.Tag(flow_io.Event), l1.flow.event), .OnCreate);
+        try expect.toBeTrue(std.mem.eql(u8, l1.flow.event.OnCreate.arg_entity, "self"));
+
+        const on_destroy =
+            \\.{
+            \\    .event = .{ .OnDestroy = .{ .arg_entity = "victim" } },
+            \\    .nodes = .{},
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        var l2 = try flow_io.parseFlow(allocator, on_destroy);
+        defer l2.deinit();
+        try expect.equal(@as(std.meta.Tag(flow_io.Event), l2.flow.event), .OnDestroy);
+        try expect.toBeTrue(std.mem.eql(u8, l2.flow.event.OnDestroy.arg_entity, "victim"));
+    }
+
+    test "round-trips example from #46 structurally" {
+        // The renderer's output is canonical (sorted, indented) so a
+        // byte-equal compare to the hand-authored source would fight
+        // the spec. Instead, parse → render → parse and confirm the
+        // structural shape matches.
+        const allocator = std.testing.allocator;
+
+        var l1 = try flow_io.parseFlow(allocator, sample_issue_46);
+        defer l1.deinit();
+
+        const rendered = try flow_io.renderFlowZon(allocator, l1);
+        defer allocator.free(rendered);
+
+        var l2 = try flow_io.parseFlow(allocator, rendered);
+        defer l2.deinit();
+
+        try expect.equal(@as(std.meta.Tag(flow_io.Event), l2.flow.event), .OnUpdate);
+        try expect.toBeTrue(std.mem.eql(u8, l2.flow.event.OnUpdate.arg_dt, "dt"));
+
+        try expect.equal(l2.flow.nodes.len, 3);
+        try expect.equal(l2.flow.nodes[0].id, 1);
+        try expect.equal(l2.flow.nodes[0].pos[0], @as(f32, 120));
+        try expect.equal(l2.flow.nodes[0].pos[1], @as(f32, 80));
+        try expect.equal(@as(std.meta.Tag(flow_io.NodeKind), l2.flow.nodes[0].kind), .GetComponent);
+        try expect.toBeTrue(std.mem.eql(u8, l2.flow.nodes[0].kind.GetComponent.type, "Position"));
+
+        try expect.equal(l2.flow.nodes[1].id, 2);
+        try expect.equal(l2.flow.nodes[1].kind.BinOp.op, .add);
+
+        try expect.equal(l2.flow.nodes[2].id, 3);
+        try expect.toBeTrue(std.mem.eql(u8, l2.flow.nodes[2].kind.SetField.target, "Position.x"));
+
+        try expect.equal(l2.flow.links.len, 1);
+        try expect.equal(l2.flow.links[0].from.node, 1);
+        try expect.toBeTrue(std.mem.eql(u8, l2.flow.links[0].from.pin, "x"));
+        try expect.equal(l2.flow.links[0].to.node, 2);
+        try expect.toBeTrue(std.mem.eql(u8, l2.flow.links[0].to.pin, "a"));
+
+        // And the rendered output should re-render byte-identically
+        // (idempotent canonicalization).
+        const rendered2 = try flow_io.renderFlowZon(allocator, l2);
+        defer allocator.free(rendered2);
+        try expect.toBeTrue(std.mem.eql(u8, rendered, rendered2));
+    }
+
+    test "rejects duplicate node IDs" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "a" } } },
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "b" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        try std.testing.expectError(error.DuplicateNodeId, flow_io.parseFlow(allocator, src));
+    }
+
+    test "rejects link to nonexistent node" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "a" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "x" }, .to = .{ .node = 99, .pin = "y" } },
+            \\    },
+            \\}
+            \\
+        ;
+        try std.testing.expectError(error.DanglingLink, flow_io.parseFlow(allocator, src));
+    }
+
+    test "rejects node id == 0" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 0, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "a" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        try std.testing.expectError(error.InvalidNodeId, flow_io.parseFlow(allocator, src));
+    }
+
+    test "displayNameFromPath strips .flow.zon" {
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.displayNameFromPath("scripts/flows/move.flow.zon"),
+            "move",
+        ));
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.displayNameFromPath("/abs/path/to/jump.flow.zon"),
+            "jump",
+        ));
+        // Bare `.zon` (without the `.flow` infix) is NOT stripped —
+        // that's a different file kind and the editor wouldn't open
+        // it via this loader anyway.
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.displayNameFromPath("scene.zon"),
+            "scene.zon",
+        ));
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.displayNameFromPath("noext"),
+            "noext",
+        ));
+    }
+
+    test "saveFlow + loadFromFile round trip via tmpDir" {
+        const allocator = std.testing.allocator;
+
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const dir = try tmp.dir.realpathAlloc(allocator, ".");
+        defer allocator.free(dir);
+        const path = try std.fs.path.join(allocator, &.{ dir, "demo.flow.zon" });
+        defer allocator.free(path);
+
+        var l1 = try flow_io.parseFlow(allocator, sample_issue_46);
+        defer l1.deinit();
+
+        try flow_io.saveFlow(allocator, path, l1);
+
+        var l2 = try flow_io.loadFromFile(allocator, path);
+        defer l2.deinit();
+
+        try expect.equal(l2.flow.nodes.len, l1.flow.nodes.len);
+        try expect.equal(l2.flow.links.len, l1.flow.links.len);
+        try expect.equal(@as(std.meta.Tag(flow_io.Event), l2.flow.event), .OnUpdate);
     }
 };
 


### PR DESCRIPTION
## Summary

Implements the on-disk read/write side of the Flow editor (issue #47, file format from #46). Ships a typed `Flow` schema, a `parseFlow` / `renderFlowZon` / `loadFromFile` / `saveFlow` quartet built on `std.zon.parse`, and an arena-owned `LoadedFlow` matching `gizmo_io.LoadedGizmo`'s ownership pattern. The natural next consumer is #50 (graph → Zig codegen), which pulls `Flow` and emits a `.zig` source file.

## What's included

- `src/flows/flow_io.zig` — typed schema:
  - `Event` tagged union (`OnUpdate` / `OnCreate` / `OnDestroy`) with default arg names
  - `Node = { id: u32, pos: [2]f32, kind: NodeKind }` — `Pos` is `[2]f32` so `.{120, 80}` parses directly via the tuple-as-array trick
  - `NodeKind` tagged union: `GetComponent` / `SetField` / `BinOp` / `Literal` / `Identifier` / `Call` (intentionally narrow — see below)
  - `Link = { from: PinRef, to: PinRef }` with `PinRef = { node: u32, pin: []const u8 }`
- `loadFromFile` / `parseFlow` — reads up to 16 MiB, tolerant of unknown fields (forward-compat)
- `renderFlowZon` / `saveFlow` — canonical field order (`event`, `nodes`, `links`), 4-space indent, nodes sorted by `id`, links sorted by `(from.node, from.pin, to.node, to.pin)`, strings escaped via `std.zig.fmtString`, enum values emitted as `.identifier`. Output is idempotent (re-rendering a parsed file is byte-equal).
- ID validation in `parseFlow`: rejects `id == 0` (`error.InvalidNodeId`), duplicate IDs (`error.DuplicateNodeId`), and links pointing at missing nodes (`error.DanglingLink`).
- `displayNameFromPath` — strips the `.flow.zon` double-extension (e.g. `scripts/flows/move.flow.zon` → `move`).
- 9 new tests in `FlowIoTests` (`src/tests.zig`): minimal parse, every NodeKind variant, every Event variant, round-trip of the issue #46 example with idempotency check, three validation rejections, the display-name helper, and a `tmpDir` disk round-trip via `saveFlow` + `loadFromFile`.

## Out of scope (deferred)

- Wiring `flow_io` into the Flow tab UI / `app.zig` — separate issue
- Forward codegen (`Flow` → `.zig`) — that's #50
- Reconciling with `src/flows/projector.zig`'s `Graph` (different direction — Zig AST → viz)
- Extending `NodeKind` beyond v1; growing the union lands in lockstep with whatever consumer needs the new shape
- Typed literal encoding (`Literal.value` is verbatim Zig expression text for now)

## Test plan

- [x] `zig build test` — 184/184 pass (9 new in `FlowIoTests`)
- [x] `zig build` — clean
- [x] No changes outside `src/flows/flow_io.zig` and `src/tests.zig`

Tracks #42.