### PR TITLE
feat(preview): decode binary plane — entity / component / flow frames

### DIFF
--- a/src/preview.zig
+++ b/src/preview.zig
@@ -12,7 +12,7 @@
 //! ABI lesson re-learned in labelle-engine#545), so `poll()` returns
 //! promptly even when nothing has connected yet.
 //!
-//! Scope ceiling — this PR (#112) restores:
+//! Scope ceiling — this PR (#112) restored:
 //!   - hello / heartbeat / bye   (engine→editor JSON control frames)
 //!   - frame_offer               (engine→editor; #543 / drives
 //!                                `on_frame_offer` callback the App
@@ -20,11 +20,13 @@
 //!   - frame_published           (engine→editor; informational, no
 //!                                state change in editor for v1)
 //!
+//! #117 extends the scope with the **binary telemetry plane** —
+//! length-prefixed records led by an `ESC` (0x1B) magic byte. The
+//! reader peeks byte 0 of the inbox: `0x1B` → decode header + payload
+//! per `BinaryFrameKind`; `{` → newline-framed JSON as before. See the
+//! engine-side `preview_mode.zig` top-doc for the wire format.
+//!
 //! Out of scope (kept stubbed so consumer code compiles):
-//!   - binary plane frames (entity_created / entity_destroyed /
-//!     component_changed / node_entered / pin_value) — `on_component
-//!     _changed` / `on_node_entered` callback slots stay defined
-//!     but never fire.
 //!   - editor→engine uplink (subscribe / unsubscribe / watch_entity
 //!     / subscribe_flow / subscribe_pin_values) — methods stay
 //!     present but write nothing on the wire.
@@ -110,23 +112,54 @@ pub const FrameOfferCallback = struct {
     func: *const fn (ctx: *anyopaque, shm_name: [:0]const u8, width: u32, height: u32) void,
 };
 
-/// Callback invoked on `component_changed` binary frames. Stubbed —
-/// the transport doesn't decode the binary plane yet. The field is
-/// preserved so consumer code (entity_inspector, flow_runtime) compiles
-/// against the post-Phase-3 API shape.
+/// Callback invoked on `component_changed` binary frames (kind=3 of the
+/// preview-mode binary plane). `name` and `bytes` are borrowed slices
+/// into the inbox — valid only for the call duration. Copy before
+/// storing. App wires this to `EntityInspector` (#84 / #91).
 pub const ComponentChangedCallback = struct {
     ctx: *anyopaque,
     func: *const fn (ctx: *anyopaque, entity_id: u64, name: []const u8, bytes: []const u8) void,
 };
 
+/// Callback invoked on `node_entered` binary frames (kind=4). `flow_name`
+/// is a borrowed slice into the inbox — valid only for the call duration.
+/// App wires this to `FlowRuntime` for the flow-node pulse (#91).
 pub const NodeEnteredCallback = struct {
     ctx: *anyopaque,
     func: *const fn (ctx: *anyopaque, flow_name: []const u8, node_id: u32) void,
 };
 
-/// Inbox buffer cap. JSON frames are tiny (~100 B for hello,
-/// ~80 B for frame_offer); a few KB is plenty of slack.
-const inbox_cap: usize = 4 * 1024;
+/// Magic byte that flags a binary telemetry frame on the multiplexed
+/// socket — must match `preview_mode.binary_magic` on the engine side.
+/// `ESC` (0x1B) is chosen because no valid JSON document or whitespace
+/// prefix can begin with it; the reader peeks the first inbox byte to
+/// discriminate JSON vs binary.
+pub const binary_magic: u8 = 0x1B;
+
+/// Mirrors `preview_mode.BinaryFrameKind` on the engine side. Numbered
+/// explicitly because these go on the wire — appending is safe,
+/// reordering is a protocol break.
+pub const BinaryFrameKind = enum(u8) {
+    entity_created = 1,
+    entity_destroyed = 2,
+    component_changed = 3,
+    node_entered = 4,
+    pin_value = 5,
+    _,
+};
+
+/// Fixed 6-byte header preceding each binary payload:
+/// `[u8 magic] [u8 kind] [u32 length_LE]`. `length` covers the payload
+/// only — not the header.
+const binary_header_bytes: usize = 6;
+
+/// Inbox buffer cap. JSON control frames are tiny (~100 B for hello,
+/// ~80 B for frame_offer). Binary plane frames (component_changed
+/// in particular) carry per-component serialized payloads — for the
+/// scenes we ship today, a handful of components × a few hundred
+/// bytes each. 16 KB gives plenty of headroom; bump if a single
+/// component's serialized payload approaches that ceiling.
+const inbox_cap: usize = 16 * 1024;
 
 pub const PreviewSession = struct {
     allocator: std.mem.Allocator,
@@ -475,13 +508,22 @@ pub const PreviewSession = struct {
             };
         }
 
-        // Parse all complete newline-framed JSON lines.
-        while (std.mem.indexOfScalar(u8, self.inbox.items, '\n')) |nl| {
-            const line = self.inbox.items[0..nl];
-            self.handleFrame(line);
-            const remaining = self.inbox.items.len - (nl + 1);
-            std.mem.copyForwards(u8, self.inbox.items[0..remaining], self.inbox.items[nl + 1 ..]);
-            self.inbox.shrinkRetainingCapacity(remaining);
+        // Drain the inbox. Peek byte 0 of each pending record to
+        // route — `binary_magic` (0x1B) → length-prefixed binary
+        // frame; anything else → newline-framed JSON. Stops when no
+        // complete frame is available (binary frame's length bytes
+        // haven't all arrived yet, or no `\n` in the buffer).
+        while (self.inbox.items.len > 0) {
+            if (self.inbox.items[0] == binary_magic) {
+                if (!self.tryReadBinary()) break;
+            } else {
+                const nl = std.mem.indexOfScalar(u8, self.inbox.items, '\n') orelse break;
+                const line = self.inbox.items[0..nl];
+                self.handleFrame(line);
+                const remaining = self.inbox.items.len - (nl + 1);
+                std.mem.copyForwards(u8, self.inbox.items[0..remaining], self.inbox.items[nl + 1 ..]);
+                self.inbox.shrinkRetainingCapacity(remaining);
+            }
         }
 
         // Post-parse: if we hit EOF in the read loop, decide
@@ -492,6 +534,140 @@ pub const PreviewSession = struct {
         if (saw_eof and self.state != .stopped and self.bye_reason == null) {
             self.markCrashed("connection closed");
         }
+    }
+
+    /// Try to consume one binary frame from the head of the inbox.
+    /// Returns `true` if a full frame was decoded (and the caller can
+    /// loop for the next one), `false` if not enough bytes have
+    /// arrived yet (caller should bail until the next `poll`). Bumps
+    /// the session to `.crashed` on a malformed `kind`/`length`.
+    fn tryReadBinary(self: *Self) bool {
+        // Need the full 6-byte header before we can read `length`.
+        if (self.inbox.items.len < binary_header_bytes) return false;
+
+        // Header layout: [u8 magic=0x1B] [u8 kind] [u32 length-LE].
+        const kind_byte = self.inbox.items[1];
+        const length: u32 = std.mem.readInt(u32, self.inbox.items[2..6], .little);
+
+        // Reject oversize lengths up front so a corrupted byte stream
+        // doesn't park the decoder waiting forever for bytes the
+        // engine will never send.
+        if (binary_header_bytes + @as(usize, length) > inbox_cap) {
+            self.markCrashed("binary frame too large");
+            return false;
+        }
+
+        const total = binary_header_bytes + @as(usize, length);
+        if (self.inbox.items.len < total) return false; // Wait for more.
+
+        const payload = self.inbox.items[binary_header_bytes..total];
+        const kind: BinaryFrameKind = @enumFromInt(kind_byte);
+        self.handleBinaryFrame(kind, payload);
+
+        // Consume the frame.
+        const remaining = self.inbox.items.len - total;
+        std.mem.copyForwards(u8, self.inbox.items[0..remaining], self.inbox.items[total..]);
+        self.inbox.shrinkRetainingCapacity(remaining);
+        return true;
+    }
+
+    fn handleBinaryFrame(self: *Self, kind: BinaryFrameKind, payload: []const u8) void {
+        // Decoders consume `payload` in place — string slices are
+        // borrowed views into the inbox, valid for the call duration.
+        // No allocator needed today. Add a per-frame FBA scratch
+        // here if a future decoder needs heap (#119 review).
+        switch (kind) {
+            .entity_created => self.decodeEntityCreated(payload),
+            .entity_destroyed => self.decodeEntityDestroyed(payload),
+            .component_changed => self.decodeComponentChanged(payload),
+            .node_entered => self.decodeNodeEntered(payload),
+            .pin_value => self.decodePinValue(payload),
+            _ => {}, // Unknown kind — drop silently (forward-compat).
+        }
+    }
+
+    /// Payload: `[u64 entity_id] [u16 name_len] [name_len bytes]`.
+    /// No callback slot today (EntityInspector doesn't have a "new
+    /// entity announced" hook yet) — consume the bytes so the decoder
+    /// stays in sync.
+    fn decodeEntityCreated(self: *Self, payload: []const u8) void {
+        _ = self;
+        if (payload.len < 10) return; // u64 + u16 minimum.
+        // const entity_id = std.mem.readInt(u64, payload[0..8], .little);
+        const name_len: u16 = std.mem.readInt(u16, payload[8..10], .little);
+        if (10 + @as(usize, name_len) > payload.len) return;
+        // Borrowed slice (unused for now): payload[10 .. 10 + name_len].
+    }
+
+    /// Payload: `[u64 entity_id]`. No callback today.
+    fn decodeEntityDestroyed(self: *Self, payload: []const u8) void {
+        _ = self;
+        if (payload.len < 8) return;
+        // const entity_id = std.mem.readInt(u64, payload[0..8], .little);
+    }
+
+    /// Payload: `[u64 entity_id] [u16 name_len] [name bytes] [u32 data_len] [data bytes]`.
+    /// Fires `on_component_changed` with borrowed `name` + `bytes` slices.
+    fn decodeComponentChanged(self: *Self, payload: []const u8) void {
+        if (payload.len < 14) return; // u64 + u16 + u32 minimum.
+        const entity_id = std.mem.readInt(u64, payload[0..8], .little);
+        const name_len: u16 = std.mem.readInt(u16, payload[8..10], .little);
+        var off: usize = 10;
+        if (off + name_len > payload.len) return;
+        const name = payload[off .. off + name_len];
+        off += name_len;
+        if (off + 4 > payload.len) return;
+        const data_len: u32 = std.mem.readInt(u32, payload[off..][0..4], .little);
+        off += 4;
+        if (off + data_len > payload.len) return;
+        const bytes = payload[off .. off + data_len];
+
+        if (self.on_component_changed) |cb| {
+            cb.func(cb.ctx, entity_id, name, bytes);
+        }
+    }
+
+    /// Payload: `[u16 flow_name_len] [flow bytes] [u32 node_id]`.
+    /// Fires `on_node_entered` with the borrowed `flow_name` slice.
+    fn decodeNodeEntered(self: *Self, payload: []const u8) void {
+        if (payload.len < 6) return; // u16 + u32 minimum.
+        const flow_len: u16 = std.mem.readInt(u16, payload[0..2], .little);
+        var off: usize = 2;
+        if (off + flow_len > payload.len) return;
+        const flow_name = payload[off .. off + flow_len];
+        off += flow_len;
+        if (off + 4 > payload.len) return;
+        const node_id: u32 = std.mem.readInt(u32, payload[off..][0..4], .little);
+
+        if (self.on_node_entered) |cb| {
+            cb.func(cb.ctx, flow_name, node_id);
+        }
+    }
+
+    /// Payload: `[u16 flow_name_len] [flow bytes] [u32 node_id]
+    /// [u16 pin_name_len] [pin bytes] [f64 value]`. No callback slot
+    /// today (consumer tracked in #100); consume the bytes correctly
+    /// and drop the payload so the decoder stays in sync.
+    fn decodePinValue(self: *Self, payload: []const u8) void {
+        _ = self;
+        if (payload.len < 2) return;
+        const flow_len: u16 = std.mem.readInt(u16, payload[0..2], .little);
+        var off: usize = 2;
+        if (off + flow_len > payload.len) return;
+        off += flow_len;
+        if (off + 4 > payload.len) return;
+        // const node_id = std.mem.readInt(u32, payload[off..][0..4], .little);
+        off += 4;
+        if (off + 2 > payload.len) return;
+        const pin_len: u16 = std.mem.readInt(u16, payload[off..][0..2], .little);
+        off += 2;
+        if (off + pin_len > payload.len) return;
+        off += pin_len;
+        if (off + 8 > payload.len) return;
+        // f64 bit-pattern as u64 little-endian — reverse the producer's
+        // `@bitCast(u64, value)`:
+        // const bits = std.mem.readInt(u64, payload[off..][0..8], .little);
+        // const value: f64 = @bitCast(bits);
     }
 
     fn handleFrame(self: *Self, line: []const u8) void {
@@ -571,7 +747,8 @@ pub const PreviewSession = struct {
             // Informational — editor consumer polls the SHM ring
             // directly. Drop silently.
         }
-        // Unknown kinds (Phase 2 binary frames, etc.) drop silently.
+        // Unknown JSON kinds drop silently. Binary plane frames are
+        // routed by `tryReadBinary` before they ever reach this path.
     }
 
     fn drainChildStderr(self: *Self) void {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3102,6 +3102,307 @@ pub const IOSurfaceLayoutTests = struct {
     }
 };
 
+pub const PreviewBinaryPlaneTests = struct {
+    // Drives `PreviewSession` end-to-end against an in-test fake
+    // engine that dials the editor's listener and writes hand-built
+    // binary plane frames (the format `labelle-engine`'s
+    // `preview_mode.zig` emits via `writeBinaryFrame`). Mirrors
+    // `PreviewTransportTests` for the JSON control plane (#112).
+
+    const Timespec = extern struct { sec: isize, nsec: isize };
+    extern "c" fn nanosleep(req: *const Timespec, rem: ?*Timespec) c_int;
+    fn sleepMs(ms: u64) void {
+        const ts: Timespec = .{ .sec = @intCast(ms / 1000), .nsec = @intCast((ms % 1000) * 1_000_000) };
+        _ = nanosleep(&ts, null);
+    }
+
+    extern "c" fn connect(fd: c_int, addr: *const std.posix.sockaddr.in, len: std.posix.socklen_t) c_int;
+    extern "c" fn write(fd: c_int, buf: [*]const u8, len: usize) isize;
+    extern "c" fn close(fd: c_int) c_int;
+
+    fn dialEditor(port: u16) !c_int {
+        const sock_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, 0);
+        if (sock_fd < 0) return error.SocketFailed;
+        const addr: std.posix.sockaddr.in = .{
+            .family = std.posix.AF.INET,
+            .port = std.mem.nativeToBig(u16, port),
+            .addr = std.mem.nativeToBig(u32, 0x7F000001),
+            .zero = .{ 0, 0, 0, 0, 0, 0, 0, 0 },
+        };
+        const rc = connect(@intCast(sock_fd), &addr, @sizeOf(@TypeOf(addr)));
+        if (rc < 0) return error.ConnectFailed;
+        return @intCast(sock_fd);
+    }
+
+    fn writeAll(fd: c_int, bytes: []const u8) !void {
+        var off: usize = 0;
+        while (off < bytes.len) {
+            const n = write(fd, bytes.ptr + off, bytes.len - off);
+            if (n <= 0) return error.WriteFailed;
+            off += @intCast(n);
+        }
+    }
+
+    fn waitUntilState(p: *preview.PreviewSession, target: preview.State, deadline_ms: u64) !void {
+        var slept: u64 = 0;
+        while (slept < deadline_ms) {
+            p.poll();
+            if (p.state == target) return;
+            sleepMs(2);
+            slept += 2;
+        }
+        return error.DeadlineExceeded;
+    }
+
+    // Boilerplate: bind editor listener, dial from the fake engine,
+    // send `hello`, wait until `.running`. Returns the engine-side
+    // fd. Caller closes it.
+    fn connectPair(sess: *preview.PreviewSession) !c_int {
+        try sess.bindListener();
+        const fd = try dialEditor(sess.port.?);
+        try waitUntilState(sess, .connecting, 500);
+        try writeAll(fd, "{\"kind\":\"hello\",\"engine_version\":\"\",\"pid\":1,\"protocol_version\":1}\n");
+        try waitUntilState(sess, .running, 500);
+        return fd;
+    }
+
+    // Write a binary frame header [u8 magic] [u8 kind] [u32 len-LE]
+    // followed by `payload`, mirroring engine-side `writeBinaryFrame`.
+    fn writeBinaryFrame(fd: c_int, kind: preview.BinaryFrameKind, payload: []const u8) !void {
+        var header: [6]u8 = undefined;
+        header[0] = preview.binary_magic;
+        header[1] = @intFromEnum(kind);
+        std.mem.writeInt(u32, header[2..6], @intCast(payload.len), .little);
+        try writeAll(fd, &header);
+        if (payload.len > 0) try writeAll(fd, payload);
+    }
+
+    // Poll the session until `predicate` returns true or the deadline
+    // expires. Used for callback-firing tests where state doesn't
+    // transition.
+    fn waitUntil(sess: *preview.PreviewSession, ctx: anytype, predicate: *const fn (@TypeOf(ctx)) bool, deadline_ms: u64) !void {
+        var slept: u64 = 0;
+        while (slept < deadline_ms) {
+            sess.poll();
+            if (predicate(ctx)) return;
+            sleepMs(2);
+            slept += 2;
+        }
+        return error.DeadlineExceeded;
+    }
+
+    test "component_changed binary frame fires on_component_changed callback" {
+        const Capture = struct {
+            var fired: bool = false;
+            var got_entity: u64 = 0;
+            var got_name: [64]u8 = [_]u8{0} ** 64;
+            var got_name_len: usize = 0;
+            var got_bytes: [128]u8 = [_]u8{0} ** 128;
+            var got_bytes_len: usize = 0;
+
+            fn cb(_: *anyopaque, entity_id: u64, name: []const u8, bytes: []const u8) void {
+                fired = true;
+                got_entity = entity_id;
+                got_name_len = @min(name.len, got_name.len);
+                @memcpy(got_name[0..got_name_len], name[0..got_name_len]);
+                got_bytes_len = @min(bytes.len, got_bytes.len);
+                @memcpy(got_bytes[0..got_bytes_len], bytes[0..got_bytes_len]);
+            }
+        };
+        Capture.fired = false;
+        Capture.got_entity = 0;
+        Capture.got_name_len = 0;
+        Capture.got_bytes_len = 0;
+
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        sess.on_component_changed = .{ .ctx = &Capture.fired, .func = Capture.cb };
+        const fd = try connectPair(&sess);
+        defer _ = close(fd);
+
+        // Payload: [u64 entity_id=42] [u16 name_len=8] ["Position"]
+        //          [u32 data_len=4] [0xDE 0xAD 0xBE 0xEF]
+        const name = "Position";
+        const data = [_]u8{ 0xDE, 0xAD, 0xBE, 0xEF };
+        var payload_buf: [256]u8 = undefined;
+        var off: usize = 0;
+        std.mem.writeInt(u64, payload_buf[off..][0..8], 42, .little);
+        off += 8;
+        std.mem.writeInt(u16, payload_buf[off..][0..2], @intCast(name.len), .little);
+        off += 2;
+        @memcpy(payload_buf[off .. off + name.len], name);
+        off += name.len;
+        std.mem.writeInt(u32, payload_buf[off..][0..4], @intCast(data.len), .little);
+        off += 4;
+        @memcpy(payload_buf[off .. off + data.len], &data);
+        off += data.len;
+
+        try writeBinaryFrame(fd, .component_changed, payload_buf[0..off]);
+
+        const wait = struct {
+            fn fired(_: *bool) bool {
+                return Capture.fired;
+            }
+        };
+        try waitUntil(&sess, &Capture.fired, wait.fired, 500);
+
+        try expect.toBeTrue(Capture.fired);
+        try expect.equal(Capture.got_entity, @as(u64, 42));
+        try std.testing.expectEqualStrings(Capture.got_name[0..Capture.got_name_len], "Position");
+        try std.testing.expectEqualSlices(u8, Capture.got_bytes[0..Capture.got_bytes_len], &data);
+    }
+
+    test "node_entered binary frame fires on_node_entered callback" {
+        const Capture = struct {
+            var fired: bool = false;
+            var got_flow: [64]u8 = [_]u8{0} ** 64;
+            var got_flow_len: usize = 0;
+            var got_node: u32 = 0;
+
+            fn cb(_: *anyopaque, flow_name: []const u8, node_id: u32) void {
+                fired = true;
+                got_flow_len = @min(flow_name.len, got_flow.len);
+                @memcpy(got_flow[0..got_flow_len], flow_name[0..got_flow_len]);
+                got_node = node_id;
+            }
+        };
+        Capture.fired = false;
+        Capture.got_flow_len = 0;
+        Capture.got_node = 0;
+
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        sess.on_node_entered = .{ .ctx = &Capture.fired, .func = Capture.cb };
+        const fd = try connectPair(&sess);
+        defer _ = close(fd);
+
+        // Payload: [u16 flow_name_len=20] ["player_state_machine"] [u32 node_id=7]
+        const flow_name = "player_state_machine";
+        var payload_buf: [128]u8 = undefined;
+        var off: usize = 0;
+        std.mem.writeInt(u16, payload_buf[off..][0..2], @intCast(flow_name.len), .little);
+        off += 2;
+        @memcpy(payload_buf[off .. off + flow_name.len], flow_name);
+        off += flow_name.len;
+        std.mem.writeInt(u32, payload_buf[off..][0..4], 7, .little);
+        off += 4;
+
+        try writeBinaryFrame(fd, .node_entered, payload_buf[0..off]);
+
+        const wait = struct {
+            fn fired(_: *bool) bool {
+                return Capture.fired;
+            }
+        };
+        try waitUntil(&sess, &Capture.fired, wait.fired, 500);
+
+        try expect.toBeTrue(Capture.fired);
+        try std.testing.expectEqualStrings(Capture.got_flow[0..Capture.got_flow_len], "player_state_machine");
+        try expect.equal(Capture.got_node, @as(u32, 7));
+    }
+
+    // `entity_created` doesn't have a callback slot today (the
+    // Entity Inspector doesn't model "new entity announced" yet) —
+    // just verify the decoder consumes the bytes so following
+    // frames stay aligned.
+    test "entity_created binary frame is consumed (no callback)" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        const fd = try connectPair(&sess);
+        defer _ = close(fd);
+
+        // [u64 entity_id=99] [u16 name_len=6] ["player"]
+        const name = "player";
+        var payload_buf: [64]u8 = undefined;
+        var off: usize = 0;
+        std.mem.writeInt(u64, payload_buf[off..][0..8], 99, .little);
+        off += 8;
+        std.mem.writeInt(u16, payload_buf[off..][0..2], @intCast(name.len), .little);
+        off += 2;
+        @memcpy(payload_buf[off .. off + name.len], name);
+        off += name.len;
+
+        try writeBinaryFrame(fd, .entity_created, payload_buf[0..off]);
+
+        // Follow up with a heartbeat — the only way to confirm the
+        // decoder didn't get stuck on the binary frame's length
+        // prefix is to see a later JSON frame still parses.
+        try writeAll(fd, "{\"kind\":\"heartbeat\",\"t\":555}\n");
+        const wait = struct {
+            fn hb(p: *preview.PreviewSession) bool {
+                return (p.last_heartbeat_ms orelse 0) == 555;
+            }
+        };
+        try waitUntil(&sess, &sess, wait.hb, 500);
+        try expect.equal(sess.last_heartbeat_ms.?, @as(i64, 555));
+        try expect.equal(sess.state, preview.State.running);
+    }
+
+    // `entity_destroyed` has no callback slot today either — confirm
+    // the 8-byte payload is consumed and the stream stays aligned.
+    test "entity_destroyed binary frame is consumed (no callback)" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        const fd = try connectPair(&sess);
+        defer _ = close(fd);
+
+        var payload: [8]u8 = undefined;
+        std.mem.writeInt(u64, &payload, 123, .little);
+        try writeBinaryFrame(fd, .entity_destroyed, &payload);
+
+        try writeAll(fd, "{\"kind\":\"heartbeat\",\"t\":777}\n");
+        const wait = struct {
+            fn hb(p: *preview.PreviewSession) bool {
+                return (p.last_heartbeat_ms orelse 0) == 777;
+            }
+        };
+        try waitUntil(&sess, &sess, wait.hb, 500);
+        try expect.equal(sess.last_heartbeat_ms.?, @as(i64, 777));
+    }
+
+    // `pin_value` has no callback slot today (consumer tracked in
+    // #100) — confirm the variable-length payload is fully consumed
+    // so the stream stays aligned for the next frame.
+    test "pin_value binary frame is consumed (no callback)" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        const fd = try connectPair(&sess);
+        defer _ = close(fd);
+
+        // Payload: [u16 flow_len] [flow bytes] [u32 node_id]
+        //          [u16 pin_len] [pin bytes] [f64 value bits]
+        const flow_name = "main_flow";
+        const pin_name = "out";
+        var payload_buf: [128]u8 = undefined;
+        var off: usize = 0;
+        std.mem.writeInt(u16, payload_buf[off..][0..2], @intCast(flow_name.len), .little);
+        off += 2;
+        @memcpy(payload_buf[off .. off + flow_name.len], flow_name);
+        off += flow_name.len;
+        std.mem.writeInt(u32, payload_buf[off..][0..4], 13, .little);
+        off += 4;
+        std.mem.writeInt(u16, payload_buf[off..][0..2], @intCast(pin_name.len), .little);
+        off += 2;
+        @memcpy(payload_buf[off .. off + pin_name.len], pin_name);
+        off += pin_name.len;
+        const value: f64 = 3.14;
+        const bits: u64 = @bitCast(value);
+        std.mem.writeInt(u64, payload_buf[off..][0..8], bits, .little);
+        off += 8;
+
+        try writeBinaryFrame(fd, .pin_value, payload_buf[0..off]);
+
+        try writeAll(fd, "{\"kind\":\"heartbeat\",\"t\":1234}\n");
+        const wait = struct {
+            fn hb(p: *preview.PreviewSession) bool {
+                return (p.last_heartbeat_ms orelse 0) == 1234;
+            }
+        };
+        try waitUntil(&sess, &sess, wait.hb, 500);
+        try expect.equal(sess.last_heartbeat_ms.?, @as(i64, 1234));
+    }
+};
+
 pub const GameViewLatencyTests = struct {
     // GameView.meanLatencyNs is pure math over its latency_ring; no
     // GL context needed. Compose the struct manually to test the


### PR DESCRIPTION
Closes #117. Stacks on #112 (TCP transport restore — JSON control plane).

## Summary

- Adds a `tryReadBinary` path to `PreviewSession` that peeks byte 0 of the inbox: `0x1B` (`binary_magic`) → length-prefixed binary frame, anything else → the existing `\n`-framed JSON path. Length-prefixed reads buffer until the full payload has arrived.
- Decodes all five `BinaryFrameKind` variants documented in `labelle-engine/src/preview_mode.zig`:
  - `entity_created` (kind=1) — bytes consumed, no callback today
  - `entity_destroyed` (kind=2) — bytes consumed, no callback today
  - `component_changed` (kind=3) — fires `on_component_changed` (App → `EntityInspector`)
  - `node_entered` (kind=4) — fires `on_node_entered` (App → `FlowRuntime`)
  - `pin_value` (kind=5) — bytes consumed; callback slot tracked in #100
- Strings handed to callbacks (`name`, `flow_name`, `bytes`) are borrowed slices into the inbox, valid for the call duration only — matches the contract the `EntityInspector` / `FlowRuntime` panels already expected from the post-Phase-3 API shape.
- New `PreviewBinaryPlaneTests` scope in `src/tests.zig` mirrors the `PreviewTransportTests` pattern from #112: one test per kind, each drives `PreviewSession` to `.running` via `connectPair` + `hello`, hand-builds frame bytes matching the producer's `writeBinaryFrame`, writes to the harness fd, and asserts the callback payload (or for stream-aligned-only kinds, that a follow-up JSON `heartbeat` still parses past the variable-length payload).

## Wire format

```
[u8 magic=0x1B] [u8 kind] [u32 length_LE] [payload]
```

Per-kind payloads (all integers little-endian; strings are `[u16 len-LE] [bytes]`):

| kind | name | payload |
|------|----------------------|---------|
| 1 | `entity_created` | `[u64 entity_id] [u16 name_len] [name bytes]` |
| 2 | `entity_destroyed` | `[u64 entity_id]` |
| 3 | `component_changed` | `[u64 entity_id] [u16 name_len] [name bytes] [u32 data_len] [data bytes]` |
| 4 | `node_entered` | `[u16 flow_name_len] [flow bytes] [u32 node_id]` |
| 5 | `pin_value` | `[u16 flow_name_len] [flow bytes] [u32 node_id] [u16 pin_name_len] [pin bytes] [f64 value]` |

`f64` is the IEEE-754 bit-pattern via `@bitCast`, matching the producer.

## Out of scope

- Phase 2 uplink writes (`subscribe` / `watch_entity` / `subscribe_flow` / ...) — separate Phase 3 wiring; existing `PreviewSession` methods stay no-op stubs.
- Per-tick batching (labelle-engine#518 phase 2 polish on the producer side).
- Subscription-state mutations on the editor side.
- A callback slot for `pin_value` (consumer tracked in #100) and `entity_created` / `entity_destroyed` (no consumer wired yet — the panels will grow slots when they need them).

## Test plan

- [x] `zig build test` — all 175 tests pass locally on macOS (170 prior + 5 new in `PreviewBinaryPlaneTests`).
- [x] `zig build` — clean labelle-gui binary builds.
- [ ] CI: zspec test suite green on macOS + Linux.
- [ ] Smoke against a real running game once the engine's `subscribe_component` / `watch_entity` uplink lands: Entity Inspector should populate from live `component_changed` frames and the flow panel's node-pulse should light up on `node_entered`.

## Notes

The 165-test number in the parent ticket's "verify" checklist undercounted — the actual baseline on `feat/112-preview-transport-restore` is 170, so this PR lands 175 total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)