### PR TITLE
feat(flows): graph to Zig codegen with topo sort + preview pulse (#50)

### DIFF
--- a/src/flows/codegen.zig
+++ b/src/flows/codegen.zig
@@ -141,12 +141,28 @@ pub fn renderFlowZig(
     // Function signature, derived from the event variant.
     try writeFnHeader(w, flow.event);
 
-    // OnUpdate has no inherent entity, so if any node needs one we
-    // emit a TODO stub binding. OnCreate/OnDestroy use the event's
-    // arg_entity directly — no extra binding required.
-    if (flow.event == .OnUpdate and anyNodeNeedsEntity(flow.nodes)) {
-        try w.writeAll("    // TODO(#42): real entity selection for OnUpdate flows.\n");
-        try w.writeAll("    const entity: EntityId = undefined;\n");
+    // Node templates reference a local `entity` binding. For OnUpdate
+    // there's no inherent entity, so we emit a TODO stub. For
+    // OnCreate/OnDestroy we alias the user-chosen `arg_entity` name
+    // to `entity` so the templates work regardless of whether the
+    // flow named the parameter `entity`, `self`, `victim`, etc.
+    if (anyNodeNeedsEntity(flow.nodes)) {
+        switch (flow.event) {
+            .OnUpdate => {
+                try w.writeAll("    // TODO(#42): real entity selection for OnUpdate flows.\n");
+                try w.writeAll("    const entity: EntityId = undefined;\n");
+            },
+            .OnCreate => |b| {
+                if (!std.mem.eql(u8, b.arg_entity, "entity")) {
+                    try w.print("    const entity = {s};\n", .{b.arg_entity});
+                }
+            },
+            .OnDestroy => |b| {
+                if (!std.mem.eql(u8, b.arg_entity, "entity")) {
+                    try w.print("    const entity = {s};\n", .{b.arg_entity});
+                }
+            },
+        }
     }
 
     // Walk in topo order, emitting preview pulse + node body for each.

--- a/src/flows/codegen.zig
+++ b/src/flows/codegen.zig
@@ -1,0 +1,501 @@
+//! Forward codegen for the Flow editor (`.flow.zon` → Zig source).
+//!
+//! `renderFlowZig` turns a parsed `flow_io.Flow` into a complete `.zig`
+//! file: imports + one `pub fn` matching the flow's `Event`. The
+//! assembler (separate, follow-up issue) calls this at
+//! `zig build generate` time and writes the result under
+//! `zig-out/.../flows/<name>.zig`.
+//!
+//! ## Pipeline
+//!
+//! 1. Index nodes by id and build the consumer→producer pin map from
+//!    the link list.
+//! 2. Topologically sort the nodes (Kahn's algorithm) so a node's
+//!    inputs are always defined before the node itself emits.
+//! 3. For each node, in topo order:
+//!    - emit the preview pulse preamble (folded from #90 — see below);
+//!    - emit the node's Zig template with input pins resolved to
+//!      either the producing node's variable, or a per-kind default.
+//!
+//! ## Preview pulse (folded from former issue #90)
+//!
+//! Each emitted node body is preceded by:
+//!
+//! ```zig
+//! if (game.preview) |*_p| {
+//!     _p.emitNodeEntered("<flow_name>", <node_id>) catch {};
+//! }
+//! ```
+//!
+//! The `catch {}` keeps gameplay alive when the preview socket has
+//! closed; the `if (game.preview)` guard means a production build
+//! (no `--preview-mode` on argv) pays zero cost.
+//!
+//! ## Pin variables
+//!
+//! Pin values live in `n<node_id>_<pin>` locals. References between
+//! nodes are entirely by-name (the topo sort guarantees the producing
+//! `const` has executed). `GetComponent` is a special case — it
+//! produces a single `n<id>_value` binding for the whole component,
+//! and downstream consumers can ask for any pin name on that node;
+//! the codegen treats non-`value` pin names as field accesses
+//! (`n<id>_value.<pin>`). This is what makes the issue #46 sketch
+//! (with `GetComponent → BinOp.a` via pin `"x"`) emit sensible Zig.
+//!
+//! ## Entity resolution (v1)
+//!
+//! `GetComponent` and `SetField` need an entity. The resolution is
+//! intentionally minimal in v1:
+//!
+//! - For `.OnCreate` / `.OnDestroy`, the event's `arg_entity` is the
+//!   identifier name used in the emitted code.
+//! - For `.OnUpdate`, there's no obvious entity context yet. If any
+//!   node needs one, the codegen emits a stub
+//!   `const entity: EntityId = undefined; // TODO(#42)` so the file
+//!   still parses; system-style iteration (`for (game.entitiesWith…) |…|`)
+//!   is deferred until the engine API lands.
+//!
+//! ## Disconnected pins
+//!
+//! Per-kind defaults — the renderer is forgiving where it can be:
+//!
+//! - `BinOp.a` / `BinOp.b`: default to `0` (numeric identity-ish).
+//! - `Call.arg<k>`: default to `undefined` (caller already chose the
+//!   shape of the call).
+//! - `SetField.value`: no default — disconnected `value` is an error
+//!   (`DanglingPin`) because a write with no input is meaningless.
+
+const std = @import("std");
+const flow_io = @import("flow_io.zig");
+
+/// Caller-facing configuration. `flow_name` is the stem of the
+/// source `.flow.zon` file — used as the first argument to
+/// `Preview.emitNodeEntered` so the editor can correlate node-entered
+/// events with the on-disk flow. Callers typically derive it via
+/// `flow_io.displayNameFromPath`.
+pub const Options = struct {
+    flow_name: []const u8,
+};
+
+/// Codegen-side failure modes. Allocation failures from the supplied
+/// allocator are merged via `CodegenError || std.mem.Allocator.Error`
+/// on the public signature.
+pub const CodegenError = error{
+    /// Topo sort couldn't make progress — the graph contains a cycle.
+    CycleDetected,
+    /// A required input pin has no incoming link and no per-kind
+    /// default (e.g. `SetField.value`).
+    DanglingPin,
+    /// A link names a `to.pin` that isn't part of the consumer
+    /// node's input pin signature.
+    UnknownPin,
+    /// Future-proofing for additional `NodeKind` variants. v1 never
+    /// raises this — every shipped variant has a template.
+    UnsupportedNodeKind,
+};
+
+/// Render a parsed flow as a Zig source file. Caller owns the
+/// returned bytes (`allocator.free`).
+pub fn renderFlowZig(
+    allocator: std.mem.Allocator,
+    flow: flow_io.Flow,
+    options: Options,
+) (CodegenError || std.mem.Allocator.Error)![]u8 {
+    // Index, validate, and topo-sort up front so we can stream the
+    // output linearly without back-patching. `index` lives on the
+    // caller's allocator (small, freed before return).
+    var index = try buildIndex(allocator, flow);
+    defer index.deinit();
+
+    const order = try topoSort(allocator, flow, &index);
+    defer allocator.free(order);
+
+    // Validate every link's pin names against the consumer's input
+    // pin signature. Output-side pin names are intentionally NOT
+    // validated — GetComponent treats any output pin as a field
+    // accessor (see module doc), so anything else would be a false
+    // negative.
+    for (flow.links) |l| {
+        const consumer = index.byId(l.to.node) orelse unreachable; // validated upstream
+        if (!isInputPin(consumer.kind, l.to.pin)) return error.UnknownPin;
+    }
+
+    var out: std.ArrayList(u8) = .{};
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+
+    // File header. The `Game` / `EntityId` types are conventionally
+    // imported from the consuming project; we re-export the
+    // assumption here so the emitted file is self-contained as far
+    // as Zig is concerned. The assembler will replace these imports
+    // with project-specific ones later.
+    try w.writeAll("//! Generated by labelle-gui codegen — DO NOT EDIT.\n");
+    try w.writeAll("//! Source: ");
+    try w.print("{f}", .{std.zig.fmtString(options.flow_name)});
+    try w.writeAll(".flow.zon\n\n");
+    try w.writeAll("const std = @import(\"std\");\n");
+    try w.writeAll("const game_mod = @import(\"game\");\n");
+    try w.writeAll("const Game = game_mod.Game;\n");
+    try w.writeAll("const EntityId = game_mod.EntityId;\n\n");
+
+    // Function signature, derived from the event variant.
+    try writeFnHeader(w, flow.event);
+
+    // OnUpdate has no inherent entity, so if any node needs one we
+    // emit a TODO stub binding. OnCreate/OnDestroy use the event's
+    // arg_entity directly — no extra binding required.
+    if (flow.event == .OnUpdate and anyNodeNeedsEntity(flow.nodes)) {
+        try w.writeAll("    // TODO(#42): real entity selection for OnUpdate flows.\n");
+        try w.writeAll("    const entity: EntityId = undefined;\n");
+    }
+
+    // Walk in topo order, emitting preview pulse + node body for each.
+    // Per-node scratch arena keeps the small string allocations from
+    // pin-resolution from churning the caller's allocator.
+    var scratch = std.heap.ArenaAllocator.init(allocator);
+    defer scratch.deinit();
+    for (order) |id| {
+        const node = index.byId(id) orelse unreachable;
+        try writePreviewPulse(w, options.flow_name, node.id);
+        try writeNodeBody(w, node, flow, &index, scratch.allocator());
+        _ = scratch.reset(.retain_capacity);
+    }
+
+    try w.writeAll("}\n");
+    return out.toOwnedSlice(allocator);
+}
+
+// =====================================================================
+// Index + topo sort
+// =====================================================================
+
+/// Lookup helpers used during codegen. Owns no flow memory — every
+/// slice borrows lifetime from the caller's `Flow`.
+const Index = struct {
+    allocator: std.mem.Allocator,
+    by_id: std.AutoHashMap(u32, *const flow_io.Node),
+    /// `(to.node, to.pin) → from-node-id`. The key includes both
+    /// fields because a single consumer node may have several input
+    /// pins, each fed by a different producer.
+    producers: std.HashMap(EdgeKey, *const flow_io.Link, EdgeKeyContext, std.hash_map.default_max_load_percentage),
+
+    fn deinit(self: *Index) void {
+        self.by_id.deinit();
+        self.producers.deinit();
+    }
+
+    fn byId(self: *const Index, id: u32) ?*const flow_io.Node {
+        return self.by_id.get(id);
+    }
+
+    fn producerOf(self: *const Index, consumer: u32, pin: []const u8) ?*const flow_io.Link {
+        return self.producers.get(.{ .node = consumer, .pin = pin });
+    }
+};
+
+const EdgeKey = struct {
+    node: u32,
+    pin: []const u8,
+};
+
+const EdgeKeyContext = struct {
+    pub fn hash(_: EdgeKeyContext, k: EdgeKey) u64 {
+        var h = std.hash.Wyhash.init(0);
+        h.update(std.mem.asBytes(&k.node));
+        h.update(k.pin);
+        return h.final();
+    }
+    pub fn eql(_: EdgeKeyContext, a: EdgeKey, b: EdgeKey) bool {
+        return a.node == b.node and std.mem.eql(u8, a.pin, b.pin);
+    }
+};
+
+fn buildIndex(allocator: std.mem.Allocator, flow: flow_io.Flow) !Index {
+    var idx: Index = .{
+        .allocator = allocator,
+        .by_id = std.AutoHashMap(u32, *const flow_io.Node).init(allocator),
+        .producers = std.HashMap(EdgeKey, *const flow_io.Link, EdgeKeyContext, std.hash_map.default_max_load_percentage).init(allocator),
+    };
+    errdefer idx.deinit();
+
+    for (flow.nodes) |*n| {
+        try idx.by_id.put(n.id, n);
+    }
+    // Links borrow `to.pin` straight from the flow's arena, which
+    // outlives the index, so the hash map can store the slice
+    // without copying.
+    for (flow.links) |*l| {
+        try idx.producers.put(.{ .node = l.to.node, .pin = l.to.pin }, l);
+    }
+    return idx;
+}
+
+/// Kahn's algorithm — produces an order where every node's
+/// dependencies appear before it. Ties break by ascending node id so
+/// the output is deterministic.
+fn topoSort(
+    allocator: std.mem.Allocator,
+    flow: flow_io.Flow,
+    index: *const Index,
+) (CodegenError || std.mem.Allocator.Error)![]u32 {
+    // In-degree count: for each node, how many of its input pins
+    // are fed by an incoming link. We don't care about pin identity
+    // here, just the count.
+    var indeg = std.AutoHashMap(u32, usize).init(allocator);
+    defer indeg.deinit();
+    for (flow.nodes) |n| {
+        try indeg.put(n.id, 0);
+    }
+    for (flow.links) |l| {
+        const entry = indeg.getPtr(l.to.node) orelse return error.CycleDetected;
+        entry.* += 1;
+    }
+
+    // Seed the ready set with every zero-indegree node, sorted by id
+    // for deterministic output.
+    var ready = std.ArrayList(u32){};
+    defer ready.deinit(allocator);
+    for (flow.nodes) |n| {
+        if (indeg.get(n.id).? == 0) try ready.append(allocator, n.id);
+    }
+    std.mem.sort(u32, ready.items, {}, std.sort.asc(u32));
+
+    const order = try allocator.alloc(u32, flow.nodes.len);
+    errdefer allocator.free(order);
+    var emitted: usize = 0;
+
+    while (ready.items.len > 0) {
+        // Pop the smallest id to keep the sort stable.
+        const next = ready.orderedRemove(0);
+        order[emitted] = next;
+        emitted += 1;
+
+        // Decrement the indegree of every node `next` feeds. Any
+        // that hit zero join the ready set in id order.
+        var added: std.ArrayList(u32) = .{};
+        defer added.deinit(allocator);
+        for (flow.links) |l| {
+            if (l.from.node != next) continue;
+            const e = indeg.getPtr(l.to.node).?;
+            if (e.* > 0) {
+                e.* -= 1;
+                if (e.* == 0) try added.append(allocator, l.to.node);
+            }
+        }
+        std.mem.sort(u32, added.items, {}, std.sort.asc(u32));
+        // Merge `added` into `ready` keeping the latter sorted. A
+        // small list — linear insertion is fine.
+        for (added.items) |id| {
+            var i: usize = 0;
+            while (i < ready.items.len and ready.items[i] < id) : (i += 1) {}
+            try ready.insert(allocator, i, id);
+        }
+    }
+
+    if (emitted != flow.nodes.len) {
+        return error.CycleDetected; // errdefer above frees `order`
+    }
+
+    _ = index; // unused but kept in the signature for future heuristics
+    return order;
+}
+
+// =====================================================================
+// Emission helpers
+// =====================================================================
+
+fn writeFnHeader(w: anytype, ev: flow_io.Event) !void {
+    switch (ev) {
+        .OnUpdate => |b| try w.print(
+            "pub fn onUpdate(game: *Game, {s}: f32) void {{\n",
+            .{b.arg_dt},
+        ),
+        .OnCreate => |b| try w.print(
+            "pub fn onCreate(game: *Game, {s}: EntityId) void {{\n",
+            .{b.arg_entity},
+        ),
+        .OnDestroy => |b| try w.print(
+            "pub fn onDestroy(game: *Game, {s}: EntityId) void {{\n",
+            .{b.arg_entity},
+        ),
+    }
+}
+
+/// Folded from former issue #90 — pulse the preview socket on every
+/// node entry. Failure is swallowed (`catch {}`) so a closed socket
+/// is invisible to gameplay; the `if (game.preview)` guard skips
+/// the work entirely in production builds.
+fn writePreviewPulse(w: anytype, flow_name: []const u8, node_id: u32) !void {
+    try w.writeAll("    if (game.preview) |*_p| {\n");
+    try w.print(
+        "        _p.emitNodeEntered(\"{f}\", {d}) catch {{}};\n",
+        .{ std.zig.fmtString(flow_name), node_id },
+    );
+    try w.writeAll("    }\n");
+}
+
+fn writeNodeBody(
+    w: anytype,
+    node: *const flow_io.Node,
+    flow: flow_io.Flow,
+    index: *const Index,
+    scratch: std.mem.Allocator,
+) (CodegenError || std.mem.Allocator.Error)!void {
+    switch (node.kind) {
+        .GetComponent => |b| try w.print(
+            "    const n{d}_value = game.getComponent({s}, entity) orelse return;\n",
+            .{ node.id, b.type },
+        ),
+        .SetField => |b| {
+            // `target` is "T.field"; split on the last `.` so type
+            // names with their own dots (`foo.bar.Baz.field`) work.
+            const dot = std.mem.lastIndexOfScalar(u8, b.target, '.') orelse return error.UnknownPin;
+            const type_name = b.target[0..dot];
+            const field_name = b.target[dot + 1 ..];
+
+            const value_expr = (try resolveInput(node, "value", flow, index, scratch)) orelse return error.DanglingPin;
+            try w.print(
+                "    game.setField({s}, .{s}, entity, {s});\n",
+                .{ type_name, field_name, value_expr },
+            );
+        },
+        .BinOp => |b| {
+            const a_expr = (try resolveInput(node, "a", flow, index, scratch)) orelse "0";
+            const b_expr = (try resolveInput(node, "b", flow, index, scratch)) orelse "0";
+            const op_text: []const u8 = switch (b.op) {
+                .add => "+",
+                .sub => "-",
+                .mul => "*",
+                .div => "/",
+            };
+            try w.print(
+                "    const n{d}_result = {s} {s} {s};\n",
+                .{ node.id, a_expr, op_text, b_expr },
+            );
+        },
+        .Literal => |b| try w.print(
+            "    const n{d}_value = {s};\n",
+            .{ node.id, b.value },
+        ),
+        .Identifier => |b| try w.print(
+            "    const n{d}_value = {s};\n",
+            .{ node.id, b.name },
+        ),
+        .Call => |b| {
+            // Highest connected `arg<k>` index sets the arity (see
+            // `countCallArgs`); gaps fill with `undefined`, matching
+            // the disconnected-pin default rule.
+            const arity = countCallArgs(flow, node.id);
+            try w.print("    const n{d}_result = {s}(", .{ node.id, b.callee });
+            var i: usize = 0;
+            while (i < arity) : (i += 1) {
+                if (i > 0) try w.writeAll(", ");
+                // 16 bytes fits "arg" + max-width usize comfortably;
+                // overflow here would be a logic bug, not a runtime
+                // condition the caller can hit.
+                var buf: [16]u8 = undefined;
+                const pin = std.fmt.bufPrint(&buf, "arg{d}", .{i}) catch unreachable;
+                const expr = (try resolveInput(node, pin, flow, index, scratch)) orelse "undefined";
+                try w.writeAll(expr);
+            }
+            try w.writeAll(");\n");
+        },
+    }
+}
+
+/// Resolve `pin` on `consumer` to a Zig expression string. Returns
+/// `null` if the pin is disconnected (the caller decides whether
+/// that's an error or a default). The returned slice is allocated
+/// on `scratch`; the caller's per-node arena reset reclaims it.
+fn resolveInput(
+    consumer: *const flow_io.Node,
+    pin: []const u8,
+    flow: flow_io.Flow,
+    index: *const Index,
+    scratch: std.mem.Allocator,
+) (CodegenError || std.mem.Allocator.Error)!?[]const u8 {
+    _ = flow;
+    const link = index.producerOf(consumer.id, pin) orelse return null;
+    const producer = index.byId(link.from.node) orelse return error.UnknownPin;
+
+    // Producer-side default: every kind ships with a "primary"
+    // output pin; if the link names it, the local variable is the
+    // value. Otherwise we fall through to per-kind special cases.
+    const primary = primaryOutputPin(producer.kind);
+    if (std.mem.eql(u8, link.from.pin, primary)) {
+        return try std.fmt.allocPrint(scratch, "n{d}_{s}", .{ producer.id, primary });
+    }
+
+    // GetComponent treats non-`value` output pins as field
+    // accessors on the bound component value. This is what makes
+    // the #46 sketch (`GetComponent → BinOp.a` via pin `"x"`)
+    // produce `n1_value.x` rather than UnknownPin.
+    switch (producer.kind) {
+        .GetComponent => {
+            return try std.fmt.allocPrint(
+                scratch,
+                "n{d}_value.{s}",
+                .{ producer.id, link.from.pin },
+            );
+        },
+        else => return error.UnknownPin,
+    }
+}
+
+fn primaryOutputPin(k: flow_io.NodeKind) []const u8 {
+    return switch (k) {
+        .GetComponent, .Literal, .Identifier => "value",
+        .BinOp, .Call => "result",
+        // SetField has no outputs; "primary" is a no-op for it
+        // (resolveInput never asks because consumers can't link
+        // *from* a SetField in any kind we ship).
+        .SetField => "",
+    };
+}
+
+fn isInputPin(k: flow_io.NodeKind, pin: []const u8) bool {
+    return switch (k) {
+        // Producers — no inputs.
+        .GetComponent, .Literal, .Identifier => false,
+        .SetField => std.mem.eql(u8, pin, "value"),
+        .BinOp => std.mem.eql(u8, pin, "a") or std.mem.eql(u8, pin, "b"),
+        .Call => isCallArgPin(pin),
+    };
+}
+
+/// `arg0`, `arg1`, … `arg<u32>`. Anything else is rejected.
+fn isCallArgPin(pin: []const u8) bool {
+    if (!std.mem.startsWith(u8, pin, "arg")) return false;
+    const tail = pin[3..];
+    if (tail.len == 0) return false;
+    for (tail) |c| {
+        if (c < '0' or c > '9') return false;
+    }
+    return true;
+}
+
+/// Largest `arg<k>` index linking *into* `node_id`, plus one. So a
+/// node with `arg0` and `arg2` connected returns 3 — arity is set by
+/// the highest connected index, not the count of present links, so
+/// argument positions stay stable.
+fn countCallArgs(flow: flow_io.Flow, node_id: u32) usize {
+    var max_idx: ?usize = null;
+    for (flow.links) |l| {
+        if (l.to.node != node_id) continue;
+        if (!std.mem.startsWith(u8, l.to.pin, "arg")) continue;
+        const tail = l.to.pin[3..];
+        const idx = std.fmt.parseInt(usize, tail, 10) catch continue;
+        if (max_idx == null or idx > max_idx.?) max_idx = idx;
+    }
+    return if (max_idx) |m| m + 1 else 0;
+}
+
+fn anyNodeNeedsEntity(nodes: []const flow_io.Node) bool {
+    for (nodes) |n| {
+        switch (n.kind) {
+            .GetComponent, .SetField => return true,
+            else => {},
+        }
+    }
+    return false;
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2720,6 +2720,43 @@ pub const FlowCodegenTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, out, "const n3_value = game.getComponent(Position, entity) orelse return;") != null);
     }
 
+    test "OnCreate with custom arg_entity aliases to entity in template scope" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "self" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "alias");
+        defer allocator.free(out);
+        // The alias binds the user-chosen parameter name to `entity` so
+        // the GetComponent template (which always says `entity`) compiles.
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const entity = self;") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "getComponent(Position, entity)") != null);
+    }
+
+    test "OnCreate with default arg_entity does not emit redundant alias" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "noalias");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const entity =") == null);
+    }
+
     test "renders SetField node sourced from a Literal" {
         const allocator = std.testing.allocator;
         const src =

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -15,6 +15,7 @@ const gizmo_io = @import("gizmo_io.zig");
 const gizmos = @import("gizmos.zig");
 const preview = @import("preview.zig");
 const flow_io = @import("flows/flow_io.zig");
+const flow_codegen = @import("flows/codegen.zig");
 const flow_projector = @import("flows/projector.zig");
 const flow_types = @import("flows/types.zig");
 const prefs = @import("prefs.zig");
@@ -2567,6 +2568,422 @@ pub const FlowIoTests = struct {
         try expect.equal(l2.flow.nodes.len, l1.flow.nodes.len);
         try expect.equal(l2.flow.links.len, l1.flow.links.len);
         try expect.equal(@as(std.meta.Tag(flow_io.Event), l2.flow.event), .OnUpdate);
+    }
+};
+
+pub const FlowCodegenTests = struct {
+    // Small helper — parse a ZON source and immediately run codegen,
+    // returning the rendered Zig. Frees the parser arena before
+    // returning; callers own the returned bytes.
+    fn renderFromZon(allocator: std.mem.Allocator, src: []const u8, name: []const u8) ![]u8 {
+        var loaded = try flow_io.parseFlow(allocator, src);
+        defer loaded.deinit();
+        return flow_codegen.renderFlowZig(allocator, loaded.flow, .{ .flow_name = name });
+    }
+
+    test "renders OnUpdate event signature with custom arg_dt name" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "delta" } },
+            \\    .nodes = .{},
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "demo");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "pub fn onUpdate(game: *Game, delta: f32) void") != null);
+    }
+
+    test "renders OnCreate event signature" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "self" } },
+            \\    .nodes = .{},
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "spawn");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "pub fn onCreate(game: *Game, self: EntityId) void") != null);
+    }
+
+    test "renders OnDestroy event signature" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnDestroy = .{ .arg_entity = "victim" } },
+            \\    .nodes = .{},
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "cleanup");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "pub fn onDestroy(game: *Game, victim: EntityId) void") != null);
+    }
+
+    test "renders Literal node as a const binding" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1.5" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "lit");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n1_value = 1.5;") != null);
+    }
+
+    test "renders Identifier node as a const binding" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 7, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "speed" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "id");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n7_value = speed;") != null);
+    }
+
+    test "renders BinOp node with both inputs connected (distinct producers)" {
+        // Regression: a single shared scratch buffer for input
+        // resolution would alias `a_expr` and `b_expr` and emit the
+        // same identifier twice. Two distinct Literal producers
+        // force the renderer to keep both alive simultaneously.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "2" } } },
+            \\        .{ .id = 3, .pos = .{0, 0}, .kind = .{ .BinOp = .{ .op = .sub } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "value" }, .to = .{ .node = 3, .pin = "a" } },
+            \\        .{ .from = .{ .node = 2, .pin = "value" }, .to = .{ .node = 3, .pin = "b" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "sub");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n3_result = n1_value - n2_value;") != null);
+    }
+
+    test "renders BinOp node with disconnected pins defaulting to 0" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .BinOp = .{ .op = .mul } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "binop");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n2_result = 0 * 0;") != null);
+    }
+
+    test "renders GetComponent node" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 3, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "get");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n3_value = game.getComponent(Position, entity) orelse return;") != null);
+    }
+
+    test "renders SetField node sourced from a Literal" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 4, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "42" } } },
+            \\        .{ .id = 5, .pos = .{0, 0}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 4, .pin = "value" }, .to = .{ .node = 5, .pin = "value" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "setf");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n4_value = 42;") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "game.setField(Position, .x, entity, n4_value);") != null);
+    }
+
+    test "renders Call node with two args" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1.0" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "2.0" } } },
+            \\        .{ .id = 3, .pos = .{0, 0}, .kind = .{ .Call = .{ .callee = "std.math.atan2" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "value" }, .to = .{ .node = 3, .pin = "arg0" } },
+            \\        .{ .from = .{ .node = 2, .pin = "value" }, .to = .{ .node = 3, .pin = "arg1" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "call");
+        defer allocator.free(out);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n3_result = std.math.atan2(n1_value, n2_value);") != null);
+    }
+
+    test "topo-sorts dependent nodes correctly" {
+        // Literal (id=3) → BinOp (id=2) → SetField (id=1). The
+        // numeric ids are intentionally in REVERSE topo order so
+        // that a naive id-sort would emit the wrong sequence.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .BinOp = .{ .op = .add } } },
+            \\        .{ .id = 3, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "5" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 3, .pin = "value" }, .to = .{ .node = 2, .pin = "a" } },
+            \\        .{ .from = .{ .node = 2, .pin = "result" }, .to = .{ .node = 1, .pin = "value" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "topo");
+        defer allocator.free(out);
+
+        const lit_idx = std.mem.indexOf(u8, out, "const n3_value = 5;") orelse return error.TestExpectedSubstring;
+        const binop_idx = std.mem.indexOf(u8, out, "const n2_result = n3_value + 0;") orelse return error.TestExpectedSubstring;
+        const set_idx = std.mem.indexOf(u8, out, "game.setField(Position, .x, entity, n2_result);") orelse return error.TestExpectedSubstring;
+        try expect.toBeTrue(lit_idx < binop_idx);
+        try expect.toBeTrue(binop_idx < set_idx);
+    }
+
+    test "rejects cycle" {
+        const allocator = std.testing.allocator;
+        // Two BinOps wired into each other — node 1's result feeds
+        // node 2's `a`, and node 2's result feeds node 1's `a`.
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .BinOp = .{ .op = .add } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .BinOp = .{ .op = .add } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "result" }, .to = .{ .node = 2, .pin = "a" } },
+            \\        .{ .from = .{ .node = 2, .pin = "result" }, .to = .{ .node = 1, .pin = "a" } },
+            \\    },
+            \\}
+            \\
+        ;
+        var loaded = try flow_io.parseFlow(allocator, src);
+        defer loaded.deinit();
+        try std.testing.expectError(
+            error.CycleDetected,
+            flow_codegen.renderFlowZig(allocator, loaded.flow, .{ .flow_name = "cyc" }),
+        );
+    }
+
+    test "rejects dangling required pin on SetField" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        var loaded = try flow_io.parseFlow(allocator, src);
+        defer loaded.deinit();
+        try std.testing.expectError(
+            error.DanglingPin,
+            flow_codegen.renderFlowZig(allocator, loaded.flow, .{ .flow_name = "missing" }),
+        );
+    }
+
+    test "rejects unknown pin name on link" {
+        const allocator = std.testing.allocator;
+        // BinOp has input pins `a` and `b` only — `c` is unknown.
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .BinOp = .{ .op = .add } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "value" }, .to = .{ .node = 2, .pin = "c" } },
+            \\    },
+            \\}
+            \\
+        ;
+        var loaded = try flow_io.parseFlow(allocator, src);
+        defer loaded.deinit();
+        try std.testing.expectError(
+            error.UnknownPin,
+            flow_codegen.renderFlowZig(allocator, loaded.flow, .{ .flow_name = "bad" }),
+        );
+    }
+
+    test "injects emitNodeEntered for each node with correct flow_name + id" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 10, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1" } } },
+            \\        .{ .id = 20, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "x" } } },
+            \\        .{ .id = 30, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "2" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "pulse");
+        defer allocator.free(out);
+
+        // The total number of emitNodeEntered calls should equal the
+        // node count.
+        const haystack = out;
+        var count: usize = 0;
+        var search_start: usize = 0;
+        while (std.mem.indexOfPos(u8, haystack, search_start, "emitNodeEntered(")) |idx| {
+            count += 1;
+            search_start = idx + 1;
+        }
+        try expect.equal(count, @as(usize, 3));
+
+        // And each id appears exactly once, paired with the right
+        // flow_name argument.
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "_p.emitNodeEntered(\"pulse\", 10) catch {};") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "_p.emitNodeEntered(\"pulse\", 20) catch {};") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "_p.emitNodeEntered(\"pulse\", 30) catch {};") != null);
+    }
+
+    test "round-trips the issue #46 example" {
+        const allocator = std.testing.allocator;
+        // Identical to FlowIoTests.sample_issue_46. The codegen
+        // pipeline interprets `GetComponent → BinOp.a` via the
+        // producer pin name `"x"` as a field access on the bound
+        // component (`n1_value.x`).
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{120, 80}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\        .{ .id = 2, .pos = .{280, 80}, .kind = .{ .BinOp = .{ .op = .add } } },
+            \\        .{ .id = 3, .pos = .{440, 80}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "x" }, .to = .{ .node = 2, .pin = "a" } },
+            \\        .{ .from = .{ .node = 2, .pin = "result" }, .to = .{ .node = 3, .pin = "value" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "move");
+        defer allocator.free(out);
+
+        // The expected statements, in order. We assert ordering by
+        // checking that each appears AFTER the previous one in the
+        // output. Position-sensitive — catches any future regression
+        // where a node ends up upstream of its dependencies.
+        const expected_in_order = [_][]const u8{
+            "const n1_value = game.getComponent(Position, entity) orelse return;",
+            "const n2_result = n1_value.x + 0;",
+            "game.setField(Position, .x, entity, n2_result);",
+        };
+        var prev: usize = 0;
+        for (expected_in_order) |needle| {
+            const at = std.mem.indexOfPos(u8, out, prev, needle) orelse {
+                std.debug.print("missing in output: '{s}'\noutput was:\n{s}\n", .{ needle, out });
+                return error.TestExpectedSubstring;
+            };
+            prev = at + needle.len;
+        }
+
+        // OnUpdate flows that touch entities get the TODO stub so
+        // the file still parses.
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const entity: EntityId = undefined;") != null);
+    }
+
+    test "output passes std.zig.Ast.parse without errors" {
+        // The single strongest correctness signal — anything we
+        // emit must be syntactically valid Zig.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{120, 80}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\        .{ .id = 2, .pos = .{280, 80}, .kind = .{ .BinOp = .{ .op = .add } } },
+            \\        .{ .id = 3, .pos = .{440, 80}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+            \\        .{ .id = 4, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1.5" } } },
+            \\        .{ .id = 5, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "speed" } } },
+            \\        .{ .id = 6, .pos = .{0, 0}, .kind = .{ .Call = .{ .callee = "std.math.max" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "x" }, .to = .{ .node = 2, .pin = "a" } },
+            \\        .{ .from = .{ .node = 4, .pin = "value" }, .to = .{ .node = 2, .pin = "b" } },
+            \\        .{ .from = .{ .node = 2, .pin = "result" }, .to = .{ .node = 6, .pin = "arg0" } },
+            \\        .{ .from = .{ .node = 5, .pin = "value" }, .to = .{ .node = 6, .pin = "arg1" } },
+            \\        .{ .from = .{ .node = 6, .pin = "result" }, .to = .{ .node = 3, .pin = "value" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "all_kinds");
+        defer allocator.free(out);
+
+        // `std.zig.Ast.parse` needs a sentinel-terminated source.
+        const z = try allocator.allocSentinel(u8, out.len, 0);
+        defer allocator.free(z);
+        @memcpy(z[0..out.len], out);
+
+        var ast = try std.zig.Ast.parse(allocator, z, .zig);
+        defer ast.deinit(allocator);
+        if (ast.errors.len != 0) {
+            std.debug.print("emitted Zig didn't parse:\n{s}\n", .{out});
+        }
+        try expect.equal(ast.errors.len, @as(usize, 0));
     }
 };
 


### PR DESCRIPTION
## Summary

Adds `src/flows/codegen.zig` — a forward codegen pass that turns a parsed `flow_io.Flow` (from #47) into a complete `.zig` file. Each node kind has a fixed Zig template; nodes emit in Kahn topo order; every node body is preceded by a preview pulse (`emitNodeEntered`) so the editor can mirror execution in real time, folded in from former issue #90.

Closes #50.

Stacked on #92 — once that merges, GitHub will rebase this onto `main` automatically.

## What's emitted

Input flow (the issue #46 sketch):

```zon
.{
    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
    .nodes = .{
        .{ .id = 1, .pos = .{120, 80}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
        .{ .id = 2, .pos = .{280, 80}, .kind = .{ .BinOp = .{ .op = .add } } },
        .{ .id = 3, .pos = .{440, 80}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
    },
    .links = .{
        .{ .from = .{ .node = 1, .pin = "x" }, .to = .{ .node = 2, .pin = "a" } },
        .{ .from = .{ .node = 2, .pin = "result" }, .to = .{ .node = 3, .pin = "value" } },
    },
}
```

Output Zig (excerpt):

```zig
pub fn onUpdate(game: *Game, dt: f32) void {
    // TODO(#42): real entity selection for OnUpdate flows.
    const entity: EntityId = undefined;
    if (game.preview) |*_p| {
        _p.emitNodeEntered("move", 1) catch {};
    }
    const n1_value = game.getComponent(Position, entity) orelse return;
    if (game.preview) |*_p| {
        _p.emitNodeEntered("move", 2) catch {};
    }
    const n2_result = n1_value.x + 0;
    if (game.preview) |*_p| {
        _p.emitNodeEntered("move", 3) catch {};
    }
    game.setField(Position, .x, entity, n2_result);
}
```

## Decisions

- **Entity resolution (OnUpdate)**: there's no obvious entity context for an OnUpdate flow until the engine ships a system-style iteration API. v1 emits `const entity: EntityId = undefined; // TODO(#42)` so the file still parses; OnCreate / OnDestroy use the event's `arg_entity` directly. A follow-up will wire real entity selection (system query? singleton? component-set filter?) once the engine API lands.
- **GetComponent output pins are permissive**: a link emerging from a `GetComponent` node on a non-`value` pin name (like `"x"`) resolves to a field access (`n<id>_value.x`) rather than `UnknownPin`. This is what makes the issue #46 sketch round-trip — the alternative (strict `value`-only output) would have rejected the canonical example.
- **Disconnected pin defaults**: per kind. `BinOp.a` / `BinOp.b` default to `0`; `Call.arg<k>` defaults to `undefined`; `SetField.value` has no default and raises `DanglingPin` (a write with no input is meaningless).
- **Call arity**: set by the highest connected `arg<k>` index plus one, with gaps filled by `undefined`. Keeps argument positions stable across edits.
- **Pin naming**: `n<id>_<pin>` everywhere. Topo sort guarantees the producing `const` exists when a consumer references it by name.
- **Strongest correctness check is `std.zig.Ast.parse`**: the dedicated test covers all six node kinds in one flow and asserts `ast.errors.len == 0`. Anything we emit must at minimum be syntactically valid Zig.

## Out of scope

- Assembler wiring (`zig build generate` codepath, `zig-out/.../flows/<name>.zig` materialization) — separate follow-up.
- Type checking beyond syntactic Ast.parse.
- ScriptRegistry registration / engine plumbing.
- New `NodeKind` variants beyond the six the parser ships.
- Editor UI changes.

## Test plan

15 new tests in `FlowCodegenTests`. `zig build test` passes (201 / 201) on `feat/flows-codegen`.

- [x] OnUpdate signature with custom `arg_dt`
- [x] OnCreate signature
- [x] OnDestroy signature
- [x] Literal node emits `const n<id>_value = <verbatim>;`
- [x] Identifier node emits `const n<id>_value = <name>;`
- [x] BinOp with both inputs connected (regression for shared-buffer aliasing)
- [x] BinOp with disconnected pins defaults to `0`
- [x] GetComponent emits `game.getComponent(T, entity) orelse return;`
- [x] SetField emits `game.setField(T, .field, entity, <value>);`
- [x] Call with two args
- [x] Topo sort orders Literal -> BinOp -> SetField even when ids are reversed
- [x] Cycle -> `CycleDetected`
- [x] Disconnected `SetField.value` -> `DanglingPin`
- [x] Unknown pin name on link -> `UnknownPin`
- [x] `emitNodeEntered` injected once per node with correct `flow_name` + id
- [x] Round-trips the issue #46 example (asserts statement ordering)
- [x] `std.zig.Ast.parse` accepts the output across all six node kinds