### PR TITLE
fix(flow-codegen): emit depth-aware @import path for component types (#103)

### DIFF
--- a/flow-codegen/src/codegen.zig
+++ b/flow-codegen/src/codegen.zig
@@ -69,10 +69,13 @@ const std = @import("std");
 const flow_io = @import("flow_io.zig");
 
 /// Format string for `@import` paths to component type files in the
-/// assembler's project layout. Centralized so a future layout change
-/// (e.g. `src/components/<Name>.zig`) is a one-line edit. The `{s}`
+/// assembler's project layout. Zig resolves `@import` paths relative
+/// to the importing file's directory, and generated flows live at
+/// `<project>/scripts/flows/<name>.zig` (the v1 convention enforced
+/// by `flow_scanner` in labelle-assembler). Components live at
+/// `<project>/components/<Name>.zig` — two directories up. The `{s}`
 /// substitutes the component type name (`Position`, `Velocity`, …).
-const components_import_path_fmt = "components/{s}.zig";
+const components_import_path_fmt = "../../components/{s}.zig";
 
 /// Caller-facing configuration. `flow_name` is the stem of the
 /// source `.flow.zon` file — used as the first argument to
@@ -152,7 +155,7 @@ pub fn renderFlowZig(
 
     // Component imports: every type-name referenced by a
     // `GetComponent` or `SetField` node needs a matching
-    // `@import("components/<Name>.zig").<Name>` so the generated
+    // `@import("../../components/<Name>.zig").<Name>` so the generated
     // file resolves under the assembler's project layout. We sort
     // for deterministic output and de-duplicate so a single type
     // referenced from multiple nodes emits only one import. See

--- a/flow-codegen/test/root_test.zig
+++ b/flow-codegen/test/root_test.zig
@@ -693,7 +693,7 @@ pub const FlowCodegenTests = struct {
         const out = try renderFromZon(allocator, src, "imp_gc");
         defer allocator.free(out);
 
-        const needle = "const Position = @import(\"components/Position.zig\").Position;";
+        const needle = "const Position = @import(\"../../components/Position.zig\").Position;";
         try expect.toBeTrue(std.mem.indexOf(u8, out, needle) != null);
         // Exactly once -- no duplicate emission.
         var count: usize = 0;
@@ -733,7 +733,7 @@ pub const FlowCodegenTests = struct {
         const out = try renderFromZon(allocator, src, "imp_sf");
         defer allocator.free(out);
 
-        try expect.toBeTrue(std.mem.indexOf(u8, out, "const Position = @import(\"components/Position.zig\").Position;") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "const Position = @import(\"../../components/Position.zig\").Position;") != null);
         // And the SetField template still calls into the same name.
         try expect.toBeTrue(std.mem.indexOf(u8, out, "game.setField(Position, .x, entity, n1_value);") != null);
     }
@@ -761,7 +761,7 @@ pub const FlowCodegenTests = struct {
         const out = try renderFromZon(allocator, src, "imp_dup");
         defer allocator.free(out);
 
-        const needle = "const Position = @import(\"components/Position.zig\").Position;";
+        const needle = "const Position = @import(\"../../components/Position.zig\").Position;";
         var count: usize = 0;
         var start: usize = 0;
         while (std.mem.indexOfPos(u8, out, start, needle)) |at| {
@@ -790,8 +790,8 @@ pub const FlowCodegenTests = struct {
         const out = try renderFromZon(allocator, src, "imp_sort");
         defer allocator.free(out);
 
-        const pos_needle = "const Position = @import(\"components/Position.zig\").Position;";
-        const vel_needle = "const Velocity = @import(\"components/Velocity.zig\").Velocity;";
+        const pos_needle = "const Position = @import(\"../../components/Position.zig\").Position;";
+        const vel_needle = "const Velocity = @import(\"../../components/Velocity.zig\").Velocity;";
         const pos_at = std.mem.indexOf(u8, out, pos_needle) orelse return error.TestExpectedSubstring;
         const vel_at = std.mem.indexOf(u8, out, vel_needle) orelse return error.TestExpectedSubstring;
         try expect.toBeTrue(pos_at < vel_at);
@@ -863,7 +863,7 @@ pub const FlowCodegenTests = struct {
         const out = try renderFromZon(allocator, src, "imp_none");
         defer allocator.free(out);
 
-        try expect.toBeTrue(std.mem.indexOf(u8, out, "@import(\"components/") == null);
+        try expect.toBeTrue(std.mem.indexOf(u8, out, "@import(\"../../components/") == null);
     }
 
     test "output passes std.zig.Ast.parse without errors" {


### PR DESCRIPTION
## Summary

Generated flow files (`scripts/flows/<name>.zig`) had `@import("components/<Name>.zig")` — but Zig resolves `@import` paths relative to the importing file's directory, so the lookup hit `scripts/flows/components/<Name>.zig` (non-existent) instead of `<project>/components/<Name>.zig` (the real location, two dirs up).

Change `components_import_path_fmt` from `"components/{s}.zig"` to `"../../components/{s}.zig"`. Single-line behaviour change, plus the 5 test needles + 1 negative-test substring in `flow-codegen/test/root_test.zig` updated to assert the new path.

Picks Option 1 from the issue (depth-aware emission). The format string assumption — flows always live at `scripts/flows/<name>.zig` — is the v1 convention enforced by `flow_scanner` in labelle-assembler.

## Closes

- #103

## What this unblocks

#102 said it closed #96 (end-to-end compile gap) but didn't — `labelle-assembler#118`'s flows-smoke fixture papered over it with a `scripts/flows/components/<Name>.zig` symlink. With this PR merged that symlink can be deleted in a follow-up; the flows-smoke CI step in labelle-assembler should stay green without it.

## Test plan

- [x] `cd flow-codegen && zig build test` — 36/36 passing
- [x] top-level `zig build && zig build test` — passing
- [ ] Follow-up: remove `scripts/flows/components/` workaround in `labelle-assembler/examples/flows-smoke/` and confirm CI stays green (acceptance criterion from the issue; separate repo, separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)