### PR TITLE
ci: assert gui-tests reports N > 0 tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,37 @@ jobs:
             libxi6
 
       - name: Run UI tests under Xvfb
+        # Also asserts the test engine actually ran tests. PR #106 fixed
+        # a silent-pass bug (#105) where non-pub gui/run callbacks made
+        # `std.meta.hasFn` return false, so every TE test no-op-passed.
+        # The binary now exits 2 when zero tests run, but we re-check
+        # the printed summary here so the regression class can't ship
+        # again even if the in-binary guard ever breaks.
         run: |
           export DISPLAY=:99
           Xvfb :99 -screen 0 1280x720x24 &
           XVFB_PID=$!
           sleep 2
-          ./zig-out/bin/gui-tests
+          set +e
+          ./zig-out/bin/gui-tests 2>&1 | tee gui-tests.log
+          STATUS=${PIPESTATUS[0]}
+          set -e
           kill $XVFB_PID 2>/dev/null || true
+          # ImGui Test Engine prints "(<passed>/<tested> tests passed)"
+          # (imgui_te_exporters.cpp:47). Extract <tested>; fail loudly if
+          # it's missing or zero — a possible TE callback visibility
+          # regression (see #105).
+          TESTED=$(grep -oE '\([0-9]+/[0-9]+ tests passed\)' gui-tests.log | tail -n1 | grep -oE '/[0-9]+' | tr -d '/')
+          if [ -z "$TESTED" ]; then
+            echo "::error::no '(N/M tests passed)' summary line found in gui-tests output — possible TE callback visibility regression, see #105"
+            exit 1
+          fi
+          if [ "$TESTED" -le 0 ]; then
+            echo "::error::gui-tests reported 0 tests run — possible TE callback visibility regression, see #105"
+            exit 1
+          fi
+          echo "gui-tests ran $TESTED test(s)"
+          exit $STATUS
 
   # Process-launch sanity check — confirms the production binary starts,
   # doesn't crash for a few seconds, and renders something. Separate from


### PR DESCRIPTION
## Summary

- Augments the `ui-tests` job's "Run UI tests under Xvfb" step in `.github/workflows/ci.yml` to capture the `gui-tests` binary's stdout, parse the ImGui Test Engine's `(N/M tests passed)` summary line, and fail the step if `M == 0` (or if the line is missing).
- Preserves the binary's own exit code via `${PIPESTATUS[0]}` so genuine test failures still surface; the new check only adds a defense-in-depth assertion that *some* tests actually ran.

## Why

PR #106 fixed a silent-pass bug (#105) where non-`pub` `gui`/`run` callbacks tripped `std.meta.hasFn`, dropping the function pointers and turning every TE test into a no-op pass. The runner binary now self-checks (`std.process.exit(2)` when `tested == 0`), but the regression class is sneaky enough that CI should re-verify from the externally-visible summary too — so a future change to that in-binary guard can't silently bring the bug back.

The exact summary format comes from `imgui_te_exporters.cpp:47` (`printf("(%d/%d tests passed)\n", summary.CountSuccess, summary.CountTested);`).

## Test plan

- [x] Confirmed `zig build gui-test-build -Dcpu=baseline` still succeeds locally.
- [x] Validated YAML parses cleanly.
- [ ] On CI: `ui-tests` job should still pass on this branch (binary reports N > 0 tests).
- [ ] If a future change ever regresses #105, the new grep on `gui-tests.log` makes the failure obvious in the log: `::error::gui-tests reported 0 tests run — possible TE callback visibility regression, see #105`.