### PR TITLE
fix(flow-codegen): emit getComponent(entity, T) to match engine API

### DIFF
--- a/flow-codegen/src/codegen.zig
+++ b/flow-codegen/src/codegen.zig
@@ -359,7 +359,7 @@ fn writeNodeBody(
 ) (CodegenError || std.mem.Allocator.Error)!void {
     switch (node.kind) {
         .GetComponent => |b| try w.print(
-            "    const n{d}_value = game.getComponent({s}, entity) orelse return;\n",
+            "    const n{d}_value = game.getComponent(entity, {s}) orelse return;\n",
             .{ node.id, b.type },
         ),
         .SetField => |b| {

--- a/flow-codegen/test/root_test.zig
+++ b/flow-codegen/test/root_test.zig
@@ -411,7 +411,7 @@ pub const FlowCodegenTests = struct {
         ;
         const out = try renderFromZon(allocator, src, "get");
         defer allocator.free(out);
-        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n3_value = game.getComponent(Position, entity) orelse return;") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const n3_value = game.getComponent(entity, Position) orelse return;") != null);
     }
 
     test "OnCreate with custom arg_entity aliases to entity in template scope" {
@@ -431,7 +431,7 @@ pub const FlowCodegenTests = struct {
         // The alias binds the user-chosen parameter name to `entity` so
         // the GetComponent template (which always says `entity`) compiles.
         try expect.toBeTrue(std.mem.indexOf(u8, out, "const entity = self;") != null);
-        try expect.toBeTrue(std.mem.indexOf(u8, out, "getComponent(Position, entity)") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "getComponent(entity, Position)") != null);
     }
 
     test "OnCreate with default arg_entity does not emit redundant alias" {
@@ -658,7 +658,7 @@ pub const FlowCodegenTests = struct {
         // output. Position-sensitive -- catches any future regression
         // where a node ends up upstream of its dependencies.
         const expected_in_order = [_][]const u8{
-            "const n1_value = game.getComponent(Position, entity) orelse return;",
+            "const n1_value = game.getComponent(entity, Position) orelse return;",
             "const n2_result = n1_value.x + 0;",
             "game.setField(Position, .x, entity, n2_result);",
         };


### PR DESCRIPTION
## Summary

The flow codegen previously emitted \`game.getComponent(T, entity)\`, which required reordering the engine's existing \`Game.getComponent(entity, T)\` shape. That reorder would have broken 48+ existing call sites across \`labelle-cli\`, \`labelle-gfx\`, \`bakery-game\`, and downstream consumer repos.

This PR flips the codegen template to the established engine order instead. Engine API stays stable; flow files generated from this codegen type-check end-to-end against the unchanged \`Game.getComponent\`.

## What changed

- \`flow-codegen/src/codegen.zig\`: \`GetComponent\` template now emits \`game.getComponent(entity, T)\`.
- \`flow-codegen/test/root_test.zig\`: three test fixtures updated to match.

## Companion

[labelle-engine#541](https://github.com/labelle-toolkit/labelle-engine/pull/541) — adds \`Game.setField\` and a regression test for the existing \`getComponent\` + \`game.preview\` shapes. Together these unblock the Flows end-to-end compile path (#96).

## Test plan

- \`zig build test\` in \`flow-codegen/\` (29 tests pass)
- \`zig build test\` at repo root (181 tests pass)
- \`zig build\` clean