### PR TITLE
chore: promote engine CI ref to main (post #545/#546 merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
           ref: feat/544-pbo-shm-publish
           path: labelle-engine
 
+      - name: Checkout labelle-core sibling
+        uses: actions/checkout@v4
+        with:
+          repository: labelle-toolkit/labelle-core
+          ref: main
+          path: labelle-core
+
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,29 @@ jobs:
     runs-on: ubuntu-latest
     name: Build & Unit Tests (Linux)
 
+    # build.zig.zon depends on `../labelle-engine` (#107 — PIE
+    # viewport). Both checkouts go into named subdirs so the sibling
+    # path resolves; all `run:` steps live inside labelle-gui via
+    # `defaults.run.working-directory`.
+    defaults:
+      run:
+        working-directory: labelle-gui
+
     steps:
-      - name: Checkout
+      - name: Checkout labelle-gui
         uses: actions/checkout@v4
+        with:
+          path: labelle-gui
+
+      - name: Checkout labelle-engine sibling
+        uses: actions/checkout@v4
+        with:
+          repository: labelle-toolkit/labelle-engine
+          # Pinned to the feat/544 branch until labelle-engine#545
+          # and #546 merge to main. Flip this to `main` (or a tag)
+          # once both PRs land.
+          ref: feat/544-pbo-shm-publish
+          path: labelle-engine
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
@@ -29,8 +49,8 @@ jobs:
         with:
           path: |
             ~/.cache/zig
-            .zig-cache
-          key: zig-${{ runner.os }}-${{ hashFiles('build.zig.zon', 'build.zig') }}
+            labelle-gui/.zig-cache
+          key: zig-${{ runner.os }}-${{ hashFiles('labelle-gui/build.zig.zon', 'labelle-gui/build.zig') }}
           restore-keys: |
             zig-${{ runner.os }}-
 
@@ -56,7 +76,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: labelle-gui-Linux
-          path: zig-out/bin/
+          # `working-directory` doesn't apply to `uses:` action steps,
+          # so the path needs the explicit prefix.
+          path: labelle-gui/zig-out/bin/
           if-no-files-found: error
 
   # ImGui Test Engine harness — downloads the gui-tests binary built by

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: labelle-toolkit/labelle-engine
-          # Pinned to the feat/544 branch until labelle-engine#545
-          # and #546 merge to main. Flip this to `main` (or a tag)
-          # once both PRs land.
-          ref: feat/544-pbo-shm-publish
+          ref: main
           path: labelle-engine
 
       - name: Checkout labelle-core sibling

--- a/build.zig
+++ b/build.zig
@@ -49,6 +49,17 @@ pub fn build(b: *std.Build) void {
     });
     const flow_codegen_module = flow_codegen.module("flow_codegen");
 
+    // labelle-engine — for the PIE viewport (#107). We pull the
+    // engine in solely for `preview_mode.preview_shm.Consumer`
+    // (cross-process pixel ring reader) and the protocol types.
+    // The engine's own deps (labelle-core etc.) come along for the
+    // ride but the editor only links the preview surface.
+    const engine = b.dependency("engine", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const engine_module = engine.module("engine");
+
     // Main executable
     const exe = b.addExecutable(.{
         .name = "labelle-gui",
@@ -72,6 +83,8 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addImport("zstbi", zstbi.module("root"));
 
     exe.root_module.addImport("flow_codegen", flow_codegen_module);
+
+    exe.root_module.addImport("engine", engine_module);
 
     // Windows-specific: embed DPI awareness manifest
     if (target.result.os.tag == .windows) {
@@ -105,6 +118,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "zopengl", .module = zopengl.module("root") },
                 .{ .name = "zstbi", .module = zstbi.module("root") },
                 .{ .name = "flow_codegen", .module = flow_codegen_module },
+                .{ .name = "engine", .module = engine_module },
             },
         }),
         .test_runner = .{ .path = zspec.path("src/runner.zig"), .mode = .simple },
@@ -147,6 +161,7 @@ pub fn build(b: *std.Build) void {
     gui_tests_exe.root_module.linkLibrary(zgui_te.artifact("imgui"));
     gui_tests_exe.root_module.addImport("zstbi", zstbi.module("root"));
     gui_tests_exe.root_module.addImport("flow_codegen", flow_codegen_module);
+    gui_tests_exe.root_module.addImport("engine", engine_module);
 
     const run_gui_tests = b.addRunArtifact(gui_tests_exe);
     const gui_test_step = b.step("gui-test", "Run the UI test runner");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,6 +31,16 @@
         .flow_codegen = .{
             .path = "flow-codegen",
         },
+        // labelle-engine pinned at the open feat/544 branch for the
+        // PIE viewport work (#107). The engine ships `preview_mode`
+        // (protocol API) and `preview_mode.preview_shm` (cross-
+        // process SHM ring consumer) — the editor's Game View module
+        // wraps `preview_shm.Consumer` to display engine-rendered
+        // frames inside an ImGui::Image panel. Flip this to a tag
+        // (e.g. v1.37.2) once labelle-engine#545 and #546 merge.
+        .engine = .{
+            .path = "../labelle-engine",
+        },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,13 +31,13 @@
         .flow_codegen = .{
             .path = "flow-codegen",
         },
-        // labelle-engine pinned at the open feat/544 branch for the
-        // PIE viewport work (#107). The engine ships `preview_mode`
-        // (protocol API) and `preview_mode.preview_shm` (cross-
-        // process SHM ring consumer) — the editor's Game View module
-        // wraps `preview_shm.Consumer` to display engine-rendered
-        // frames inside an ImGui::Image panel. Flip this to a tag
-        // (e.g. v1.37.2) once labelle-engine#545 and #546 merge.
+        // labelle-engine via sibling-path dep — same pattern
+        // labelle-assembler uses for `../labelle-gui/flow-codegen`.
+        // Dev-time and CI both check out the engine as a sibling
+        // (see `.github/workflows/ci.yml`). Release builds swap in
+        // a `git+https://...?ref=vX.Y.Z#<hash>` pin at build time;
+        // the path here is the dev-time default, not the source of
+        // truth for shipped binaries.
         .engine = .{
             .path = "../labelle-engine",
         },

--- a/src/app.zig
+++ b/src/app.zig
@@ -267,6 +267,31 @@ pub const App = struct {
         // pointer is stable for the lifetime of the App.
         app.entity_inspector = entity_inspector_mod.EntityInspector.init(allocator, &app.preview);
 
+        // Wire the preview session's `frame_offer` listener — the
+        // editor-side end of #112's transport restore + #107's Game
+        // View panel meet here. When the engine emits `frame_offer`
+        // the transport calls back into App, which attaches the
+        // Game View consumer to the advertised SHM region. Tests
+        // can drive this end-to-end via `bindListener` +
+        // `LABELLE_GAME_VIEW_SHM`, the production path uses
+        // `start(project)` + `labelle run` spawn.
+        app.preview.on_frame_offer = .{
+            .ctx = app,
+            .func = struct {
+                fn cb(ctx: *anyopaque, shm_name: [:0]const u8, width: u32, height: u32) void {
+                    _ = width;
+                    _ = height;
+                    const a: *App = @ptrCast(@alignCast(ctx));
+                    a.attachGameView(shm_name) catch |err| {
+                        std.log.warn(
+                            "preview: attachGameView('{s}') failed: {s}",
+                            .{ shm_name, @errorName(err) },
+                        );
+                    };
+                }
+            }.cb,
+        };
+
         // Wire the preview session's binary-frame listeners. Both are
         // single-consumer in Phase 3; future panels that need the same
         // stream will gain a multi-listener path.

--- a/src/app.zig
+++ b/src/app.zig
@@ -26,6 +26,9 @@ const prefab_mod = @import("modules/prefab.zig");
 const flow_mod = @import("modules/flow.zig");
 const gizmo_mod = @import("modules/gizmo.zig");
 const entity_inspector_mod = @import("modules/entity_inspector.zig");
+const game_view_mod = @import("modules/game_view.zig");
+const game_view = @import("game_view.zig");
+const io_global = @import("io_global.zig");
 const flow_runtime_mod = @import("modules/flow_runtime.zig");
 const close_scene_dialog = @import("dialogs/close_scene.zig");
 const atlas = @import("atlas.zig");
@@ -140,6 +143,14 @@ pub const App = struct {
     /// pointer; clicking Run preview also force-opens it.
     show_preview: bool = false,
 
+    /// Game View panel state (#107). Owns the SHM consumer + GL
+    /// texture for the live game frames. Toggleable from the View
+    /// menu; until the editor-side preview transport is restored
+    /// (separate follow-up), the consumer is attached either via
+    /// `App.attachGameView` or the `LABELLE_GAME_VIEW_SHM` env var.
+    show_game_view: bool = false,
+    game_view: game_view.GameView = undefined,
+
     /// Phase 3 (#84): Entity Inspector panel toggle.
     show_entity_inspector: bool = false,
     /// Entity Inspector state — fed by `PreviewSession`'s
@@ -229,7 +240,7 @@ pub const App = struct {
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [7]module.Module = undefined,
+    modules: [8]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -245,6 +256,7 @@ pub const App = struct {
             .tree_view = tree_view.TreeView.init(allocator),
             .compiler = compiler.Compiler.init(allocator),
             .preview = preview.PreviewSession.init(allocator),
+            .game_view = game_view.GameView.init(allocator),
             .prefs = user_prefs,
             .startup_prefs = user_prefs,
         };
@@ -298,7 +310,29 @@ pub const App = struct {
         app.modules[4] = preview_mod.makeModule(app);
         app.modules[5] = entity_inspector_mod.makeModule(app);
         app.modules[6] = flow_runtime_mod.makeModule(app);
+        app.modules[7] = game_view_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
+
+        // Honor LABELLE_GAME_VIEW_SHM as a manual attach path until
+        // the preview-transport restore wires this up automatically.
+        // Empty / unset → no attach. Lookup errors (missing region,
+        // bad magic) are logged but don't fail App.init — the user
+        // can still drive the editor without preview. GameView.attach
+        // dupes the name into its own buffer so the env-var string
+        // can be freed immediately.
+        if (io_global.environ().getAlloc(allocator, "LABELLE_GAME_VIEW_SHM") catch null) |raw| {
+            defer allocator.free(raw);
+            if (raw.len > 0) {
+                const shm_name_z = allocator.dupeZ(u8, raw) catch null;
+                if (shm_name_z) |z| {
+                    defer allocator.free(z);
+                    app.game_view.attach(z) catch |err| {
+                        std.log.warn("game_view: attach('{s}') failed: {s}", .{ z, @errorName(err) });
+                    };
+                    if (app.game_view.isAttached()) app.show_game_view = true;
+                }
+            }
+        }
 
         return app;
     }
@@ -318,7 +352,19 @@ pub const App = struct {
         self.tree_view.deinit();
         self.compiler.deinit();
         self.preview.deinit();
+        self.game_view.deinit();
         self.allocator.destroy(self);
+    }
+
+    /// Open the SHM region the engine advertised in `frame_offer`
+    /// (#107). Convenience wrapper that surfaces the panel
+    /// automatically on a successful attach. Used both by the
+    /// LABELLE_GAME_VIEW_SHM startup hook and by external test
+    /// code; will also be the seam the eventual preview-transport
+    /// restore plugs into.
+    pub fn attachGameView(self: *Self, shm_name: [:0]const u8) !void {
+        try self.game_view.attach(shm_name);
+        self.show_game_view = true;
     }
 
     /// Rebuild the atlas index from the active project's

--- a/src/game_view.zig
+++ b/src/game_view.zig
@@ -1,0 +1,216 @@
+//! Embedded game-view panel state.
+//!
+//! Owns the consumer side of the PIE viewport pixel ring: opens an
+//! `engine.preview_mode.preview_shm.Consumer` against a SHM region
+//! the engine allocated, mirrors each new frame into a `GL_TEXTURE_2D`
+//! via `glTexSubImage2D`, and tracks end-to-end latency for the
+//! Stats overlay.
+//!
+//! Pairs with `src/modules/game_view.zig` — that file wraps this
+//! state in a togglable ImGui panel and registers it with the
+//! Module Registry. This file is UI-free so the texture / consumer
+//! lifecycle is testable headless.
+//!
+//! Architecture validated end-to-end in `imgui-preview-poc/src/editor.zig`
+//! at 1280×720@60 with raw-IPC p50=5µs on Apple Silicon. This module
+//! is a direct port of that pattern, minus the PoC's standalone
+//! GLFW window since labelle-gui's frame loop already owns the GL
+//! context.
+//!
+//! See labelle-engine#544 for the producer side and the protocol
+//! handshake (#543) that delivers `frame_offer` payloads.
+
+const std = @import("std");
+const zopengl = @import("zopengl");
+const engine = @import("engine");
+const shm = engine.preview_mode_mod.preview_shm;
+
+const gl = zopengl.bindings;
+
+const latency_ring_capacity: usize = 120;
+
+/// Errors specific to `GameView.attach`. SHM-open / mmap failures
+/// from `preview_shm.Consumer.init` (`error.ShmOpenFailed`, etc.)
+/// propagate verbatim.
+pub const AttachError = shm.Error || error{AlreadyAttached};
+
+pub const GameView = struct {
+    allocator: std.mem.Allocator,
+    /// `null` until `attach` opens a consumer.
+    consumer: ?shm.Consumer = null,
+    /// Owned (allocator-allocated, NUL-terminated) duplicate of the
+    /// shm_name passed to `attach`. `engine.preview_shm.Consumer`
+    /// stashes the name slice and we want a stable pointer for the
+    /// lifetime of the consumer — caller-provided buffers might be
+    /// stack-allocated or env-var scratch space.
+    owned_shm_name: ?[:0]u8 = null,
+    /// GL texture handle for the displayed frame. Zero when no texture
+    /// is currently allocated. Width/height kept alongside so a
+    /// frame_resize landed on the SHM ring lets us re-allocate the
+    /// texture instead of misaligned `glTexSubImage2D` uploads.
+    tex_id: gl.Uint = 0,
+    tex_w: u32 = 0,
+    tex_h: u32 = 0,
+    /// Monotonic — the frame_idx the texture currently contains.
+    /// Test code reads this to assert "the editor is presenting new
+    /// frames" without ever inspecting pixels (the zgui binding
+    /// doesn't expose `ImGuiTestEngine_CaptureScreenshot`).
+    last_frame_idx: u64 = 0,
+    last_latency_ns: u64 = 0,
+    /// Frames the producer outran us on — `frame.frame_idx -
+    /// prior_idx - 1` summed over the session.
+    dropped: u64 = 0,
+    /// Frames uploaded by `poll`. Bumps once per successful texture
+    /// upload — used for the FPS reading on the Stats overlay.
+    presented: u64 = 0,
+    /// Circular buffer of recent end-to-end latency samples in ns.
+    /// Sized to 120 — at 60 Hz that's a 2-second window which is
+    /// sticky enough to read on screen without averaging away spikes.
+    latency_ring: [latency_ring_capacity]u64 = [_]u64{0} ** latency_ring_capacity,
+    latency_head: usize = 0,
+    latency_count: usize = 0,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.detach();
+    }
+
+    /// Open the named SHM region the engine allocated for this
+    /// session and stand up a matching `GL_TEXTURE_2D`. The GL
+    /// context must be current on the calling thread (which it
+    /// always is on the main thread for labelle-gui's frame loop).
+    pub fn attach(self: *Self, shm_name: [:0]const u8) AttachError!void {
+        if (self.consumer != null) return error.AlreadyAttached;
+
+        const owned = self.allocator.dupeZ(u8, shm_name) catch return error.MmapFailed;
+        errdefer self.allocator.free(owned);
+
+        var consumer = try shm.Consumer.init(owned);
+        errdefer consumer.deinit();
+
+        const w = consumer.header.width;
+        const h = consumer.header.height;
+
+        // Build a zero-initialized texture; per-frame uploads will
+        // `glTexSubImage2D` into it. `GL_RGBA8` matches the SHM's
+        // RGBA8 pixel format. `GL_CLAMP_TO_EDGE` avoids edge-bleed
+        // when the panel renders the texture at a non-integer
+        // scale.
+        var tex: gl.Uint = 0;
+        gl.genTextures(1, &tex);
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA8,
+            @intCast(w),
+            @intCast(h),
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            null,
+        );
+
+        self.consumer = consumer;
+        self.owned_shm_name = owned;
+        self.tex_id = tex;
+        self.tex_w = w;
+        self.tex_h = h;
+        self.last_frame_idx = 0;
+        self.last_latency_ns = 0;
+        self.dropped = 0;
+        self.presented = 0;
+        self.latency_head = 0;
+        self.latency_count = 0;
+    }
+
+    /// Tear down the consumer + GL texture. Safe to call when not
+    /// attached; called by `deinit`.
+    pub fn detach(self: *Self) void {
+        if (self.consumer) |*c| {
+            c.deinit();
+            self.consumer = null;
+        }
+        if (self.owned_shm_name) |n| {
+            self.allocator.free(n);
+            self.owned_shm_name = null;
+        }
+        if (self.tex_id != 0) {
+            gl.deleteTextures(1, &self.tex_id);
+            self.tex_id = 0;
+        }
+        self.tex_w = 0;
+        self.tex_h = 0;
+    }
+
+    pub fn isAttached(self: *const Self) bool {
+        return self.consumer != null;
+    }
+
+    /// Poll the SHM ring for a newer frame. If one is available,
+    /// upload it to the texture and update the stats. Call once per
+    /// editor frame from the main loop.
+    ///
+    /// Returns true when a new frame was uploaded — handy for tests
+    /// + future "redraw only on new frame" optimization.
+    pub fn poll(self: *Self) bool {
+        const consumer = if (self.consumer) |*c| c else return false;
+        const frame = consumer.latest() orelse return false;
+
+        // Defensive: producer's resize should have triggered a re-
+        // attach (engine sends a fresh `frame_offer` on resize) but
+        // skip mid-resize frames just in case.
+        if (frame.width != self.tex_w or frame.height != self.tex_h) return false;
+
+        gl.bindTexture(gl.TEXTURE_2D, self.tex_id);
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            @intCast(frame.width),
+            @intCast(frame.height),
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            frame.pixels,
+        );
+
+        // Drop accounting: how many producer frames did we skip
+        // between `last_frame_idx` and this one? First frame after
+        // attach has `last_frame_idx == 0` so the gap-from-zero math
+        // is correct.
+        if (self.last_frame_idx > 0 and frame.frame_idx > self.last_frame_idx + 1) {
+            self.dropped += frame.frame_idx - self.last_frame_idx - 1;
+        }
+        self.last_frame_idx = frame.frame_idx;
+
+        const now_ns = shm.nowNs();
+        if (now_ns > frame.produce_ns) {
+            self.last_latency_ns = now_ns - frame.produce_ns;
+            self.latency_ring[self.latency_head] = self.last_latency_ns;
+            self.latency_head = (self.latency_head + 1) % latency_ring_capacity;
+            if (self.latency_count < latency_ring_capacity) self.latency_count += 1;
+        }
+        self.presented += 1;
+        return true;
+    }
+
+    /// Mean end-to-end latency in nanoseconds over the most recent
+    /// `latency_ring_capacity` samples. Returns 0 before the first
+    /// frame is uploaded.
+    pub fn meanLatencyNs(self: *const Self) u64 {
+        if (self.latency_count == 0) return 0;
+        var sum: u128 = 0;
+        for (self.latency_ring[0..self.latency_count]) |v| sum += v;
+        return @intCast(sum / @as(u128, self.latency_count));
+    }
+};

--- a/src/modules/game_view.zig
+++ b/src/modules/game_view.zig
@@ -1,0 +1,123 @@
+//! Game View panel — renders the live game frames the engine is
+//! streaming through the PIE viewport pixel ring (#107).
+//!
+//! Two ImGui windows, both gated on `app.show_game_view`:
+//!
+//!   - "Game View"    : `zgui.image(...)` of the frame texture,
+//!                      aspect-fit inside the available content
+//!                      region.
+//!   - "Game Stats"   : last/avg latency, presented FPS, dropped
+//!                      frames, producer frame index.
+//!
+//! When the panel is open but the consumer hasn't attached yet,
+//! the "Game View" window shows a paragraph explaining how to
+//! attach — currently a manual hand-off via `App.attachGameView`
+//! (or the `LABELLE_GAME_VIEW_SHM` environment variable on
+//! startup). Auto-attach from a live `PreviewSession` is the
+//! follow-up ticket (#107's body notes the existing transport
+//! is stubbed pending #543/#544 merge).
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "game_view",
+        .display_name = "Game View",
+        .is_open = &app.show_game_view,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    // Drive the upload first so the stats window reads fresh values.
+    _ = app.game_view.poll();
+
+    renderViewport(app);
+    renderStats(app);
+}
+
+fn renderViewport(app: *App) void {
+    zgui.setNextWindowSize(.{ .w = 720, .h = 460, .cond = .first_use_ever });
+    if (!zgui.begin("Game View", .{ .popen = &app.show_game_view, .flags = .{} })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    if (!app.game_view.isAttached()) {
+        zgui.textWrapped(
+            \\No engine attached.
+            \\
+            \\To watch a running game, either set the
+            \\LABELLE_GAME_VIEW_SHM environment variable to the
+            \\SHM name advertised in the engine's `frame_offer`
+            \\and restart the editor, or call
+            \\`App.attachGameView` from your wiring.
+            \\
+            \\Auto-attach from a live `PreviewSession` is tracked
+            \\as a follow-up — the preview transport itself is
+            \\currently stubbed (zig-0.16 migration).
+            ,
+            .{},
+        );
+        return;
+    }
+
+    const avail = zgui.getContentRegionAvail();
+    const src_w: f32 = @floatFromInt(app.game_view.tex_w);
+    const src_h: f32 = @floatFromInt(app.game_view.tex_h);
+    // Aspect-fit inside the available content region; centre the
+    // image rather than stretching to the panel dimensions.
+    const aspect_src = src_w / src_h;
+    const aspect_avail = avail[0] / avail[1];
+    var draw_w: f32 = avail[0];
+    var draw_h: f32 = avail[1];
+    if (aspect_src > aspect_avail) {
+        draw_h = avail[0] / aspect_src;
+    } else {
+        draw_w = avail[1] * aspect_src;
+    }
+    // Centre with an InvisibleButton offset before the image.
+    const dx = (avail[0] - draw_w) * 0.5;
+    const dy = (avail[1] - draw_h) * 0.5;
+    if (dx > 0 or dy > 0) {
+        const cur = zgui.getCursorPos();
+        zgui.setCursorPos(.{ cur[0] + dx, cur[1] + dy });
+    }
+
+    const tex_ref: zgui.TextureRef = .{
+        .tex_data = null,
+        .tex_id = @enumFromInt(@as(u64, app.game_view.tex_id)),
+    };
+    zgui.image(tex_ref, .{ .w = draw_w, .h = draw_h });
+}
+
+fn renderStats(app: *App) void {
+    zgui.setNextWindowSize(.{ .w = 280, .h = 180, .cond = .first_use_ever });
+    if (!zgui.begin("Game Stats", .{ .popen = &app.show_game_view, .flags = .{} })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    if (!app.game_view.isAttached()) {
+        zgui.text("Not attached.", .{});
+        return;
+    }
+
+    const ns_per_ms: f64 = 1_000_000.0;
+    const last_ms: f64 = @as(f64, @floatFromInt(app.game_view.last_latency_ns)) / ns_per_ms;
+    const mean_ms: f64 = @as(f64, @floatFromInt(app.game_view.meanLatencyNs())) / ns_per_ms;
+
+    zgui.text("frame_idx = {d}", .{app.game_view.last_frame_idx});
+    zgui.text("presented = {d}", .{app.game_view.presented});
+    zgui.text("dropped   = {d}", .{app.game_view.dropped});
+    zgui.text("dims      = {d}x{d}", .{ app.game_view.tex_w, app.game_view.tex_h });
+    zgui.separator();
+    zgui.text("last latency  = {d:.2} ms", .{last_ms});
+    zgui.text("avg latency   = {d:.2} ms ({d} samples)", .{ mean_ms, app.game_view.latency_count });
+}

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -1,33 +1,77 @@
-//! Preview-mode session — stubbed for Zig 0.16 migration.
+//! Preview-mode session — TCP listener for engine connections.
 //!
-//! The original preview module used `std.net.Server` with
-//! `force_nonblocking`, `std.process.Child` async stdio drains, and
-//! `std.time.milliTimestamp` — all reshaped in Zig 0.16 such that a
-//! full rewrite is needed. To unblock the rest of the migration we
-//! keep the public API surface (so `App`, `modules/preview.zig`, and
-//! `gui_tests.zig` still compile) but make every operation a no-op
-//! that lands in `crashed` with a "preview disabled" reason.
+//! Architecture (per labelle-gui#60): the editor binds a loopback
+//! TCP listener and the engine dials out, so port selection lives
+//! here. `start(project)` binds the listener, spawns
+//! `labelle run <dir> --preview-mode 127.0.0.1:<port>`, transitions
+//! to `.listening`, and lets `poll()` (called once per frame from
+//! the main loop) drive state transitions via non-blocking I/O.
 //!
-//! TODO: restore real preview behavior on top of `std.Io.net.Server`
-//! (blocking accept under a background thread, or a poll-based
-//! integration via the new `Io` cancellation handles) and
-//! `std.process.spawn` with manually drained pipes. The state machine
-//! shape can stay identical to the pre-rebase HEAD design — only the
-//! transport plumbing changes.
+//! Threading model: single-threaded. The listener FD is set to
+//! `O_NONBLOCK` via libc `fcntl` (see #112 for the variadic-`fcntl`
+//! ABI lesson re-learned in labelle-engine#545), so `poll()` returns
+//! promptly even when nothing has connected yet.
+//!
+//! Scope ceiling — this PR (#112) restores:
+//!   - hello / heartbeat / bye   (engine→editor JSON control frames)
+//!   - frame_offer               (engine→editor; #543 / drives
+//!                                `on_frame_offer` callback the App
+//!                                wires to `attachGameView`)
+//!   - frame_published           (engine→editor; informational, no
+//!                                state change in editor for v1)
+//!
+//! Out of scope (kept stubbed so consumer code compiles):
+//!   - binary plane frames (entity_created / entity_destroyed /
+//!     component_changed / node_entered / pin_value) — `on_component
+//!     _changed` / `on_node_entered` callback slots stay defined
+//!     but never fire.
+//!   - editor→engine uplink (subscribe / unsubscribe / watch_entity
+//!     / subscribe_flow / subscribe_pin_values) — methods stay
+//!     present but write nothing on the wire.
+//!   - Auto-restart on disconnect.
+//!
+//! See #112 body for the deferred work list.
 
 const std = @import("std");
 const builtin = @import("builtin");
 const project = @import("project.zig");
+const io_global = @import("io_global.zig");
+
+extern "c" fn close(fd: c_int) c_int;
+extern "c" fn read(fd: c_int, buf: [*]u8, len: usize) isize;
+extern "c" fn __error() *c_int;
+extern "c" fn __errno_location() *c_int;
+
+fn libcErrno() c_int {
+    return if (builtin.os.tag == .macos) __error().* else __errno_location().*;
+}
+
+// `fcntl` is variadic in libc. Declaring it non-variadic with a fixed
+// third arg is a calling-convention mismatch on aarch64-darwin (and
+// other ABIs that put variadic args on the stack), so the stdlib's
+// correctly-declared decl gets used. See labelle-engine#545 for the
+// same lesson on the engine side.
+const c_fcntl = std.c.fcntl;
+const F_GETFL: c_int = 3;
+const F_SETFL: c_int = 4;
+const O_NONBLOCK: c_int = if (builtin.os.tag == .macos) 4 else 2048;
+const EAGAIN: c_int = if (builtin.os.tag == .macos) 35 else 11;
 
 /// Lifecycle of one preview session. Strictly monotonic except for the
 /// terminal `stopped`/`crashed` → `idle` reset that `stop()` does so the
 /// user can press Run again.
 pub const State = enum {
     idle,
+    /// Listener is up, child is spawned, awaiting accept().
     listening,
+    /// Client connected, waiting for `hello` frame.
     connecting,
+    /// `hello` received; heartbeats are flowing.
     running,
+    /// Stream EOFed before a `bye` arrived, or the connect timeout fired.
     crashed,
+    /// Clean shutdown — engine sent `bye` and disconnected, or user
+    /// pressed Stop.
     stopped,
 };
 
@@ -55,11 +99,21 @@ pub const Bye = struct {
 
 pub const connecting_timeout_ms: i64 = 2_000;
 
-/// Callback invoked on `component_changed` binary frames. Stubbed
-/// alongside the rest of the preview module during the Zig 0.16 migration —
-/// PreviewSession never actually fires it, but the field is preserved
-/// so consumer code that wires entity-inspector / flow-runtime listeners
-/// (added on main after the migration was cut) still compiles.
+/// Callback slot — fires on the first `frame_offer` JSON frame the
+/// engine sends after the `hello` handshake. The App wires this to
+/// `attachGameView(shm_name)` (#107 → #112 end-to-end seam).
+///
+/// `shm_name` is borrowed — only valid for the call duration. Copy
+/// before storing.
+pub const FrameOfferCallback = struct {
+    ctx: *anyopaque,
+    func: *const fn (ctx: *anyopaque, shm_name: [:0]const u8, width: u32, height: u32) void,
+};
+
+/// Callback invoked on `component_changed` binary frames. Stubbed —
+/// the transport doesn't decode the binary plane yet. The field is
+/// preserved so consumer code (entity_inspector, flow_runtime) compiles
+/// against the post-Phase-3 API shape.
 pub const ComponentChangedCallback = struct {
     ctx: *anyopaque,
     func: *const fn (ctx: *anyopaque, entity_id: u64, name: []const u8, bytes: []const u8) void,
@@ -69,6 +123,10 @@ pub const NodeEnteredCallback = struct {
     ctx: *anyopaque,
     func: *const fn (ctx: *anyopaque, flow_name: []const u8, node_id: u32) void,
 };
+
+/// Inbox buffer cap. JSON frames are tiny (~100 B for hello,
+/// ~80 B for frame_offer); a few KB is plenty of slack.
+const inbox_cap: usize = 4 * 1024;
 
 pub const PreviewSession = struct {
     allocator: std.mem.Allocator,
@@ -80,10 +138,31 @@ pub const PreviewSession = struct {
     bye_reason: ?[]u8,
     started_ms: ?i64,
     stderr_buf: std.ArrayList(u8),
-    /// Phase-3 callback slots — stubbed during 0.16 migration. App
-    /// wires these but the stubbed PreviewSession never invokes them.
+    /// PIE viewport frame-offer hook (#112). App wires to
+    /// `attachGameView` so the Game View panel auto-opens when the
+    /// engine emits its `frame_offer`. `null` = ignore offers.
+    on_frame_offer: ?FrameOfferCallback = null,
+    /// Stubbed callbacks — binary plane is out of scope for #112.
     on_component_changed: ?ComponentChangedCallback = null,
     on_node_entered: ?NodeEnteredCallback = null,
+
+    /// Active listener once `state >= .listening`. We don't keep the
+    /// listener around after the editor's connection is accepted —
+    /// preview is single-game-at-a-time.
+    listener: ?std.Io.net.Server = null,
+    /// Connected engine fd once `state >= .connecting`. -1 sentinel
+    /// rather than ?fd_t to simplify the read path's signed-int
+    /// compares.
+    conn_fd: c_int = -1,
+    /// Newline-framing buffer fed by the per-frame poll. Heap-
+    /// allocated so we can grow on a giant message if needed.
+    inbox: std.ArrayListUnmanaged(u8) = .empty,
+    /// Spawned subprocess. `null` in tests (the loopback fixture
+    /// dials the listener directly).
+    child: ?std.process.Child = null,
+    /// Monotonic millisecond clock at start() — used for the
+    /// connecting-timeout check inside poll().
+    connect_start_ms: ?i64 = null,
 
     const Self = @This();
 
@@ -102,8 +181,10 @@ pub const PreviewSession = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        self.stop();
         self.releaseOwnedStrings();
         self.stderr_buf.deinit(self.allocator);
+        self.inbox.deinit(self.allocator);
     }
 
     fn releaseOwnedStrings(self: *Self) void {
@@ -117,25 +198,134 @@ pub const PreviewSession = struct {
         }
     }
 
-    /// Stubbed — the preview feature is disabled during the 0.16
-    /// migration. Returns success and lands in `.crashed` so the panel
-    /// surfaces the "disabled" message without throwing.
+    /// Bind a loopback TCP listener on a kernel-assigned port. Test
+    /// hook — production callers go through `start` which also
+    /// spawns the engine subprocess.
+    pub fn bindListener(self: *Self) PreviewError!void {
+        if (self.state != .idle and self.state != .stopped and self.state != .crashed) {
+            return error.AlreadyRunning;
+        }
+        self.releaseOwnedStrings();
+        self.stderr_buf.clearRetainingCapacity();
+        self.inbox.clearRetainingCapacity();
+
+        const addr = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable;
+        var server = addr.listen(io_global.io(), .{ .reuse_address = true }) catch
+            return error.ListenFailed;
+
+        // Read the OS-assigned port off the bound socket.
+        var sa: std.posix.sockaddr.in = undefined;
+        var sa_len: std.posix.socklen_t = @sizeOf(@TypeOf(sa));
+        if (std.posix.system.getsockname(server.socket.handle, @ptrCast(&sa), &sa_len) != 0) {
+            server.deinit(io_global.io());
+            return error.ListenFailed;
+        }
+        const port = std.mem.bigToNative(u16, sa.port);
+
+        // Non-blocking listener so `accept` in poll() returns
+        // EAGAIN promptly instead of blocking the UI.
+        const fd: c_int = @intCast(server.socket.handle);
+        const orig_flags = c_fcntl(fd, F_GETFL, @as(c_int, 0));
+        if (orig_flags >= 0) {
+            _ = c_fcntl(fd, F_SETFL, @as(c_int, orig_flags | O_NONBLOCK));
+        }
+
+        self.listener = server;
+        self.port = port;
+        self.state = .listening;
+        self.connect_start_ms = nowMs();
+        self.started_ms = self.connect_start_ms;
+    }
+
+    /// Production entry: bind + spawn `labelle run <project_dir>
+    /// --preview-mode 127.0.0.1:<port>`. Captures the subprocess'
+    /// stderr to surface on `.crashed` (currently the engine doesn't
+    /// expose useful stderr — that's #79 territory — but the
+    /// scaffolding is back in place).
     pub fn start(self: *Self, proj: *const project.Project) PreviewError!void {
-        _ = proj;
-        self.releaseOwnedStrings();
-        self.stderr_buf.clearRetainingCapacity();
-        self.state = .crashed;
-        self.bye_reason = self.allocator.dupe(u8, "preview disabled — 0.16 migration WIP") catch null;
+        const dir_path = proj.dir orelse return error.NoProjectPath;
+
+        try self.bindListener();
+        errdefer self.stop();
+
+        var port_buf: [8]u8 = undefined;
+        const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{self.port.?}) catch
+            return error.OutOfMemory;
+
+        var argv_buf: [16][]const u8 = undefined;
+        const argv = blk: {
+            argv_buf[0] = "labelle";
+            argv_buf[1] = "run";
+            argv_buf[2] = dir_path;
+            argv_buf[3] = "--preview-mode";
+            argv_buf[4] = port_str;
+            break :blk argv_buf[0..5];
+        };
+
+        const child = std.process.spawn(io_global.io(), .{
+            .argv = argv,
+            .stdin = .ignore,
+            .stdout = .inherit,
+            .stderr = .pipe,
+        }) catch |err| switch (err) {
+            error.FileNotFound => return error.LauncherNotFound,
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.ListenFailed,
+        };
+        self.child = child;
     }
 
+    /// Kill any running subprocess, close listener + connection.
+    /// Idempotent — safe to call from `.idle` or after a previous
+    /// `.crashed`/`.stopped` landing.
     pub fn stop(self: *Self) void {
-        self.releaseOwnedStrings();
-        self.stderr_buf.clearRetainingCapacity();
-        self.state = .stopped;
+        if (self.child) |*c| {
+            c.kill(io_global.io());
+            self.child = null;
+        }
+        if (self.conn_fd >= 0) {
+            _ = close(self.conn_fd);
+            self.conn_fd = -1;
+        }
+        if (self.listener) |*l| {
+            l.deinit(io_global.io());
+            self.listener = null;
+        }
+        self.connect_start_ms = null;
+        // Don't reset `state` if it's already `.crashed` — `poll`
+        // landed us there for a reason and the UI still needs to
+        // show "preview crashed". Only `.listening`/`.connecting`/
+        // `.running` lift to `.stopped` here (the user pressed
+        // Stop).
+        if (self.state == .listening or self.state == .connecting or self.state == .running) {
+            self.state = .stopped;
+        }
     }
 
+    /// Drives the state machine. Call once per editor frame.
     pub fn poll(self: *Self) void {
-        _ = self;
+        // Drain subprocess stderr opportunistically. Always safe; if
+        // the child piped stderr we'll see crash output the panel
+        // can surface.
+        self.drainChildStderr();
+
+        switch (self.state) {
+            .idle, .stopped, .crashed => return,
+            .listening => self.tryAccept(),
+            .connecting, .running => self.tryRead(),
+        }
+
+        // Connecting-timeout: if no client showed up within the
+        // window, the subprocess likely failed to dial. Land in
+        // `.crashed` so the UI surfaces it.
+        if (self.state == .listening or self.state == .connecting) {
+            if (self.connect_start_ms) |t0| {
+                const elapsed = nowMs() - t0;
+                if (elapsed > connecting_timeout_ms and self.state == .listening) {
+                    self.markCrashed("engine never connected");
+                }
+            }
+        }
     }
 
     pub fn isActive(self: *const Self) bool {
@@ -145,46 +335,234 @@ pub const PreviewSession = struct {
         };
     }
 
-    /// Bytes captured from the child's stderr; surfaced by the
-    /// preview panel when a session lands in `crashed`. Always empty
-    /// in the stub.
     pub fn capturedStderr(self: *const Self) []const u8 {
         return self.stderr_buf.items;
     }
 
-    // ── Phase-3 callback/subscription API (all stubbed) ───────────
+    // ── Phase-3 uplink stubs (out of scope for #112) ──────────────
     pub fn watchEntity(self: *Self, entity_id: u64) !void {
         _ = self;
         _ = entity_id;
     }
-
     pub fn unwatchEntity(self: *Self, entity_id: u64) !void {
         _ = self;
         _ = entity_id;
     }
-
     pub fn subscribeComponent(self: *Self, name: []const u8) !void {
         _ = self;
         _ = name;
     }
-
     pub fn unsubscribeComponent(self: *Self, name: []const u8) !void {
         _ = self;
         _ = name;
     }
-
     pub fn subscribeFlow(self: *Self, flow_name: []const u8) !void {
         _ = self;
         _ = flow_name;
     }
-
     pub fn unsubscribeFlow(self: *Self, flow_name: []const u8) !void {
         _ = self;
         _ = flow_name;
     }
+
+    // ── Internals ──────────────────────────────────────────────────
+
+    fn tryAccept(self: *Self) void {
+        const server = if (self.listener) |*l| l else return;
+        // Non-blocking accept — relies on the O_NONBLOCK flag we set
+        // in bindListener. `std.Io.net.Server.accept` doesn't
+        // differentiate EAGAIN from real errors, so we sniff errno
+        // directly via std.posix.system.accept to keep the polling
+        // hot path branch-free.
+        var addr: std.posix.sockaddr.in = undefined;
+        var addr_len: std.posix.socklen_t = @sizeOf(@TypeOf(addr));
+        const fd = std.posix.system.accept(
+            server.socket.handle,
+            @ptrCast(&addr),
+            &addr_len,
+        );
+        if (fd < 0) {
+            const errno = libcErrno();
+            if (errno == EAGAIN) return; // No client yet.
+            self.markCrashed("accept failed");
+            return;
+        }
+
+        // Drop the listener now — we only handle one game per
+        // session.
+        if (self.listener) |*l| {
+            l.deinit(io_global.io());
+            self.listener = null;
+        }
+
+        self.conn_fd = @intCast(fd);
+        // Keep the new fd blocking-mode so we can also handle test
+        // fixtures that write small messages without retries —
+        // we'll set non-blocking explicitly inside tryRead.
+        const orig = c_fcntl(self.conn_fd, F_GETFL, @as(c_int, 0));
+        if (orig >= 0) _ = c_fcntl(self.conn_fd, F_SETFL, @as(c_int, orig | O_NONBLOCK));
+        self.state = .connecting;
+    }
+
+    fn tryRead(self: *Self) void {
+        if (self.conn_fd < 0) return;
+        var scratch: [1024]u8 = undefined;
+        // Loop: drain everything currently available. The connection
+        // is non-blocking; EAGAIN ends the loop.
+        while (true) {
+            const n = read(self.conn_fd, @ptrCast(&scratch[0]), scratch.len);
+            if (n < 0) {
+                const errno = libcErrno();
+                if (errno == EAGAIN) break;
+                self.markCrashed("read failed");
+                return;
+            }
+            if (n == 0) {
+                // EOF without a `bye` — engine died.
+                if (self.bye_reason == null) self.markCrashed("connection closed");
+                return;
+            }
+            if (self.inbox.items.len + @as(usize, @intCast(n)) > inbox_cap) {
+                self.markCrashed("inbox overflow");
+                return;
+            }
+            self.inbox.appendSlice(self.allocator, scratch[0..@intCast(n)]) catch {
+                self.markCrashed("OOM");
+                return;
+            };
+        }
+
+        // Parse all complete newline-framed JSON lines.
+        while (true) {
+            const nl = std.mem.indexOfScalar(u8, self.inbox.items, '\n') orelse return;
+            const line = self.inbox.items[0..nl];
+            self.handleFrame(line);
+            const remaining = self.inbox.items.len - (nl + 1);
+            std.mem.copyForwards(u8, self.inbox.items[0..remaining], self.inbox.items[nl + 1 ..]);
+            self.inbox.shrinkRetainingCapacity(remaining);
+        }
+    }
+
+    fn handleFrame(self: *Self, line: []const u8) void {
+        // Single-pass parse: discover the `kind`, then route. Use
+        // `parseFromSliceLeaky` so the temporary allocations live
+        // for one frame and free on the arena reset (we use a tiny
+        // FBA-backed scratch arena rather than the persistent
+        // allocator).
+        var buf: [4 * 1024]u8 = undefined;
+        var fba = std.heap.FixedBufferAllocator.init(&buf);
+        const alloc = fba.allocator();
+
+        const KindOnly = struct { kind: []const u8 };
+        const kind_only = std.json.parseFromSliceLeaky(KindOnly, alloc, line, .{
+            .ignore_unknown_fields = true,
+        }) catch return;
+
+        if (std.mem.eql(u8, kind_only.kind, "hello")) {
+            const Msg = struct {
+                kind: []const u8,
+                engine_version: []const u8 = "",
+                pid: i64 = 0,
+                protocol_version: u32 = 0,
+            };
+            const m = std.json.parseFromSliceLeaky(Msg, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return;
+            self.engine_pid = m.pid;
+            if (self.engine_version) |v| self.allocator.free(v);
+            self.engine_version = self.allocator.dupe(u8, m.engine_version) catch null;
+            self.state = .running;
+        } else if (std.mem.eql(u8, kind_only.kind, "heartbeat")) {
+            const Msg = struct { kind: []const u8, t: i64 = 0 };
+            const m = std.json.parseFromSliceLeaky(Msg, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return;
+            self.last_heartbeat_ms = m.t;
+        } else if (std.mem.eql(u8, kind_only.kind, "bye")) {
+            const Msg = struct { kind: []const u8, reason: []const u8 = "normal" };
+            const m = std.json.parseFromSliceLeaky(Msg, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return;
+            if (self.bye_reason) |r| self.allocator.free(r);
+            self.bye_reason = self.allocator.dupe(u8, m.reason) catch null;
+            self.state = .stopped;
+        } else if (std.mem.eql(u8, kind_only.kind, "frame_offer")) {
+            const Msg = struct {
+                kind: []const u8,
+                shm_name: []const u8 = "",
+                width: u32 = 0,
+                height: u32 = 0,
+            };
+            const m = std.json.parseFromSliceLeaky(Msg, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return;
+            if (self.on_frame_offer) |cb| {
+                // Promote the borrowed name into a NUL-terminated
+                // slice so the App's `attachGameView` (which calls
+                // `shm_open`) gets a stable pointer. Lives on the
+                // stack of `handleFrame` — fine because attachGameView
+                // dupes again into the GameView's owned buffer.
+                var name_buf: [64]u8 = undefined;
+                if (m.shm_name.len >= name_buf.len) return;
+                @memcpy(name_buf[0..m.shm_name.len], m.shm_name);
+                name_buf[m.shm_name.len] = 0;
+                const name_z: [:0]const u8 = name_buf[0..m.shm_name.len :0];
+                cb.func(cb.ctx, name_z, m.width, m.height);
+            }
+        } else if (std.mem.eql(u8, kind_only.kind, "frame_published")) {
+            // Informational — editor consumer polls the SHM ring
+            // directly. Drop silently.
+        }
+        // Unknown kinds (Phase 2 binary frames, etc.) drop silently.
+    }
+
+    fn drainChildStderr(self: *Self) void {
+        const child = if (self.child) |*c| c else return;
+        const stderr_file = child.stderr orelse return;
+        // Best-effort non-blocking peek. `stderr_file.handle` is the
+        // raw fd; switch to O_NONBLOCK around the read so a happy
+        // path with nothing to read doesn't block.
+        const fd: c_int = @intCast(stderr_file.handle);
+        const orig = c_fcntl(fd, F_GETFL, @as(c_int, 0));
+        if (orig < 0) return;
+        _ = c_fcntl(fd, F_SETFL, @as(c_int, orig | O_NONBLOCK));
+        defer _ = c_fcntl(fd, F_SETFL, @as(c_int, orig));
+        var buf: [512]u8 = undefined;
+        while (true) {
+            const n = read(fd, @ptrCast(&buf[0]), buf.len);
+            if (n <= 0) return;
+            // Cap to keep the buffer from runaway-growing if the
+            // subprocess spams stderr.
+            const stderr_cap: usize = 16 * 1024;
+            if (self.stderr_buf.items.len >= stderr_cap) return;
+            const room = stderr_cap - self.stderr_buf.items.len;
+            const take = @min(@as(usize, @intCast(n)), room);
+            self.stderr_buf.appendSlice(self.allocator, buf[0..take]) catch return;
+        }
+    }
+
+    fn markCrashed(self: *Self, reason: []const u8) void {
+        if (self.bye_reason == null) {
+            self.bye_reason = self.allocator.dupe(u8, reason) catch null;
+        }
+        self.state = .crashed;
+        if (self.conn_fd >= 0) {
+            _ = close(self.conn_fd);
+            self.conn_fd = -1;
+        }
+        if (self.listener) |*l| {
+            l.deinit(io_global.io());
+            self.listener = null;
+        }
+    }
 };
 
-// Suppress unused-import warning while the stub stays minimal.
+fn nowMs() i64 {
+    var ts: std.posix.timespec = undefined;
+    _ = std.posix.system.clock_gettime(.MONOTONIC, &ts);
+    return @as(i64, ts.sec) * 1000 + @divTrunc(@as(i64, ts.nsec), 1_000_000);
+}
+
 comptime {
     _ = builtin;
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -18,6 +18,7 @@ const flow_projector = @import("flows/projector.zig");
 const flow_types = @import("flows/types.zig");
 const prefs = @import("prefs.zig");
 const io_global = @import("io_global.zig");
+const game_view = @import("game_view.zig");
 
 /// Wall-clock seconds since the Unix epoch; replacement for the
 /// `std.time.timestamp` helper removed in Zig 0.16. Used only to
@@ -2898,5 +2899,40 @@ pub const PreferencesTests = struct {
 
         const loaded = prefs.loadFromPath(std.testing.allocator, path);
         try expect.equal(loaded.font_scale, prefs.default_font_scale);
+    }
+};
+
+pub const GameViewLatencyTests = struct {
+    // GameView.meanLatencyNs is pure math over its latency_ring; no
+    // GL context needed. Compose the struct manually to test the
+    // bookkeeping in isolation. attach()/poll() are exercised
+    // end-to-end in the gui-tests TE binary (display + headless GL).
+
+    test "meanLatencyNs returns 0 before any samples" {
+        var gv = game_view.GameView.init(std.testing.allocator);
+        defer gv.deinit();
+        try expect.equal(gv.meanLatencyNs(), @as(u64, 0));
+    }
+
+    test "meanLatencyNs averages every populated slot" {
+        var gv = game_view.GameView.init(std.testing.allocator);
+        defer gv.deinit();
+        gv.latency_ring[0] = 1_000_000;
+        gv.latency_ring[1] = 2_000_000;
+        gv.latency_ring[2] = 3_000_000;
+        gv.latency_count = 3;
+        // (1 + 2 + 3) / 3 == 2 ms.
+        try expect.equal(gv.meanLatencyNs(), @as(u64, 2_000_000));
+    }
+
+    test "meanLatencyNs uses latency_count, not the full capacity" {
+        // Guards against averaging across uninitialized slots after a
+        // fresh attach but before the ring fills.
+        var gv = game_view.GameView.init(std.testing.allocator);
+        defer gv.deinit();
+        gv.latency_ring[0] = 5_000_000;
+        // Slots [1..120) are zero-initialized; only slot 0 counts.
+        gv.latency_count = 1;
+        try expect.equal(gv.meanLatencyNs(), @as(u64, 5_000_000));
     }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2902,6 +2902,170 @@ pub const PreferencesTests = struct {
     }
 };
 
+pub const PreviewTransportTests = struct {
+    // Drives `PreviewSession` end-to-end against an in-test fake
+    // engine that dials the editor's listener and writes JSON
+    // frames. Subprocess spawn is **not** exercised here — tests
+    // use `bindListener` instead of `start(proj)` to skip the
+    // `labelle run` invocation.
+
+    const Timespec = extern struct { sec: isize, nsec: isize };
+    extern "c" fn nanosleep(req: *const Timespec, rem: ?*Timespec) c_int;
+    fn sleepMs(ms: u64) void {
+        const ts: Timespec = .{ .sec = @intCast(ms / 1000), .nsec = @intCast((ms % 1000) * 1_000_000) };
+        _ = nanosleep(&ts, null);
+    }
+
+    extern "c" fn connect(fd: c_int, addr: *const std.posix.sockaddr.in, len: std.posix.socklen_t) c_int;
+    extern "c" fn write(fd: c_int, buf: [*]const u8, len: usize) isize;
+    extern "c" fn close(fd: c_int) c_int;
+
+    /// Dial the editor's listener as if we were a freshly-spawned
+    /// engine. Returns the connected fd; caller writes JSON frames
+    /// via `write(2)`.
+    fn dialEditor(port: u16) !c_int {
+        const sock_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, 0);
+        if (sock_fd < 0) return error.SocketFailed;
+        const addr: std.posix.sockaddr.in = .{
+            .family = std.posix.AF.INET,
+            .port = std.mem.nativeToBig(u16, port),
+            .addr = std.mem.nativeToBig(u32, 0x7F000001),
+            .zero = .{ 0, 0, 0, 0, 0, 0, 0, 0 },
+        };
+        const rc = connect(@intCast(sock_fd), &addr, @sizeOf(@TypeOf(addr)));
+        if (rc < 0) return error.ConnectFailed;
+        return @intCast(sock_fd);
+    }
+
+    fn sendJsonLine(fd: c_int, body: []const u8) !void {
+        var off: usize = 0;
+        while (off < body.len) {
+            const n = write(fd, body.ptr + off, body.len - off);
+            if (n <= 0) return error.WriteFailed;
+            off += @intCast(n);
+        }
+    }
+
+    /// Poll the session until `predicate` returns true or the
+    /// deadline expires. Mirrors the engine-side `waitFor` pattern.
+    fn waitUntilState(p: *preview.PreviewSession, target: preview.State, deadline_ms: u64) !void {
+        var slept: u64 = 0;
+        while (slept < deadline_ms) {
+            p.poll();
+            if (p.state == target) return;
+            sleepMs(2);
+            slept += 2;
+        }
+        return error.DeadlineExceeded;
+    }
+
+    test "bindListener picks a port and lands in .listening" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+
+        try sess.bindListener();
+        try expect.equal(sess.state, preview.State.listening);
+        try expect.toBeTrue(sess.port != null);
+        try expect.toBeTrue(sess.port.? != 0);
+    }
+
+    test "hello frame transitions .connecting → .running and records engine_pid" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+
+        const port = sess.port.?;
+        const fd = try dialEditor(port);
+        // give the kernel a beat to land the SYN
+        try waitUntilState(&sess, .connecting, 500);
+
+        try sendJsonLine(fd, "{\"kind\":\"hello\",\"engine_version\":\"1.37.1\",\"pid\":12345,\"protocol_version\":1}\n");
+        try waitUntilState(&sess, .running, 500);
+        try expect.equal(sess.engine_pid.?, @as(i64, 12345));
+
+        _ = close(fd);
+    }
+
+    test "frame_offer fires on_frame_offer callback with shm_name + dims" {
+        const Capture = struct {
+            var got_name: [64]u8 = [_]u8{0} ** 64;
+            var got_name_len: usize = 0;
+            var got_width: u32 = 0;
+            var got_height: u32 = 0;
+            var fired: bool = false;
+
+            fn cb(_: *anyopaque, name: [:0]const u8, w: u32, h: u32) void {
+                fired = true;
+                got_name_len = @min(name.len, got_name.len);
+                @memcpy(got_name[0..got_name_len], name[0..got_name_len]);
+                got_width = w;
+                got_height = h;
+            }
+        };
+        Capture.fired = false;
+        Capture.got_name_len = 0;
+        Capture.got_width = 0;
+        Capture.got_height = 0;
+
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+        sess.on_frame_offer = .{ .ctx = &Capture.fired, .func = Capture.cb };
+
+        const fd = try dialEditor(sess.port.?);
+        try waitUntilState(&sess, .connecting, 500);
+        try sendJsonLine(fd, "{\"kind\":\"hello\",\"engine_version\":\"x\",\"pid\":1,\"protocol_version\":1}\n");
+        try waitUntilState(&sess, .running, 500);
+
+        try sendJsonLine(fd,
+            "{\"kind\":\"frame_offer\",\"shm_name\":\"/lbl-test\",\"width\":640,\"height\":360,\"format\":\"rgba8\",\"ring_size\":3,\"slot_size_bytes\":921600}\n");
+
+        // poll for ~500 ms waiting for the callback
+        var i: u32 = 0;
+        while (i < 250 and !Capture.fired) : (i += 1) {
+            sess.poll();
+            sleepMs(2);
+        }
+        try expect.toBeTrue(Capture.fired);
+        try std.testing.expectEqualStrings(Capture.got_name[0..Capture.got_name_len], "/lbl-test");
+        try expect.equal(Capture.got_width, @as(u32, 640));
+        try expect.equal(Capture.got_height, @as(u32, 360));
+
+        _ = close(fd);
+    }
+
+    test "bye frame transitions .running → .stopped and records reason" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+
+        const fd = try dialEditor(sess.port.?);
+        try waitUntilState(&sess, .connecting, 500);
+        try sendJsonLine(fd, "{\"kind\":\"hello\",\"engine_version\":\"\",\"pid\":7,\"protocol_version\":1}\n");
+        try waitUntilState(&sess, .running, 500);
+        try sendJsonLine(fd, "{\"kind\":\"bye\",\"reason\":\"normal\"}\n");
+        try waitUntilState(&sess, .stopped, 500);
+        try std.testing.expectEqualStrings(sess.bye_reason.?, "normal");
+
+        _ = close(fd);
+    }
+
+    test "EOF without bye lands in .crashed" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+
+        const fd = try dialEditor(sess.port.?);
+        try waitUntilState(&sess, .connecting, 500);
+        try sendJsonLine(fd, "{\"kind\":\"hello\",\"engine_version\":\"\",\"pid\":7,\"protocol_version\":1}\n");
+        try waitUntilState(&sess, .running, 500);
+
+        // Hard-close the engine fd without bye.
+        _ = close(fd);
+        try waitUntilState(&sess, .crashed, 500);
+    }
+};
+
 pub const GameViewLatencyTests = struct {
     // GameView.meanLatencyNs is pure math over its latency_ring; no
     // GL context needed. Compose the struct manually to test the


### PR DESCRIPTION
**Draft — queued for the moment labelle-engine#545 + #546 merge.**

Two-line cleanup once the engine PRs land:

1. `.github/workflows/ci.yml`: `ref: feat/544-pbo-shm-publish` → `ref: main` on the labelle-engine sibling checkout. Nothing more — the dep is a sibling-path checkout, no version bumping needed.
2. `build.zig.zon`: rewrites the temporary "pinned at feat/544 branch" comment with the actual long-term convention (sibling-path dep at dev time, release-time pin via `git+https://...?ref=vX.Y.Z#<hash>` — same trick labelle-cli's release uses).

## Why no tag bump?

Established toolkit pattern. `labelle-assembler/build.zig.zon` depends on `../labelle-gui/flow-codegen` by path. The game examples in `labelle-assembler/examples/*/project.labelle` pull `core`/`engine`/`gfx` via `local:` paths too. Path-deps are the dev-time default for sibling repos in the toolkit; tag pins enter the picture only at release-cut time.

Bonus: every engine fix doesn't need a follow-up labelle-gui PR to bump a pin.

## Diff stack

This branch is currently stacked on `feat/112-preview-transport-restore` (the top of #107/#112). The shown diff includes those parents until they merge — then this PR's net diff collapses to just the two-line flip.

## Stays draft until

- labelle-engine#545 (handshake) merges to engine main
- labelle-engine#546 (SHM publish) merges to engine main

Once both land, mark this Ready and ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)