### PR TITLE
feat(flow-codegen): emit @import lines for component types (#101)

### DIFF
--- a/flow-codegen/src/codegen.zig
+++ b/flow-codegen/src/codegen.zig
@@ -68,6 +68,12 @@
 const std = @import("std");
 const flow_io = @import("flow_io.zig");
 
+/// Format string for `@import` paths to component type files in the
+/// assembler's project layout. Centralized so a future layout change
+/// (e.g. `src/components/<Name>.zig`) is a one-line edit. The `{s}`
+/// substitutes the component type name (`Position`, `Velocity`, …).
+const components_import_path_fmt = "components/{s}.zig";
+
 /// Caller-facing configuration. `flow_name` is the stem of the
 /// source `.flow.zon` file — used as the first argument to
 /// `Preview.emitNodeEntered` so the editor can correlate node-entered
@@ -136,7 +142,27 @@ pub fn renderFlowZig(
     try w.writeAll("const std = @import(\"std\");\n");
     try w.writeAll("const game_mod = @import(\"game\");\n");
     try w.writeAll("const Game = game_mod.Game;\n");
-    try w.writeAll("const EntityId = game_mod.EntityId;\n\n");
+    try w.writeAll("const EntityId = game_mod.EntityId;\n");
+
+    // Component imports: every type-name referenced by a
+    // `GetComponent` or `SetField` node needs a matching
+    // `@import("components/<Name>.zig").<Name>` so the generated
+    // file resolves under the assembler's project layout. We sort
+    // for deterministic output and de-duplicate so a single type
+    // referenced from multiple nodes emits only one import. See
+    // issue #101.
+    const component_types = try collectComponentTypes(allocator, flow);
+    defer allocator.free(component_types);
+    for (component_types) |type_name| {
+        try w.writeAll("const ");
+        try w.writeAll(type_name);
+        try w.writeAll(" = @import(\"");
+        try w.print(components_import_path_fmt, .{type_name});
+        try w.writeAll("\").");
+        try w.writeAll(type_name);
+        try w.writeAll(";\n");
+    }
+    try w.writeAll("\n");
 
     // Function signature, derived from the event variant.
     try writeFnHeader(w, flow.event);
@@ -504,6 +530,52 @@ fn countCallArgs(flow: flow_io.Flow, node_id: u32) usize {
         if (max_idx == null or idx > max_idx.?) max_idx = idx;
     }
     return if (max_idx) |m| m + 1 else 0;
+}
+
+/// Walk the flow's nodes and collect every component type-name
+/// referenced by `GetComponent` (verbatim `type` field) or
+/// `SetField` (the segment of `target` left of the LAST `.`, matching
+/// the split rule used by the `SetField` template — see
+/// `writeNodeBody`). The returned slice is allocated on `allocator`,
+/// is alphabetically sorted, and contains no duplicates so the
+/// caller can emit one `@import` per name with deterministic order.
+///
+/// `SetField.target` values without any `.` are skipped — they're
+/// rejected as `UnknownPin` further down the pipeline, and we don't
+/// want to crash building the import set on a flow that's about to
+/// fail validation anyway.
+fn collectComponentTypes(
+    allocator: std.mem.Allocator,
+    flow: flow_io.Flow,
+) std.mem.Allocator.Error![][]const u8 {
+    var seen = std.StringHashMap(void).init(allocator);
+    defer seen.deinit();
+    var list: std.ArrayList([]const u8) = .{};
+    errdefer list.deinit(allocator);
+
+    for (flow.nodes) |n| {
+        const type_name: ?[]const u8 = switch (n.kind) {
+            .GetComponent => |b| b.type,
+            .SetField => |b| blk: {
+                const dot = std.mem.lastIndexOfScalar(u8, b.target, '.') orelse break :blk null;
+                break :blk b.target[0..dot];
+            },
+            else => null,
+        };
+        if (type_name) |t| {
+            if (t.len == 0) continue;
+            const gop = try seen.getOrPut(t);
+            if (!gop.found_existing) try list.append(allocator, t);
+        }
+    }
+
+    const out = try list.toOwnedSlice(allocator);
+    std.mem.sort([]const u8, out, {}, struct {
+        fn lt(_: void, a: []const u8, b: []const u8) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.lt);
+    return out;
 }
 
 fn anyNodeNeedsEntity(nodes: []const flow_io.Node) bool {

--- a/flow-codegen/src/codegen.zig
+++ b/flow-codegen/src/codegen.zig
@@ -95,6 +95,12 @@ pub const CodegenError = error{
     /// A link names a `to.pin` that isn't part of the consumer
     /// node's input pin signature.
     UnknownPin,
+    /// A `GetComponent` / `SetField` references a type name that
+    /// contains a `.` (namespaced like `foo.bar.Baz`). v1 codegen
+    /// emits `const <Name> = @import(...);` lines for each referenced
+    /// type, and `const foo.bar.Baz = ...` isn't valid Zig. Bare
+    /// component names only for now; namespaced types are a follow-up.
+    NamespacedComponentType,
     /// Future-proofing for additional `NodeKind` variants. v1 never
     /// raises this — every shipped variant has a template.
     UnsupportedNodeKind,
@@ -547,7 +553,7 @@ fn countCallArgs(flow: flow_io.Flow, node_id: u32) usize {
 fn collectComponentTypes(
     allocator: std.mem.Allocator,
     flow: flow_io.Flow,
-) std.mem.Allocator.Error![][]const u8 {
+) (CodegenError || std.mem.Allocator.Error)![][]const u8 {
     var seen = std.StringHashMap(void).init(allocator);
     defer seen.deinit();
     var list: std.ArrayList([]const u8) = .{};
@@ -564,6 +570,11 @@ fn collectComponentTypes(
         };
         if (type_name) |t| {
             if (t.len == 0) continue;
+            // Bare identifiers only — namespaced types (`foo.bar.Baz`)
+            // would emit `const foo.bar.Baz = @import(...);`, which
+            // isn't valid Zig. Surface as a typed error so the
+            // assembler can give a useful diagnostic; tracked for v2.
+            if (std.mem.indexOfScalar(u8, t, '.') != null) return error.NamespacedComponentType;
             const gop = try seen.getOrPut(t);
             if (!gop.found_existing) try list.append(allocator, t);
         }

--- a/flow-codegen/test/root_test.zig
+++ b/flow-codegen/test/root_test.zig
@@ -797,6 +797,50 @@ pub const FlowCodegenTests = struct {
         try expect.toBeTrue(pos_at < vel_at);
     }
 
+    test "namespaced component type name surfaces NamespacedComponentType error" {
+        // Bare identifiers only in v1: `const foo.bar.Baz = @import(...);`
+        // isn't valid Zig, so the codegen must refuse rather than emit
+        // a broken prelude. Tracked for v2.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "foo.bar.Baz" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const result = renderFromZon(allocator, src, "ns");
+        try expect.toBeTrue(if (result) |out| blk: {
+            allocator.free(out);
+            break :blk false;
+        } else |err| err == error.NamespacedComponentType);
+    }
+
+    test "SetField target with multi-dot type name surfaces NamespacedComponentType" {
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1.0" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .SetField = .{ .target = "foo.bar.Baz.x" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "value" }, .to = .{ .node = 2, .pin = "value" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const result = renderFromZon(allocator, src, "ns_sf");
+        try expect.toBeTrue(if (result) |out| blk: {
+            allocator.free(out);
+            break :blk false;
+        } else |err| err == error.NamespacedComponentType);
+    }
+
     test "flow with no component references emits zero component @imports" {
         // Don't leak imports into pure-arithmetic flows -- they'd
         // reference files that don't exist on disk.

--- a/flow-codegen/test/root_test.zig
+++ b/flow-codegen/test/root_test.zig
@@ -676,6 +676,152 @@ pub const FlowCodegenTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, out, "const entity: EntityId = undefined;") != null);
     }
 
+    test "GetComponent node emits component @import in prelude" {
+        // Issue #101: the codegen used to reference `Position` without
+        // importing it, so the emitted file failed to compile.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "imp_gc");
+        defer allocator.free(out);
+
+        const needle = "const Position = @import(\"components/Position.zig\").Position;";
+        try expect.toBeTrue(std.mem.indexOf(u8, out, needle) != null);
+        // Exactly once -- no duplicate emission.
+        var count: usize = 0;
+        var start: usize = 0;
+        while (std.mem.indexOfPos(u8, out, start, needle)) |at| {
+            count += 1;
+            start = at + 1;
+        }
+        try expect.equal(count, @as(usize, 1));
+
+        // And it lands in the prelude, before the function header.
+        const import_at = std.mem.indexOf(u8, out, needle).?;
+        const fn_at = std.mem.indexOf(u8, out, "pub fn onCreate").?;
+        try expect.toBeTrue(import_at < fn_at);
+    }
+
+    test "SetField target extracts type-name with the same split rule as the template" {
+        // The SetField template uses `lastIndexOfScalar('.')` to peel
+        // the type off `target`. The import collector must use the
+        // same split so a target like `Position.x` produces a single
+        // `Position` import that matches the symbol the template
+        // actually references.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "42" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "value" }, .to = .{ .node = 2, .pin = "value" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "imp_sf");
+        defer allocator.free(out);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const Position = @import(\"components/Position.zig\").Position;") != null);
+        // And the SetField template still calls into the same name.
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "game.setField(Position, .x, entity, n1_value);") != null);
+    }
+
+    test "duplicate component references emit exactly one @import" {
+        // Two GetComponent nodes for the same type used to risk
+        // emitting two import lines. The collector de-dupes via a
+        // string set.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\        .{ .id = 3, .pos = .{0, 0}, .kind = .{ .SetField = .{ .target = "Position.x" } } },
+            \\        .{ .id = 4, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "0" } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 4, .pin = "value" }, .to = .{ .node = 3, .pin = "value" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "imp_dup");
+        defer allocator.free(out);
+
+        const needle = "const Position = @import(\"components/Position.zig\").Position;";
+        var count: usize = 0;
+        var start: usize = 0;
+        while (std.mem.indexOfPos(u8, out, start, needle)) |at| {
+            count += 1;
+            start = at + 1;
+        }
+        try expect.equal(count, @as(usize, 1));
+    }
+
+    test "multiple distinct component types emit sorted @import lines" {
+        // Alphabetical order keeps the output byte-stable across
+        // graph re-arrangements -- a `Velocity` node added before a
+        // `Position` node would otherwise flip the prelude.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnCreate = .{ .arg_entity = "entity" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Velocity" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .GetComponent = .{ .type = "Position" } } },
+            \\    },
+            \\    .links = .{},
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "imp_sort");
+        defer allocator.free(out);
+
+        const pos_needle = "const Position = @import(\"components/Position.zig\").Position;";
+        const vel_needle = "const Velocity = @import(\"components/Velocity.zig\").Velocity;";
+        const pos_at = std.mem.indexOf(u8, out, pos_needle) orelse return error.TestExpectedSubstring;
+        const vel_at = std.mem.indexOf(u8, out, vel_needle) orelse return error.TestExpectedSubstring;
+        try expect.toBeTrue(pos_at < vel_at);
+    }
+
+    test "flow with no component references emits zero component @imports" {
+        // Don't leak imports into pure-arithmetic flows -- they'd
+        // reference files that don't exist on disk.
+        const allocator = std.testing.allocator;
+        const src =
+            \\.{
+            \\    .event = .{ .OnUpdate = .{ .arg_dt = "dt" } },
+            \\    .nodes = .{
+            \\        .{ .id = 1, .pos = .{0, 0}, .kind = .{ .Literal = .{ .value = "1.0" } } },
+            \\        .{ .id = 2, .pos = .{0, 0}, .kind = .{ .Identifier = .{ .name = "speed" } } },
+            \\        .{ .id = 3, .pos = .{0, 0}, .kind = .{ .BinOp = .{ .op = .mul } } },
+            \\    },
+            \\    .links = .{
+            \\        .{ .from = .{ .node = 1, .pin = "value" }, .to = .{ .node = 3, .pin = "a" } },
+            \\        .{ .from = .{ .node = 2, .pin = "value" }, .to = .{ .node = 3, .pin = "b" } },
+            \\    },
+            \\}
+            \\
+        ;
+        const out = try renderFromZon(allocator, src, "imp_none");
+        defer allocator.free(out);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "@import(\"components/") == null);
+    }
+
     test "output passes std.zig.Ast.parse without errors" {
         // The single strongest correctness signal -- anything we
         // emit must be syntactically valid Zig.


### PR DESCRIPTION
Closes #101
Part of #96

## Summary

- Walks the flow's nodes once and collects every component type-name referenced by `GetComponent.type` or `SetField.target` (split on the LAST `.` to match the existing `SetField` template's `lastIndexOfScalar` rule).
- Emits one `const <Name> = @import("components/<Name>.zig").<Name>;` per unique name, sorted alphabetically for byte-stable output and de-duplicated via a string set.
- Adds a single `components_import_path_fmt` constant so the path convention (`<project>/components/<name>.zig`) is a one-line change if the assembler's layout ever shifts.

## What's emitted

Before:

```zig
const std = @import("std");
const game_mod = @import("game");
const Game = game_mod.Game;
const EntityId = game_mod.EntityId;

pub fn onCreate(game: *Game, entity: EntityId) void {
    const n1_value = game.getComponent(entity, Position) orelse return;
    game.setField(Position, .x, entity, n2_result);
}
```

After:

```zig
const std = @import("std");
const game_mod = @import("game");
const Game = game_mod.Game;
const EntityId = game_mod.EntityId;
const Position = @import("components/Position.zig").Position;

pub fn onCreate(game: *Game, entity: EntityId) void {
    const n1_value = game.getComponent(entity, Position) orelse return;
    game.setField(Position, .x, entity, n2_result);
}
```

Two components, sorted:

```zig
const Position = @import("components/Position.zig").Position;
const Velocity = @import("components/Velocity.zig").Velocity;
```

## Tests

Five new test cases under `FlowCodegenTests` (34 of 34 in the sub-package pass):

1. `GetComponent` emits a single `@import` for its type in the prelude, before the `pub fn` header.
2. `SetField` with `target = "Position.x"` extracts `Position` using the same `lastIndexOfScalar` rule the template uses, and the existing `game.setField(Position, .x, entity, ...)` call resolves.
3. Two `GetComponent` nodes for the same type emit exactly one `@import` (de-duplication).
4. Two `GetComponent` nodes for distinct types emit both lines in alphabetical order (`Position` before `Velocity`), independent of node id order.
5. A flow with no component-touching nodes emits zero `@import("components/...")` lines (no spurious imports).
6. The existing `output passes std.zig.Ast.parse without errors` test still passes — covers syntactic validity of the new prelude.

The companion `labelle-assembler#117` binds the `"game"` module so a real `.flow.zon` will now compile end-to-end once both land.

## Test plan

- [x] `zig build test` in `flow-codegen/` — 34 of 34 tests pass (was 29, added 5).
- [x] `zig build test` at the `labelle-gui` repo root — 181 of 181 tests pass.
- [x] `zig build` clean at the repo root.
- [ ] Reviewer: spot-check the generated prelude against the assembler's project layout once `labelle-assembler#117` lands.

## Out of scope

- Resolving non-component identifiers (`Identifier` / `Call` callees) — separate model needed, tracked elsewhere.
- Configurable import paths — `components/<Name>.zig` is hardcoded behind a single constant for now.