### PR TITLE
feat(gui): Game View panel — SHM consumer + ImGui::Image (#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
           ref: feat/544-pbo-shm-publish
           path: labelle-engine
 
+      - name: Checkout labelle-core sibling
+        uses: actions/checkout@v4
+        with:
+          repository: labelle-toolkit/labelle-core
+          ref: main
+          path: labelle-core
+
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,29 @@ jobs:
     runs-on: ubuntu-latest
     name: Build & Unit Tests (Linux)
 
+    # build.zig.zon depends on `../labelle-engine` (#107 — PIE
+    # viewport). Both checkouts go into named subdirs so the sibling
+    # path resolves; all `run:` steps live inside labelle-gui via
+    # `defaults.run.working-directory`.
+    defaults:
+      run:
+        working-directory: labelle-gui
+
     steps:
-      - name: Checkout
+      - name: Checkout labelle-gui
         uses: actions/checkout@v4
+        with:
+          path: labelle-gui
+
+      - name: Checkout labelle-engine sibling
+        uses: actions/checkout@v4
+        with:
+          repository: labelle-toolkit/labelle-engine
+          # Pinned to the feat/544 branch until labelle-engine#545
+          # and #546 merge to main. Flip this to `main` (or a tag)
+          # once both PRs land.
+          ref: feat/544-pbo-shm-publish
+          path: labelle-engine
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
@@ -29,8 +49,8 @@ jobs:
         with:
           path: |
             ~/.cache/zig
-            .zig-cache
-          key: zig-${{ runner.os }}-${{ hashFiles('build.zig.zon', 'build.zig') }}
+            labelle-gui/.zig-cache
+          key: zig-${{ runner.os }}-${{ hashFiles('labelle-gui/build.zig.zon', 'labelle-gui/build.zig') }}
           restore-keys: |
             zig-${{ runner.os }}-
 
@@ -56,7 +76,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: labelle-gui-Linux
-          path: zig-out/bin/
+          # `working-directory` doesn't apply to `uses:` action steps,
+          # so the path needs the explicit prefix.
+          path: labelle-gui/zig-out/bin/
           if-no-files-found: error
 
   # ImGui Test Engine harness — downloads the gui-tests binary built by

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: labelle-toolkit/labelle-engine
-          # Pinned to the feat/544 branch until labelle-engine#545
-          # and #546 merge to main. Flip this to `main` (or a tag)
-          # once both PRs land.
-          ref: feat/544-pbo-shm-publish
+          ref: main
           path: labelle-engine
 
       - name: Checkout labelle-core sibling

--- a/build.zig
+++ b/build.zig
@@ -49,6 +49,17 @@ pub fn build(b: *std.Build) void {
     });
     const flow_codegen_module = flow_codegen.module("flow_codegen");
 
+    // labelle-engine — for the PIE viewport (#107). We pull the
+    // engine in solely for `preview_mode.preview_shm.Consumer`
+    // (cross-process pixel ring reader) and the protocol types.
+    // The engine's own deps (labelle-core etc.) come along for the
+    // ride but the editor only links the preview surface.
+    const engine = b.dependency("engine", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const engine_module = engine.module("engine");
+
     // Main executable
     const exe = b.addExecutable(.{
         .name = "labelle-gui",
@@ -72,6 +83,8 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addImport("zstbi", zstbi.module("root"));
 
     exe.root_module.addImport("flow_codegen", flow_codegen_module);
+
+    exe.root_module.addImport("engine", engine_module);
 
     // Windows-specific: embed DPI awareness manifest
     if (target.result.os.tag == .windows) {
@@ -105,6 +118,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "zopengl", .module = zopengl.module("root") },
                 .{ .name = "zstbi", .module = zstbi.module("root") },
                 .{ .name = "flow_codegen", .module = flow_codegen_module },
+                .{ .name = "engine", .module = engine_module },
             },
         }),
         .test_runner = .{ .path = zspec.path("src/runner.zig"), .mode = .simple },
@@ -153,6 +167,7 @@ pub fn build(b: *std.Build) void {
     // as soon as the previously-dead `Callbacks.gui` / `Callbacks.run`
     // bodies start being analyzed.
     gui_tests_exe.root_module.addImport("nfd", nfd.module("nfd"));
+    gui_tests_exe.root_module.addImport("engine", engine_module);
 
     const run_gui_tests = b.addRunArtifact(gui_tests_exe);
     const gui_test_step = b.step("gui-test", "Run the UI test runner");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,6 +31,16 @@
         .flow_codegen = .{
             .path = "flow-codegen",
         },
+        // labelle-engine pinned at the open feat/544 branch for the
+        // PIE viewport work (#107). The engine ships `preview_mode`
+        // (protocol API) and `preview_mode.preview_shm` (cross-
+        // process SHM ring consumer) — the editor's Game View module
+        // wraps `preview_shm.Consumer` to display engine-rendered
+        // frames inside an ImGui::Image panel. Flip this to a tag
+        // (e.g. v1.37.2) once labelle-engine#545 and #546 merge.
+        .engine = .{
+            .path = "../labelle-engine",
+        },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,13 +31,13 @@
         .flow_codegen = .{
             .path = "flow-codegen",
         },
-        // labelle-engine pinned at the open feat/544 branch for the
-        // PIE viewport work (#107). The engine ships `preview_mode`
-        // (protocol API) and `preview_mode.preview_shm` (cross-
-        // process SHM ring consumer) — the editor's Game View module
-        // wraps `preview_shm.Consumer` to display engine-rendered
-        // frames inside an ImGui::Image panel. Flip this to a tag
-        // (e.g. v1.37.2) once labelle-engine#545 and #546 merge.
+        // labelle-engine via sibling-path dep — same pattern
+        // labelle-assembler uses for `../labelle-gui/flow-codegen`.
+        // Dev-time and CI both check out the engine as a sibling
+        // (see `.github/workflows/ci.yml`). Release builds swap in
+        // a `git+https://...?ref=vX.Y.Z#<hash>` pin at build time;
+        // the path here is the dev-time default, not the source of
+        // truth for shipped binaries.
         .engine = .{
             .path = "../labelle-engine",
         },

--- a/src/app.zig
+++ b/src/app.zig
@@ -26,6 +26,9 @@ const prefab_mod = @import("modules/prefab.zig");
 const flow_mod = @import("modules/flow.zig");
 const gizmo_mod = @import("modules/gizmo.zig");
 const entity_inspector_mod = @import("modules/entity_inspector.zig");
+const game_view_mod = @import("modules/game_view.zig");
+const game_view = @import("game_view.zig");
+const io_global = @import("io_global.zig");
 const flow_runtime_mod = @import("modules/flow_runtime.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
 const atlas = @import("atlas.zig");
@@ -140,6 +143,14 @@ pub const App = struct {
     /// pointer; clicking Run preview also force-opens it.
     show_preview: bool = false,
 
+    /// Game View panel state (#107). Owns the SHM consumer + GL
+    /// texture for the live game frames. Toggleable from the View
+    /// menu; until the editor-side preview transport is restored
+    /// (separate follow-up), the consumer is attached either via
+    /// `App.attachGameView` or the `LABELLE_GAME_VIEW_SHM` env var.
+    show_game_view: bool = false,
+    game_view: game_view.GameView = undefined,
+
     /// Phase 3 (#84): Entity Inspector panel toggle.
     show_entity_inspector: bool = false,
     /// Entity Inspector state — fed by `PreviewSession`'s
@@ -229,7 +240,7 @@ pub const App = struct {
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [7]module.Module = undefined,
+    modules: [8]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -245,6 +256,7 @@ pub const App = struct {
             .tree_view = tree_view.TreeView.init(allocator),
             .compiler = compiler.Compiler.init(allocator),
             .preview = preview.PreviewSession.init(allocator),
+            .game_view = game_view.GameView.init(allocator),
             .prefs = user_prefs,
             .startup_prefs = user_prefs,
         };
@@ -298,7 +310,29 @@ pub const App = struct {
         app.modules[4] = preview_mod.makeModule(app);
         app.modules[5] = entity_inspector_mod.makeModule(app);
         app.modules[6] = flow_runtime_mod.makeModule(app);
+        app.modules[7] = game_view_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
+
+        // Honor LABELLE_GAME_VIEW_SHM as a manual attach path until
+        // the preview-transport restore wires this up automatically.
+        // Empty / unset → no attach. Lookup errors (missing region,
+        // bad magic) are logged but don't fail App.init — the user
+        // can still drive the editor without preview. GameView.attach
+        // dupes the name into its own buffer so the env-var string
+        // can be freed immediately.
+        if (io_global.environ().getAlloc(allocator, "LABELLE_GAME_VIEW_SHM") catch null) |raw| {
+            defer allocator.free(raw);
+            if (raw.len > 0) {
+                const shm_name_z = allocator.dupeZ(u8, raw) catch null;
+                if (shm_name_z) |z| {
+                    defer allocator.free(z);
+                    app.game_view.attach(z) catch |err| {
+                        std.log.warn("game_view: attach('{s}') failed: {s}", .{ z, @errorName(err) });
+                    };
+                    if (app.game_view.isAttached()) app.show_game_view = true;
+                }
+            }
+        }
 
         return app;
     }
@@ -318,7 +352,19 @@ pub const App = struct {
         self.tree_view.deinit();
         self.compiler.deinit();
         self.preview.deinit();
+        self.game_view.deinit();
         self.allocator.destroy(self);
+    }
+
+    /// Open the SHM region the engine advertised in `frame_offer`
+    /// (#107). Convenience wrapper that surfaces the panel
+    /// automatically on a successful attach. Used both by the
+    /// LABELLE_GAME_VIEW_SHM startup hook and by external test
+    /// code; will also be the seam the eventual preview-transport
+    /// restore plugs into.
+    pub fn attachGameView(self: *Self, shm_name: [:0]const u8) !void {
+        try self.game_view.attach(shm_name);
+        self.show_game_view = true;
     }
 
     /// Rebuild the atlas index from the active project's

--- a/src/app.zig
+++ b/src/app.zig
@@ -318,19 +318,14 @@ pub const App = struct {
         // Empty / unset → no attach. Lookup errors (missing region,
         // bad magic) are logged but don't fail App.init — the user
         // can still drive the editor without preview. GameView.attach
-        // dupes the name into its own buffer so the env-var string
-        // can be freed immediately.
+        // dupes the name into its own buffer.
         if (io_global.environ().getAlloc(allocator, "LABELLE_GAME_VIEW_SHM") catch null) |raw| {
             defer allocator.free(raw);
             if (raw.len > 0) {
-                const shm_name_z = allocator.dupeZ(u8, raw) catch null;
-                if (shm_name_z) |z| {
-                    defer allocator.free(z);
-                    app.game_view.attach(z) catch |err| {
-                        std.log.warn("game_view: attach('{s}') failed: {s}", .{ z, @errorName(err) });
-                    };
-                    if (app.game_view.isAttached()) app.show_game_view = true;
-                }
+                app.game_view.attach(raw) catch |err| {
+                    std.log.warn("game_view: attach('{s}') failed: {s}", .{ raw, @errorName(err) });
+                };
+                if (app.game_view.isAttached()) app.show_game_view = true;
             }
         }
 
@@ -362,7 +357,7 @@ pub const App = struct {
     /// LABELLE_GAME_VIEW_SHM startup hook and by external test
     /// code; will also be the seam the eventual preview-transport
     /// restore plugs into.
-    pub fn attachGameView(self: *Self, shm_name: [:0]const u8) !void {
+    pub fn attachGameView(self: *Self, shm_name: []const u8) !void {
         try self.game_view.attach(shm_name);
         self.show_game_view = true;
     }

--- a/src/game_view.zig
+++ b/src/game_view.zig
@@ -31,8 +31,9 @@ const latency_ring_capacity: usize = 120;
 
 /// Errors specific to `GameView.attach`. SHM-open / mmap failures
 /// from `preview_shm.Consumer.init` (`error.ShmOpenFailed`, etc.)
-/// propagate verbatim.
-pub const AttachError = shm.Error || error{AlreadyAttached};
+/// propagate verbatim; the shm_name-dupe step folds into
+/// `error.OutOfMemory`.
+pub const AttachError = shm.Error || error{OutOfMemory};
 
 pub const GameView = struct {
     allocator: std.mem.Allocator,
@@ -51,11 +52,15 @@ pub const GameView = struct {
     tex_id: gl.Uint = 0,
     tex_w: u32 = 0,
     tex_h: u32 = 0,
-    /// Monotonic — the frame_idx the texture currently contains.
-    /// Test code reads this to assert "the editor is presenting new
-    /// frames" without ever inspecting pixels (the zgui binding
-    /// doesn't expose `ImGuiTestEngine_CaptureScreenshot`).
-    last_frame_idx: u64 = 0,
+    /// `null` before the first frame is uploaded; the frame_idx of
+    /// the texture's current contents once a frame has been seen.
+    /// Optional so a producer frame_idx of 0 doesn't collide with
+    /// the "no frame received yet" sentinel — drops would otherwise
+    /// undercount on the very first frame of a session (#111
+    /// review). Test code reads this to assert "the editor is
+    /// presenting new frames" without ever inspecting pixels (the
+    /// zgui binding doesn't expose `ImGuiTestEngine_CaptureScreenshot`).
+    last_frame_idx: ?u64 = null,
     last_latency_ns: u64 = 0,
     /// Frames the producer outran us on — `frame.frame_idx -
     /// prior_idx - 1` summed over the session.
@@ -84,10 +89,14 @@ pub const GameView = struct {
     /// session and stand up a matching `GL_TEXTURE_2D`. The GL
     /// context must be current on the calling thread (which it
     /// always is on the main thread for labelle-gui's frame loop).
-    pub fn attach(self: *Self, shm_name: [:0]const u8) AttachError!void {
-        if (self.consumer != null) return error.AlreadyAttached;
+    pub fn attach(self: *Self, shm_name: []const u8) AttachError!void {
+        // Auto-detach any prior session — the engine emits a fresh
+        // `frame_offer` on resize / restart, and forcing the caller
+        // to manually detach first would block routine resolution
+        // changes (#111 review).
+        if (self.consumer != null) self.detach();
 
-        const owned = self.allocator.dupeZ(u8, shm_name) catch return error.MmapFailed;
+        const owned = self.allocator.dupeZ(u8, shm_name) catch return error.OutOfMemory;
         errdefer self.allocator.free(owned);
 
         var consumer = try shm.Consumer.init(owned);
@@ -125,7 +134,7 @@ pub const GameView = struct {
         self.tex_id = tex;
         self.tex_w = w;
         self.tex_h = h;
-        self.last_frame_idx = 0;
+        self.last_frame_idx = null;
         self.last_latency_ns = 0;
         self.dropped = 0;
         self.presented = 0;
@@ -184,12 +193,14 @@ pub const GameView = struct {
             frame.pixels,
         );
 
-        // Drop accounting: how many producer frames did we skip
-        // between `last_frame_idx` and this one? First frame after
-        // attach has `last_frame_idx == 0` so the gap-from-zero math
-        // is correct.
-        if (self.last_frame_idx > 0 and frame.frame_idx > self.last_frame_idx + 1) {
-            self.dropped += frame.frame_idx - self.last_frame_idx - 1;
+        // Drop accounting: count producer frames we skipped between
+        // the previous frame and this one. First frame after attach
+        // (`last_frame_idx == null`) sets the counter but doesn't
+        // count gaps — we have no prior baseline.
+        if (self.last_frame_idx) |prior| {
+            if (frame.frame_idx > prior + 1) {
+                self.dropped += frame.frame_idx - prior - 1;
+            }
         }
         self.last_frame_idx = frame.frame_idx;
 

--- a/src/game_view.zig
+++ b/src/game_view.zig
@@ -1,0 +1,216 @@
+//! Embedded game-view panel state.
+//!
+//! Owns the consumer side of the PIE viewport pixel ring: opens an
+//! `engine.preview_mode.preview_shm.Consumer` against a SHM region
+//! the engine allocated, mirrors each new frame into a `GL_TEXTURE_2D`
+//! via `glTexSubImage2D`, and tracks end-to-end latency for the
+//! Stats overlay.
+//!
+//! Pairs with `src/modules/game_view.zig` — that file wraps this
+//! state in a togglable ImGui panel and registers it with the
+//! Module Registry. This file is UI-free so the texture / consumer
+//! lifecycle is testable headless.
+//!
+//! Architecture validated end-to-end in `imgui-preview-poc/src/editor.zig`
+//! at 1280×720@60 with raw-IPC p50=5µs on Apple Silicon. This module
+//! is a direct port of that pattern, minus the PoC's standalone
+//! GLFW window since labelle-gui's frame loop already owns the GL
+//! context.
+//!
+//! See labelle-engine#544 for the producer side and the protocol
+//! handshake (#543) that delivers `frame_offer` payloads.
+
+const std = @import("std");
+const zopengl = @import("zopengl");
+const engine = @import("engine");
+const shm = engine.preview_mode_mod.preview_shm;
+
+const gl = zopengl.bindings;
+
+const latency_ring_capacity: usize = 120;
+
+/// Errors specific to `GameView.attach`. SHM-open / mmap failures
+/// from `preview_shm.Consumer.init` (`error.ShmOpenFailed`, etc.)
+/// propagate verbatim.
+pub const AttachError = shm.Error || error{AlreadyAttached};
+
+pub const GameView = struct {
+    allocator: std.mem.Allocator,
+    /// `null` until `attach` opens a consumer.
+    consumer: ?shm.Consumer = null,
+    /// Owned (allocator-allocated, NUL-terminated) duplicate of the
+    /// shm_name passed to `attach`. `engine.preview_shm.Consumer`
+    /// stashes the name slice and we want a stable pointer for the
+    /// lifetime of the consumer — caller-provided buffers might be
+    /// stack-allocated or env-var scratch space.
+    owned_shm_name: ?[:0]u8 = null,
+    /// GL texture handle for the displayed frame. Zero when no texture
+    /// is currently allocated. Width/height kept alongside so a
+    /// frame_resize landed on the SHM ring lets us re-allocate the
+    /// texture instead of misaligned `glTexSubImage2D` uploads.
+    tex_id: gl.Uint = 0,
+    tex_w: u32 = 0,
+    tex_h: u32 = 0,
+    /// Monotonic — the frame_idx the texture currently contains.
+    /// Test code reads this to assert "the editor is presenting new
+    /// frames" without ever inspecting pixels (the zgui binding
+    /// doesn't expose `ImGuiTestEngine_CaptureScreenshot`).
+    last_frame_idx: u64 = 0,
+    last_latency_ns: u64 = 0,
+    /// Frames the producer outran us on — `frame.frame_idx -
+    /// prior_idx - 1` summed over the session.
+    dropped: u64 = 0,
+    /// Frames uploaded by `poll`. Bumps once per successful texture
+    /// upload — used for the FPS reading on the Stats overlay.
+    presented: u64 = 0,
+    /// Circular buffer of recent end-to-end latency samples in ns.
+    /// Sized to 120 — at 60 Hz that's a 2-second window which is
+    /// sticky enough to read on screen without averaging away spikes.
+    latency_ring: [latency_ring_capacity]u64 = [_]u64{0} ** latency_ring_capacity,
+    latency_head: usize = 0,
+    latency_count: usize = 0,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.detach();
+    }
+
+    /// Open the named SHM region the engine allocated for this
+    /// session and stand up a matching `GL_TEXTURE_2D`. The GL
+    /// context must be current on the calling thread (which it
+    /// always is on the main thread for labelle-gui's frame loop).
+    pub fn attach(self: *Self, shm_name: [:0]const u8) AttachError!void {
+        if (self.consumer != null) return error.AlreadyAttached;
+
+        const owned = self.allocator.dupeZ(u8, shm_name) catch return error.MmapFailed;
+        errdefer self.allocator.free(owned);
+
+        var consumer = try shm.Consumer.init(owned);
+        errdefer consumer.deinit();
+
+        const w = consumer.header.width;
+        const h = consumer.header.height;
+
+        // Build a zero-initialized texture; per-frame uploads will
+        // `glTexSubImage2D` into it. `GL_RGBA8` matches the SHM's
+        // RGBA8 pixel format. `GL_CLAMP_TO_EDGE` avoids edge-bleed
+        // when the panel renders the texture at a non-integer
+        // scale.
+        var tex: gl.Uint = 0;
+        gl.genTextures(1, &tex);
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA8,
+            @intCast(w),
+            @intCast(h),
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            null,
+        );
+
+        self.consumer = consumer;
+        self.owned_shm_name = owned;
+        self.tex_id = tex;
+        self.tex_w = w;
+        self.tex_h = h;
+        self.last_frame_idx = 0;
+        self.last_latency_ns = 0;
+        self.dropped = 0;
+        self.presented = 0;
+        self.latency_head = 0;
+        self.latency_count = 0;
+    }
+
+    /// Tear down the consumer + GL texture. Safe to call when not
+    /// attached; called by `deinit`.
+    pub fn detach(self: *Self) void {
+        if (self.consumer) |*c| {
+            c.deinit();
+            self.consumer = null;
+        }
+        if (self.owned_shm_name) |n| {
+            self.allocator.free(n);
+            self.owned_shm_name = null;
+        }
+        if (self.tex_id != 0) {
+            gl.deleteTextures(1, &self.tex_id);
+            self.tex_id = 0;
+        }
+        self.tex_w = 0;
+        self.tex_h = 0;
+    }
+
+    pub fn isAttached(self: *const Self) bool {
+        return self.consumer != null;
+    }
+
+    /// Poll the SHM ring for a newer frame. If one is available,
+    /// upload it to the texture and update the stats. Call once per
+    /// editor frame from the main loop.
+    ///
+    /// Returns true when a new frame was uploaded — handy for tests
+    /// + future "redraw only on new frame" optimization.
+    pub fn poll(self: *Self) bool {
+        const consumer = if (self.consumer) |*c| c else return false;
+        const frame = consumer.latest() orelse return false;
+
+        // Defensive: producer's resize should have triggered a re-
+        // attach (engine sends a fresh `frame_offer` on resize) but
+        // skip mid-resize frames just in case.
+        if (frame.width != self.tex_w or frame.height != self.tex_h) return false;
+
+        gl.bindTexture(gl.TEXTURE_2D, self.tex_id);
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            @intCast(frame.width),
+            @intCast(frame.height),
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            frame.pixels,
+        );
+
+        // Drop accounting: how many producer frames did we skip
+        // between `last_frame_idx` and this one? First frame after
+        // attach has `last_frame_idx == 0` so the gap-from-zero math
+        // is correct.
+        if (self.last_frame_idx > 0 and frame.frame_idx > self.last_frame_idx + 1) {
+            self.dropped += frame.frame_idx - self.last_frame_idx - 1;
+        }
+        self.last_frame_idx = frame.frame_idx;
+
+        const now_ns = shm.nowNs();
+        if (now_ns > frame.produce_ns) {
+            self.last_latency_ns = now_ns - frame.produce_ns;
+            self.latency_ring[self.latency_head] = self.last_latency_ns;
+            self.latency_head = (self.latency_head + 1) % latency_ring_capacity;
+            if (self.latency_count < latency_ring_capacity) self.latency_count += 1;
+        }
+        self.presented += 1;
+        return true;
+    }
+
+    /// Mean end-to-end latency in nanoseconds over the most recent
+    /// `latency_ring_capacity` samples. Returns 0 before the first
+    /// frame is uploaded.
+    pub fn meanLatencyNs(self: *const Self) u64 {
+        if (self.latency_count == 0) return 0;
+        var sum: u128 = 0;
+        for (self.latency_ring[0..self.latency_count]) |v| sum += v;
+        return @intCast(sum / @as(u128, self.latency_count));
+    }
+};

--- a/src/modules/game_view.zig
+++ b/src/modules/game_view.zig
@@ -1,0 +1,123 @@
+//! Game View panel — renders the live game frames the engine is
+//! streaming through the PIE viewport pixel ring (#107).
+//!
+//! Two ImGui windows, both gated on `app.show_game_view`:
+//!
+//!   - "Game View"    : `zgui.image(...)` of the frame texture,
+//!                      aspect-fit inside the available content
+//!                      region.
+//!   - "Game Stats"   : last/avg latency, presented FPS, dropped
+//!                      frames, producer frame index.
+//!
+//! When the panel is open but the consumer hasn't attached yet,
+//! the "Game View" window shows a paragraph explaining how to
+//! attach — currently a manual hand-off via `App.attachGameView`
+//! (or the `LABELLE_GAME_VIEW_SHM` environment variable on
+//! startup). Auto-attach from a live `PreviewSession` is the
+//! follow-up ticket (#107's body notes the existing transport
+//! is stubbed pending #543/#544 merge).
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "game_view",
+        .display_name = "Game View",
+        .is_open = &app.show_game_view,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    // Drive the upload first so the stats window reads fresh values.
+    _ = app.game_view.poll();
+
+    renderViewport(app);
+    renderStats(app);
+}
+
+fn renderViewport(app: *App) void {
+    zgui.setNextWindowSize(.{ .w = 720, .h = 460, .cond = .first_use_ever });
+    if (!zgui.begin("Game View", .{ .popen = &app.show_game_view, .flags = .{} })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    if (!app.game_view.isAttached()) {
+        zgui.textWrapped(
+            \\No engine attached.
+            \\
+            \\To watch a running game, either set the
+            \\LABELLE_GAME_VIEW_SHM environment variable to the
+            \\SHM name advertised in the engine's `frame_offer`
+            \\and restart the editor, or call
+            \\`App.attachGameView` from your wiring.
+            \\
+            \\Auto-attach from a live `PreviewSession` is tracked
+            \\as a follow-up — the preview transport itself is
+            \\currently stubbed (zig-0.16 migration).
+            ,
+            .{},
+        );
+        return;
+    }
+
+    const avail = zgui.getContentRegionAvail();
+    const src_w: f32 = @floatFromInt(app.game_view.tex_w);
+    const src_h: f32 = @floatFromInt(app.game_view.tex_h);
+    // Aspect-fit inside the available content region; centre the
+    // image rather than stretching to the panel dimensions.
+    const aspect_src = src_w / src_h;
+    const aspect_avail = avail[0] / avail[1];
+    var draw_w: f32 = avail[0];
+    var draw_h: f32 = avail[1];
+    if (aspect_src > aspect_avail) {
+        draw_h = avail[0] / aspect_src;
+    } else {
+        draw_w = avail[1] * aspect_src;
+    }
+    // Centre with an InvisibleButton offset before the image.
+    const dx = (avail[0] - draw_w) * 0.5;
+    const dy = (avail[1] - draw_h) * 0.5;
+    if (dx > 0 or dy > 0) {
+        const cur = zgui.getCursorPos();
+        zgui.setCursorPos(.{ cur[0] + dx, cur[1] + dy });
+    }
+
+    const tex_ref: zgui.TextureRef = .{
+        .tex_data = null,
+        .tex_id = @enumFromInt(@as(u64, app.game_view.tex_id)),
+    };
+    zgui.image(tex_ref, .{ .w = draw_w, .h = draw_h });
+}
+
+fn renderStats(app: *App) void {
+    zgui.setNextWindowSize(.{ .w = 280, .h = 180, .cond = .first_use_ever });
+    if (!zgui.begin("Game Stats", .{ .popen = &app.show_game_view, .flags = .{} })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    if (!app.game_view.isAttached()) {
+        zgui.text("Not attached.", .{});
+        return;
+    }
+
+    const ns_per_ms: f64 = 1_000_000.0;
+    const last_ms: f64 = @as(f64, @floatFromInt(app.game_view.last_latency_ns)) / ns_per_ms;
+    const mean_ms: f64 = @as(f64, @floatFromInt(app.game_view.meanLatencyNs())) / ns_per_ms;
+
+    zgui.text("frame_idx = {d}", .{app.game_view.last_frame_idx});
+    zgui.text("presented = {d}", .{app.game_view.presented});
+    zgui.text("dropped   = {d}", .{app.game_view.dropped});
+    zgui.text("dims      = {d}x{d}", .{ app.game_view.tex_w, app.game_view.tex_h });
+    zgui.separator();
+    zgui.text("last latency  = {d:.2} ms", .{last_ms});
+    zgui.text("avg latency   = {d:.2} ms ({d} samples)", .{ mean_ms, app.game_view.latency_count });
+}

--- a/src/modules/game_view.zig
+++ b/src/modules/game_view.zig
@@ -70,16 +70,26 @@ fn renderViewport(app: *App) void {
     const avail = zgui.getContentRegionAvail();
     const src_w: f32 = @floatFromInt(app.game_view.tex_w);
     const src_h: f32 = @floatFromInt(app.game_view.tex_h);
+    // Guard the aspect-fit divisions: a tiny / collapsed window can
+    // give a zero `avail[]`, and a malformed SHM header could (in
+    // theory) hand us zero dims. Either lands NaN/inf in
+    // `draw_w` / `draw_h` and inside `zgui.image` (#111 review).
+    // Floor each dimension at 1 px so the math is well-defined; the
+    // resulting image is invisible but the panel keeps rendering.
+    const safe_src_w = @max(src_w, 1.0);
+    const safe_src_h = @max(src_h, 1.0);
+    const safe_avail_w = @max(avail[0], 1.0);
+    const safe_avail_h = @max(avail[1], 1.0);
     // Aspect-fit inside the available content region; centre the
     // image rather than stretching to the panel dimensions.
-    const aspect_src = src_w / src_h;
-    const aspect_avail = avail[0] / avail[1];
-    var draw_w: f32 = avail[0];
-    var draw_h: f32 = avail[1];
+    const aspect_src = safe_src_w / safe_src_h;
+    const aspect_avail = safe_avail_w / safe_avail_h;
+    var draw_w: f32 = safe_avail_w;
+    var draw_h: f32 = safe_avail_h;
     if (aspect_src > aspect_avail) {
-        draw_h = avail[0] / aspect_src;
+        draw_h = safe_avail_w / aspect_src;
     } else {
-        draw_w = avail[1] * aspect_src;
+        draw_w = safe_avail_h * aspect_src;
     }
     // Centre with an InvisibleButton offset before the image.
     const dx = (avail[0] - draw_w) * 0.5;
@@ -113,7 +123,10 @@ fn renderStats(app: *App) void {
     const last_ms: f64 = @as(f64, @floatFromInt(app.game_view.last_latency_ns)) / ns_per_ms;
     const mean_ms: f64 = @as(f64, @floatFromInt(app.game_view.meanLatencyNs())) / ns_per_ms;
 
-    zgui.text("frame_idx = {d}", .{app.game_view.last_frame_idx});
+    if (app.game_view.last_frame_idx) |idx|
+        zgui.text("frame_idx = {d}", .{idx})
+    else
+        zgui.text("frame_idx = (waiting for first frame)", .{});
     zgui.text("presented = {d}", .{app.game_view.presented});
     zgui.text("dropped   = {d}", .{app.game_view.dropped});
     zgui.text("dims      = {d}x{d}", .{ app.game_view.tex_w, app.game_view.tex_h });

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -18,6 +18,7 @@ const flow_projector = @import("flows/projector.zig");
 const flow_types = @import("flows/types.zig");
 const prefs = @import("prefs.zig");
 const io_global = @import("io_global.zig");
+const game_view = @import("game_view.zig");
 
 /// Wall-clock seconds since the Unix epoch; replacement for the
 /// `std.time.timestamp` helper removed in Zig 0.16. Used only to
@@ -2898,5 +2899,40 @@ pub const PreferencesTests = struct {
 
         const loaded = prefs.loadFromPath(std.testing.allocator, path);
         try expect.equal(loaded.font_scale, prefs.default_font_scale);
+    }
+};
+
+pub const GameViewLatencyTests = struct {
+    // GameView.meanLatencyNs is pure math over its latency_ring; no
+    // GL context needed. Compose the struct manually to test the
+    // bookkeeping in isolation. attach()/poll() are exercised
+    // end-to-end in the gui-tests TE binary (display + headless GL).
+
+    test "meanLatencyNs returns 0 before any samples" {
+        var gv = game_view.GameView.init(std.testing.allocator);
+        defer gv.deinit();
+        try expect.equal(gv.meanLatencyNs(), @as(u64, 0));
+    }
+
+    test "meanLatencyNs averages every populated slot" {
+        var gv = game_view.GameView.init(std.testing.allocator);
+        defer gv.deinit();
+        gv.latency_ring[0] = 1_000_000;
+        gv.latency_ring[1] = 2_000_000;
+        gv.latency_ring[2] = 3_000_000;
+        gv.latency_count = 3;
+        // (1 + 2 + 3) / 3 == 2 ms.
+        try expect.equal(gv.meanLatencyNs(), @as(u64, 2_000_000));
+    }
+
+    test "meanLatencyNs uses latency_count, not the full capacity" {
+        // Guards against averaging across uninitialized slots after a
+        // fresh attach but before the ring fills.
+        var gv = game_view.GameView.init(std.testing.allocator);
+        defer gv.deinit();
+        gv.latency_ring[0] = 5_000_000;
+        // Slots [1..120) are zero-initialized; only slot 0 counts.
+        gv.latency_count = 1;
+        try expect.equal(gv.meanLatencyNs(), @as(u64, 5_000_000));
     }
 };


### PR DESCRIPTION
Implements gui#107. Depends on labelle-engine#545 (handshake) and #546 (SHM publish) — both open. The `build.zig.zon` `engine` dep is pinned to `local:../labelle-engine` and the CI checks out the engine's `feat/544-pbo-shm-publish` branch as a sibling. Flip both pins to a tag (or main+path) once the engine PRs merge.

## What this adds

| File | Role |
|---|---|
| `src/game_view.zig` | UI-free state. Wraps `engine.preview_mode.preview_shm.Consumer`; owns the `GL_TEXTURE_2D`; per-frame poll + `glTexSubImage2D` upload; 120-sample latency ring; drop counter. |
| `src/modules/game_view.zig` | Two ImGui windows ("Game View" + "Game Stats"), aspect-fit image render via the post-ImGui-1.92 `zgui.TextureRef { tex_data=null, tex_id=@enumFromInt(...) }` shape. |
| `App.attachGameView(shm_name)` | Convenience seam: opens the consumer + surfaces the panel. |
| `LABELLE_GAME_VIEW_SHM` env hook | Manual attach path until the preview transport restore lands — set the env var, the editor opens the matching shm region on startup. |

## What this **doesn't** do (deferred)

1. **Auto-attach from a live `PreviewSession`.** `src/preview.zig` has been a stub since the Zig 0.16 migration. Restoring it (TCP listener, `frame_offer` decode → `App.attachGameView`) is its own ticket — will file as a blocker on full end-to-end. For now the panel is testable headless + via `LABELLE_GAME_VIEW_SHM=/<name>` against a running engine binary.
2. **TE coverage** — that's #109. Adding tests requires #106 (the non-pub-fn TE-callback fix) to merge first; the chrome assertions are straightforward once the test runner actually runs the registered callbacks.
3. **macOS IOSurface fast path** — that's #108. SHM-with-glTexSubImage2D-upload is the baseline; iosurface drops the consumer-side copy. Validated in the PoC at `imgui-preview-poc/`; integration is a separate ticket.

## Test plan

- [x] 3 new `GameViewLatencyTests` in `src/tests.zig` covering pure math (`meanLatencyNs` zero-sample, fully-populated, partial-ring). 165/165 zspec pass.
- [x] `zig build` clean — production binary compiles with the new module + dep.
- [x] `zig build gui-test-build` clean — the with-TE variant also picks up the engine dep.
- [ ] CI confirmation after push.
- [ ] Manual end-to-end against a running engine binary using `LABELLE_GAME_VIEW_SHM=...`. Deferred (no engine binary running locally during PR drafting); the architecture is the same one validated in `imgui-preview-poc/` at 210 MB/s @ 1280×720@60 raw IPC p50=5µs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)