### PR TITLE
fix(test): triage #120 silent-passing TE tests

### DIFF
--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -194,37 +194,40 @@ pub fn main() !void {
     // process exits so the next run gets a clean shm slot.
     defer piePreviewStop();
 
-    // Skipped pending triage. Pub-fn fix in #106 surfaced a real
-    // failure here that was hidden by the silent-pass bug. See
-    // labelle-gui#120 for the audit.
-    //
-    // _ = engine.registerTest("phase3", "view_compiler_output_toggle", @src(), struct {
-    //     pub fn gui(_: *zgui.te.TestContext) !void {
-    //         // Synthetic dt; tests don't observe status_timer decay.
-    //         if (g_app) |a| a.renderFrame(1.0 / 60.0);
-    //     }
-    //     pub fn run(ctx: *zgui.te.TestContext) !void {
-    //         const a = g_app orelse {
-    //             _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
-    //             return;
-    //         };
-    //
-    //         // Sanity: panel starts closed.
-    //         _ = zgui.te.check(@src(), .{}, !a.show_compiler_output, "panel starts closed");
-    //
-    //         // Drive View > Compiler Output.
-    //         ctx.menuAction(.click, "View/Compiler Output");
-    //
-    //         // The toggle flips the same `bool` the panel reads, so the
-    //         // assertion below sees the update without waiting on another
-    //         // frame.
-    //         _ = zgui.te.check(@src(), .{}, a.show_compiler_output, "View/Compiler Output opens panel");
-    //
-    //         // Toggle off again to confirm the menu reflects current state.
-    //         ctx.menuAction(.click, "View/Compiler Output");
-    //         _ = zgui.te.check(@src(), .{}, !a.show_compiler_output, "View/Compiler Output closes panel");
-    //     }
-    // });
+    _ = engine.registerTest("phase3", "view_compiler_output_toggle", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            // Synthetic dt; tests don't observe status_timer decay.
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            // `MenuAction` walks relative to the test context's `RefID`;
+            // unset RefID makes the path's first segment be interpreted
+            // as a window name (e.g. "View" would be looked up as a
+            // top-level window), so anchor it to the main menu bar
+            // explicitly. The `ctx.yield(1)` after each click gives
+            // ImGui one frame to update the menu open/close state
+            // before the next item lookup.
+            ctx.setRef("//##MainMenuBar");
+
+            // Sanity: panel starts closed.
+            _ = zgui.te.check(@src(), .{}, !a.show_compiler_output, "panel starts closed");
+
+            // Drive View > Compiler Output.
+            ctx.menuAction(.click, "View/Compiler Output");
+            ctx.yield(1);
+            _ = zgui.te.check(@src(), .{}, a.show_compiler_output, "View/Compiler Output opens panel");
+
+            // Toggle off again to confirm the menu reflects current state.
+            ctx.menuAction(.click, "View/Compiler Output");
+            ctx.yield(1);
+            _ = zgui.te.check(@src(), .{}, !a.show_compiler_output, "View/Compiler Output closes panel");
+        }
+    });
 
     // Drop a scene file with a Sprite component into the temp project
     // so the Scene module's save test can exercise round-trip
@@ -289,56 +292,56 @@ pub fn main() !void {
         });
     }
 
-    // Skipped pending triage. Pub-fn fix in #106 surfaced a real
-    // failure here that was hidden by the silent-pass bug. See
-    // labelle-gui#120 for the audit.
-    //
-    // _ = engine.registerTest("phase3", "prefab_open_save_preserves_extras", @src(), struct {
-    //     pub fn gui(_: *zgui.te.TestContext) !void {
-    //         if (g_app) |a| a.renderFrame(1.0 / 60.0);
-    //     }
-    //     pub fn run(ctx: *zgui.te.TestContext) !void {
-    //         const a = g_app orelse {
-    //             _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
-    //             return;
-    //         };
-    //
-    //         const dir = g_settings_project_dir.?;
-    //         var path_buf: [512]u8 = undefined;
-    //         const path = std.fmt.bufPrint(&path_buf, "{s}/prefabs/coin.jsonc", .{dir}) catch return;
-    //
-    //         a.openPrefab(path) catch {
-    //             _ = zgui.te.check(@src(), .{}, false, "openPrefab must succeed");
-    //             return;
-    //         };
-    //         ctx.yield(1);
-    //
-    //         const opened_ok = a.open_tabs.items.len == 1 and
-    //             a.open_tabs.items[0] == .prefab and
-    //             a.open_tabs.items[0].prefab.loaded.component_extras.len == 2 and
-    //             a.open_tabs.items[0].prefab.loaded.children.len == 1;
-    //         _ = zgui.te.check(@src(), .{}, opened_ok, "prefab opened with 2 components + 1 child");
-    //
-    //         // Move the child's Position, save through the public API,
-    //         // and confirm the new position lands on disk while Sprite +
-    //         // Coin survive verbatim.
-    //         const tab = &a.open_tabs.items[0].prefab;
-    //         tab.loaded.children[0].position.?.x = 999;
-    //         tab.is_dirty = true;
-    //         prefab_mod.savePrefab(tab, a);
-    //         _ = zgui.te.check(@src(), .{}, !tab.is_dirty, "is_dirty cleared after Save");
-    //
-    //         const content = std.Io.Dir.cwd().readFileAlloc(io_global.io(), path, a.allocator, .limited(4096)) catch return;
-    //         defer a.allocator.free(content);
-    //
-    //         _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Sprite\"") != null, "Sprite preserved on disk");
-    //         _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Coin\"") != null, "Coin preserved on disk");
-    //         _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"x\": 999") != null, "child Position x persisted");
-    //         _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"children\":") != null, "children block emitted");
-    //
-    //         a.closeTab(0);
-    //     }
-    // });
+    _ = engine.registerTest("phase3", "prefab_open_save_preserves_extras", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            const dir = g_settings_project_dir.?;
+            var path_buf: [512]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "{s}/prefabs/coin.jsonc", .{dir}) catch return;
+
+            a.openPrefab(path) catch {
+                _ = zgui.te.check(@src(), .{}, false, "openPrefab must succeed");
+                return;
+            };
+            ctx.yield(1);
+
+            // Sprite is a typed/managed component so it round-trips
+            // through `loaded.entity.sprite`, not `component_extras`.
+            // The fixture has two top-level components (Sprite +
+            // Coin) but only Coin lands in extras.
+            const opened_ok = a.open_tabs.items.len == 1 and
+                a.open_tabs.items[0] == .prefab and
+                a.open_tabs.items[0].prefab.loaded.component_extras.len == 1 and
+                a.open_tabs.items[0].prefab.loaded.children.len == 1;
+            _ = zgui.te.check(@src(), .{}, opened_ok, "prefab opened with 1 extra (Coin) + 1 child");
+
+            // Move the child's Position, save through the public API,
+            // and confirm the new position lands on disk while Sprite +
+            // Coin survive verbatim.
+            const tab = &a.open_tabs.items[0].prefab;
+            tab.loaded.children[0].position.?.x = 999;
+            tab.is_dirty = true;
+            prefab_mod.savePrefab(tab, a);
+            _ = zgui.te.check(@src(), .{}, !tab.is_dirty, "is_dirty cleared after Save");
+
+            const content = std.Io.Dir.cwd().readFileAlloc(io_global.io(), path, a.allocator, .limited(4096)) catch return;
+            defer a.allocator.free(content);
+
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Sprite\"") != null, "Sprite preserved on disk");
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"Coin\"") != null, "Coin preserved on disk");
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"x\": 999") != null, "child Position x persisted");
+            _ = zgui.te.check(@src(), .{}, std.mem.indexOf(u8, content, "\"children\":") != null, "children block emitted");
+
+            a.closeTab(0);
+        }
+    });
 
     _ = engine.registerTest("phase3", "scene_open_save_preserves_extras", @src(), struct {
         pub fn gui(_: *zgui.te.TestContext) !void {
@@ -389,50 +392,58 @@ pub fn main() !void {
         }
     });
 
-    // Skipped pending triage. Pub-fn fix in #106 surfaced a real
-    // failure here that was hidden by the silent-pass bug. See
-    // labelle-gui#120 for the audit.
-    //
-    // _ = engine.registerTest("phase3", "resources_add_and_save", @src(), struct {
-    //     pub fn gui(_: *zgui.te.TestContext) !void {
-    //         // Synthetic dt; tests don't observe status_timer decay.
-    //         if (g_app) |a| a.renderFrame(1.0 / 60.0);
-    //     }
-    //     pub fn run(ctx: *zgui.te.TestContext) !void {
-    //         const a = g_app orelse {
-    //             _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
-    //             return;
-    //         };
-    //
-    //         ctx.menuAction(.click, "View/Resources");
-    //         _ = zgui.te.check(@src(), .{}, a.show_resources, "panel opened");
-    //
-    //         ctx.itemAction(.click, "Resources/Add", .{}, null);
-    //         _ = zgui.te.check(@src(), .{}, a.resources_editor.count == 1, "Add created a slot");
-    //
-    //         // Row 0's inputs live under the pushStrIdZ("row0") scope.
-    //         ctx.itemInputStrValue("Resources/row0/name", "sprites");
-    //         ctx.itemInputStrValue("Resources/row0/json", "assets/sprites.json");
-    //         ctx.itemInputStrValue("Resources/row0/texture", "assets/sprites.png");
-    //
-    //         ctx.itemAction(.click, "Resources/Save", .{}, null);
-    //
-    //         const proj = a.project_manager.current_project.?;
-    //         const in_memory = proj.config.resources.len == 1 and
-    //             std.mem.eql(u8, proj.config.resources[0].name, "sprites");
-    //         _ = zgui.te.check(@src(), .{}, in_memory, "config.resources updated in memory");
-    //
-    //         // Read project.labelle off disk and confirm the resource line is there.
-    //         const dir = g_settings_project_dir.?;
-    //         var path_buf: [512]u8 = undefined;
-    //         const path = std.fmt.bufPrint(&path_buf, "{s}/project.labelle", .{dir}) catch return;
-    //         const content = std.Io.Dir.cwd().readFileAlloc(io_global.io(), path, a.allocator, .limited(4096)) catch return;
-    //         defer a.allocator.free(content);
-    //         const on_disk = std.mem.indexOf(u8, content, "\"sprites\"") != null and
-    //             std.mem.indexOf(u8, content, "assets/sprites.json") != null;
-    //         _ = zgui.te.check(@src(), .{}, on_disk, "project.labelle on disk has the resource");
-    //     }
-    // });
+    _ = engine.registerTest("phase3", "resources_add_and_save", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            // Synthetic dt; tests don't observe status_timer decay.
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            ctx.setRef("//##MainMenuBar");
+            ctx.menuAction(.click, "View/Resources");
+            ctx.yield(1);
+            _ = zgui.te.check(@src(), .{}, a.show_resources, "panel opened");
+
+            // The panel's own widgets live under the "Resources" window
+            // — point the test ref there so itemAction can resolve
+            // "Add" / "row0/name" / etc. without spelling out the
+            // window every time.
+            ctx.setRef("Resources");
+
+            ctx.itemAction(.click, "Add", .{}, null);
+            _ = zgui.te.check(@src(), .{}, a.resources_editor.count == 1, "Add created a slot");
+
+            // Use the same fixture values the unit test in src/tests.zig
+            // round-trips (see "resources round-trip through save +
+            // load") so the on-disk values line up with
+            // ResourceFactory's defaults. Row 0's inputs live under
+            // the pushStrIdZ("row0") scope.
+            ctx.itemInputStrValue("row0/name", "sprites");
+            ctx.itemInputStrValue("row0/json", "assets/sprites.json");
+            ctx.itemInputStrValue("row0/texture", "assets/sprites.png");
+
+            ctx.itemAction(.click, "Save", .{}, null);
+
+            const proj = a.project_manager.current_project.?;
+            const in_memory = proj.config.resources.len == 1 and
+                std.mem.eql(u8, proj.config.resources[0].name, "sprites");
+            _ = zgui.te.check(@src(), .{}, in_memory, "config.resources updated in memory");
+
+            // Read project.labelle off disk and confirm the resource line is there.
+            const dir = g_settings_project_dir.?;
+            var path_buf: [512]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "{s}/project.labelle", .{dir}) catch return;
+            const content = std.Io.Dir.cwd().readFileAlloc(io_global.io(), path, a.allocator, .limited(4096)) catch return;
+            defer a.allocator.free(content);
+            const on_disk = std.mem.indexOf(u8, content, "\"sprites\"") != null and
+                std.mem.indexOf(u8, content, "assets/sprites.json") != null;
+            _ = zgui.te.check(@src(), .{}, on_disk, "project.labelle on disk has the resource");
+        }
+    });
 
     // Preview panel — toggle from View menu and drive the Stop button
     // path. We deliberately don't drive Run preview here because that
@@ -440,41 +451,38 @@ pub fn main() !void {
     // haven't landed --preview-mode yet). Hand-injecting a state via
     // the public API keeps this test hermetic — same pattern the
     // scene/prefab tests use to avoid touching nfd.
-    // Skipped pending triage. Pub-fn fix in #106 surfaced a real
-    // failure here that was hidden by the silent-pass bug. See
-    // labelle-gui#120 for the audit.
-    //
-    // _ = engine.registerTest("phase3", "preview_panel_toggle_and_stop", @src(), struct {
-    //     pub fn gui(_: *zgui.te.TestContext) !void {
-    //         if (g_app) |a| a.renderFrame(1.0 / 60.0);
-    //     }
-    //     pub fn run(ctx: *zgui.te.TestContext) !void {
-    //         const a = g_app orelse {
-    //             _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
-    //             return;
-    //         };
-    //
-    //         // Sanity: panel starts closed.
-    //         _ = zgui.te.check(@src(), .{}, !a.show_preview, "Preview panel starts closed");
-    //
-    //         // View menu toggle.
-    //         ctx.menuAction(.click, "View/Preview");
-    //         _ = zgui.te.check(@src(), .{}, a.show_preview, "View/Preview opens panel");
-    //
-    //         // From idle, isActive must be false and Stop is a no-op
-    //         // (state stays at .stopped after a stop call).
-    //         _ = zgui.te.check(@src(), .{}, !a.preview.isActive(), "preview starts inactive");
-    //
-    //         // Drive the Stop path through the App method — exercises
-    //         // the same code the panel button hits.
-    //         a.stopPreview();
-    //         _ = zgui.te.check(@src(), .{}, a.preview.state == .stopped, "Stop preview lands at .stopped");
-    //
-    //         // Toggle off again.
-    //         ctx.menuAction(.click, "View/Preview");
-    //         _ = zgui.te.check(@src(), .{}, !a.show_preview, "View/Preview closes panel");
-    //     }
-    // });
+    _ = engine.registerTest("phase3", "preview_panel_toggle_and_stop", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            ctx.setRef("//##MainMenuBar");
+
+            // Sanity: panel starts closed.
+            _ = zgui.te.check(@src(), .{}, !a.show_preview, "Preview panel starts closed");
+
+            // View menu toggle.
+            ctx.menuAction(.click, "View/Preview");
+            ctx.yield(1);
+            _ = zgui.te.check(@src(), .{}, a.show_preview, "View/Preview opens panel");
+
+            // From idle, isActive must be false.
+            _ = zgui.te.check(@src(), .{}, !a.preview.isActive(), "preview starts inactive");
+
+            a.stopPreview();
+            _ = zgui.te.check(@src(), .{}, !a.preview.isActive(), "preview still inactive after Stop");
+
+            // Toggle off again.
+            ctx.menuAction(.click, "View/Preview");
+            ctx.yield(1);
+            _ = zgui.te.check(@src(), .{}, !a.show_preview, "View/Preview closes panel");
+        }
+    });
 
     _ = engine.registerTest("phase3", "flow_opens_and_renders_graph", @src(), struct {
         pub fn gui(_: *zgui.te.TestContext) !void {
@@ -517,46 +525,45 @@ pub fn main() !void {
         }
     });
 
-    // Skipped pending triage. Pub-fn fix in #106 surfaced a real
-    // failure here that was hidden by the silent-pass bug. See
-    // labelle-gui#120 for the audit.
-    //
-    // _ = engine.registerTest("phase3", "project_settings_edit_save", @src(), struct {
-    //     pub fn gui(_: *zgui.te.TestContext) !void {
-    //         // Synthetic dt; tests don't observe status_timer decay.
-    //         if (g_app) |a| a.renderFrame(1.0 / 60.0);
-    //     }
-    //     pub fn run(ctx: *zgui.te.TestContext) !void {
-    //         const a = g_app orelse {
-    //             _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
-    //             return;
-    //         };
-    //
-    //         // Open the panel.
-    //         ctx.menuAction(.click, "View/Project Settings");
-    //         _ = zgui.te.check(@src(), .{}, a.show_project_settings, "panel opened");
-    //
-    //         // Type into the Title field and click Save. The button click
-    //         // also drives the on-disk write via ProjectManager.saveProject.
-    //         ctx.itemInputStrValue("Project Settings/Title", "Edited By TE");
-    //         ctx.itemAction(.click, "Project Settings/Save", .{}, null);
-    //
-    //         const proj = a.project_manager.current_project.?;
-    //         const in_memory = std.mem.eql(u8, proj.config.title, "Edited By TE");
-    //         _ = zgui.te.check(@src(), .{}, in_memory, "config.title updated in memory");
-    //
-    //         // Reread project.labelle from disk and confirm the new title
-    //         // landed there. Failure here means Save ran but didn't
-    //         // persist (the integration we actually care about).
-    //         const dir = g_settings_project_dir.?;
-    //         var path_buf: [512]u8 = undefined;
-    //         const path = std.fmt.bufPrint(&path_buf, "{s}/project.labelle", .{dir}) catch return;
-    //         const content = std.Io.Dir.cwd().readFileAlloc(io_global.io(), path, a.allocator, .limited(4096)) catch return;
-    //         defer a.allocator.free(content);
-    //         const on_disk = std.mem.indexOf(u8, content, "Edited By TE") != null;
-    //         _ = zgui.te.check(@src(), .{}, on_disk, "project.labelle on disk has new title");
-    //     }
-    // });
+    _ = engine.registerTest("phase3", "project_settings_edit_save", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            // Synthetic dt; tests don't observe status_timer decay.
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            ctx.setRef("//##MainMenuBar");
+            // Open the panel.
+            ctx.menuAction(.click, "View/Project Settings");
+            ctx.yield(1);
+            _ = zgui.te.check(@src(), .{}, a.show_project_settings, "panel opened");
+
+            // Type into the Title field and click Save. The button click
+            // also drives the on-disk write via ProjectManager.saveProject.
+            ctx.setRef("Project Settings");
+            ctx.itemInputStrValue("Title", "Edited By TE");
+            ctx.itemAction(.click, "Save", .{}, null);
+
+            const proj = a.project_manager.current_project.?;
+            const in_memory = std.mem.eql(u8, proj.config.title, "Edited By TE");
+            _ = zgui.te.check(@src(), .{}, in_memory, "config.title updated in memory");
+
+            // Reread project.labelle from disk and confirm the new title
+            // landed there. Failure here means Save ran but didn't
+            // persist (the integration we actually care about).
+            const dir = g_settings_project_dir.?;
+            var path_buf: [512]u8 = undefined;
+            const path = std.fmt.bufPrint(&path_buf, "{s}/project.labelle", .{dir}) catch return;
+            const content = std.Io.Dir.cwd().readFileAlloc(io_global.io(), path, a.allocator, .limited(4096)) catch return;
+            defer a.allocator.free(content);
+            const on_disk = std.mem.indexOf(u8, content, "Edited By TE") != null;
+            _ = zgui.te.check(@src(), .{}, on_disk, "project.labelle on disk has new title");
+        }
+    });
 
     // ── PIE viewport tests (#109) ──────────────────────────────────
     //


### PR DESCRIPTION
## Summary

Closes #120. PR #106 fixed the `std.meta.hasFn` requires-`pub` bug that
let `gui_tests.zig` callbacks register as no-ops; five phase3 tests then
started actually running and immediately failing. This PR walks each
test, fixes the stale parts, and un-skips them.

All five were stale (no real bugs surfaced):

- **view_compiler_output_toggle**, **resources_add_and_save**,
  **preview_panel_toggle_and_stop**, **project_settings_edit_save** —
  `TestContext.MenuAction(path)` requires `RefID != 0`; otherwise it
  parses the first path segment as a window name (so `"View/..."` was
  looking up a window literally named `View`). Anchor each test to
  `//##MainMenuBar` via `setRef` before walking the View menu, and
  `yield(1)` between consecutive clicks so the menu open/close state
  settles before the next item lookup.

- **resources_add_and_save**, **project_settings_edit_save** — also
  rescope `setRef` to the panel window for post-open `itemAction` /
  `itemInputStrValue` calls, dropping the now-redundant `Resources/` /
  `Project Settings/` prefix on each ref.

- **preview_panel_toggle_and_stop** — `PreviewSession.stop()` only
  transitions `.listening/.connecting/.running → .stopped`; from
  `.idle` it's a no-op. Assert `!preview.isActive()` instead of
  `state == .stopped`.

- **prefab_open_save_preserves_extras** — `Sprite` is a managed
  component now (round-trips through `loaded.entity.sprite`), so the
  fixture's two top-level components yield one `component_extras`
  entry (`Coin`), not two.

## Test plan

- [x] `zig build gui-test` → 8/8 pass
- [x] `zig build test` → 180/180 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)