### PR TITLE
feat(preview): dispatch iosurface consumer on frame_offer.format

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -181,6 +181,19 @@ pub fn build(b: *std.Build) void {
     gui_tests_exe.root_module.addImport("nfd", nfd.module("nfd"));
     gui_tests_exe.root_module.addImport("engine", engine_module);
 
+    // macOS-only frameworks — same set as the production `exe` above.
+    // The iosurface dispatch test (PIE viewport) drives the real
+    // `iosurface.Consumer` + `bindSurface`, which call into
+    // `CGLTexImageIOSurface2D` / `CGLGetCurrentContext`. Without the
+    // OpenGL framework, the gui-tests binary fails to link on macOS
+    // even though only one TE test exercises the path. See
+    // labelle-gui#108 for the upstream rationale.
+    if (target.result.os.tag == .macos) {
+        gui_tests_exe.root_module.linkFramework("IOSurface", .{});
+        gui_tests_exe.root_module.linkFramework("CoreFoundation", .{});
+        gui_tests_exe.root_module.linkFramework("OpenGL", .{});
+    }
+
     const run_gui_tests = b.addRunArtifact(gui_tests_exe);
     const gui_test_step = b.step("gui-test", "Run the UI test runner");
     gui_test_step.dependOn(&run_gui_tests.step);

--- a/src/app.zig
+++ b/src/app.zig
@@ -278,14 +278,14 @@ pub const App = struct {
         app.preview.on_frame_offer = .{
             .ctx = app,
             .func = struct {
-                fn cb(ctx: *anyopaque, shm_name: [:0]const u8, width: u32, height: u32) void {
+                fn cb(ctx: *anyopaque, shm_name: [:0]const u8, width: u32, height: u32, format: []const u8) void {
                     _ = width;
                     _ = height;
                     const a: *App = @ptrCast(@alignCast(ctx));
-                    a.attachGameView(shm_name) catch |err| {
+                    a.attachGameView(shm_name, format) catch |err| {
                         std.log.warn(
-                            "preview: attachGameView('{s}') failed: {s}",
-                            .{ shm_name, @errorName(err) },
+                            "preview: attachGameView('{s}', '{s}') failed: {s}",
+                            .{ shm_name, format, @errorName(err) },
                         );
                     };
                 }
@@ -347,7 +347,9 @@ pub const App = struct {
         if (io_global.environ().getAlloc(allocator, "LABELLE_GAME_VIEW_SHM") catch null) |raw| {
             defer allocator.free(raw);
             if (raw.len > 0) {
-                app.game_view.attach(raw) catch |err| {
+                // Env-var hook is shm-only; the iosurface dispatch
+                // arrives through the engine's `frame_offer` JSON.
+                app.game_view.attach(raw, "bgra8") catch |err| {
                     std.log.warn("game_view: attach('{s}') failed: {s}", .{ raw, @errorName(err) });
                 };
                 if (app.game_view.isAttached()) app.show_game_view = true;
@@ -378,12 +380,14 @@ pub const App = struct {
 
     /// Open the SHM region the engine advertised in `frame_offer`
     /// (#107). Convenience wrapper that surfaces the panel
-    /// automatically on a successful attach. Used both by the
-    /// LABELLE_GAME_VIEW_SHM startup hook and by external test
-    /// code; will also be the seam the eventual preview-transport
-    /// restore plugs into.
-    pub fn attachGameView(self: *Self, shm_name: []const u8) !void {
-        try self.game_view.attach(shm_name);
+    /// automatically on a successful attach.
+    ///
+    /// `format` mirrors the engine's `frame_offer.format` field —
+    /// `"bgra8"` (the default for legacy callers) routes to the SHM
+    /// CPU upload path, `"iosurface_bgra8"` routes to the macOS
+    /// zero-copy path. Anything else falls back to SHM.
+    pub fn attachGameView(self: *Self, shm_name: []const u8, format: []const u8) !void {
+        try self.game_view.attach(shm_name, format);
         self.show_game_view = true;
     }
 

--- a/src/game_view.zig
+++ b/src/game_view.zig
@@ -1,15 +1,29 @@
 //! Embedded game-view panel state.
 //!
-//! Owns the consumer side of the PIE viewport pixel ring: opens an
-//! `engine.preview_mode.preview_shm.Consumer` against a SHM region
-//! the engine allocated, mirrors each new frame into a `GL_TEXTURE_2D`
-//! via `glTexSubImage2D`, and tracks end-to-end latency for the
-//! Stats overlay.
+//! Owns the consumer side of the PIE viewport pixel ring. Two transport
+//! modes are supported via the `ConsumerMode` sum type:
 //!
-//! Pairs with `src/modules/game_view.zig` — that file wraps this
-//! state in a togglable ImGui panel and registers it with the
-//! Module Registry. This file is UI-free so the texture / consumer
-//! lifecycle is testable headless.
+//!   - `.shm`         — `preview_shm.Consumer`. Engine memcpys BGRA8/
+//!                       RGBA8 pixels into a POSIX shm ring; per frame
+//!                       we `glTexSubImage2D` the latest slot into a
+//!                       `GL_TEXTURE_2D`.
+//!   - `.iosurface`   — macOS-only. `iosurface.Consumer` looks up an
+//!                       IOSurface ring (id list lives in the shm
+//!                       region's ControlBlock); each surface is
+//!                       pre-bound to a `GL_TEXTURE_RECTANGLE` via
+//!                       `CGLTexImageIOSurface2D`. Per frame we FBO-blit
+//!                       the rectangle texture into a `GL_TEXTURE_2D`
+//!                       (the target zgui.image actually samples, since
+//!                       `imgui_impl_opengl3` hardcodes `GL_TEXTURE_2D`).
+//!
+//! The dispatch happens at `attach` time, driven by the `format` field
+//! of the engine's `frame_offer` JSON frame: `"bgra8"` (or unset) takes
+//! the SHM path, `"iosurface_bgra8"` takes the iosurface path on macOS.
+//!
+//! Pairs with `src/modules/game_view.zig` — that file wraps this state
+//! in a togglable ImGui panel and registers it with the Module Registry.
+//! This file is UI-free so the texture / consumer lifecycle is testable
+//! headless.
 //!
 //! Architecture validated end-to-end in `imgui-preview-poc/src/editor.zig`
 //! at 1280×720@60 with raw-IPC p50=5µs on Apple Silicon. This module
@@ -21,8 +35,10 @@
 //! handshake (#543) that delivers `frame_offer` payloads.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const zopengl = @import("zopengl");
 const engine = @import("engine");
+const iosurface = @import("iosurface.zig");
 const shm = engine.preview_mode_mod.preview_shm;
 
 const gl = zopengl.bindings;
@@ -31,27 +47,62 @@ const latency_ring_capacity: usize = 120;
 
 /// Errors specific to `GameView.attach`. SHM-open / mmap failures
 /// from `preview_shm.Consumer.init` (`error.ShmOpenFailed`, etc.)
-/// propagate verbatim; the shm_name-dupe step folds into
-/// `error.OutOfMemory`.
-pub const AttachError = shm.Error || error{OutOfMemory};
+/// propagate verbatim. IOSurface lookup failures from
+/// `iosurface.Consumer.init` (`error.ControlBlockMissing`, etc.) join
+/// the set. The shm_name-dupe step folds into `error.OutOfMemory`.
+pub const AttachError = shm.Error || iosurface.Error || error{
+    OutOfMemory,
+    /// `GL_TEXTURE_RECTANGLE` ↔ `GL_TEXTURE_2D` FBO blit setup failed.
+    /// Surfaces either a `CGLTexImageIOSurface2D` non-zero return or
+    /// an incomplete framebuffer status — both are unrecoverable, so
+    /// the consumer rolls back and the caller can fall back to SHM.
+    IosurfaceGlBindFailed,
+};
+
+/// Which transport this `GameView` is currently fronting. Set at
+/// `attach` time from the `format` argument; `detach` resets to the
+/// implicit `.none` (the field is `?ConsumerMode = null` on `GameView`,
+/// not an explicit variant).
+pub const ConsumerMode = union(enum) {
+    shm: shm.Consumer,
+    /// macOS-only. The `iosurface.Consumer` owns the IOSurface refs
+    /// (one CFRelease per ref on `deinit`); we layer rectangle GL
+    /// textures + an FBO blit on top so ImGui can sample a
+    /// `GL_TEXTURE_2D`.
+    iosurface: iosurface.Consumer,
+};
 
 pub const GameView = struct {
     allocator: std.mem.Allocator,
-    /// `null` until `attach` opens a consumer.
-    consumer: ?shm.Consumer = null,
+    /// `null` until `attach` opens a consumer. Tagged by transport mode.
+    consumer: ?ConsumerMode = null,
     /// Owned (allocator-allocated, NUL-terminated) duplicate of the
-    /// shm_name passed to `attach`. `engine.preview_shm.Consumer`
-    /// stashes the name slice and we want a stable pointer for the
-    /// lifetime of the consumer — caller-provided buffers might be
-    /// stack-allocated or env-var scratch space.
+    /// shm_name passed to `attach`. Both consumer variants stash a
+    /// copy of the name internally; we keep our own as the long-lived
+    /// backing store so the caller's buffer can be ephemeral.
     owned_shm_name: ?[:0]u8 = null,
-    /// GL texture handle for the displayed frame. Zero when no texture
-    /// is currently allocated. Width/height kept alongside so a
-    /// frame_resize landed on the SHM ring lets us re-allocate the
-    /// texture instead of misaligned `glTexSubImage2D` uploads.
+    /// GL texture handle for the displayed frame — always
+    /// `GL_TEXTURE_2D`, regardless of transport. In shm mode we
+    /// `glTexSubImage2D` straight into it; in iosurface mode we FBO-
+    /// blit from a `GL_TEXTURE_RECTANGLE` into it.
     tex_id: gl.Uint = 0,
     tex_w: u32 = 0,
     tex_h: u32 = 0,
+    /// iosurface mode: one rectangle texture per ring slot, pre-bound
+    /// to its IOSurface via `CGLTexImageIOSurface2D`. The binding is
+    /// "live" — producer writes become visible automatically; we
+    /// rebind the source FBO each frame to pick up the new pixels.
+    /// All slots are 0 in shm mode.
+    rect_tex_ids: [iosurface.MAX_RING]gl.Uint = [_]gl.Uint{0} ** iosurface.MAX_RING,
+    /// iosurface mode: ring size captured at attach. 0 in shm mode.
+    /// Bounded by `iosurface.MAX_RING` upstream of here.
+    rect_count: u32 = 0,
+    /// iosurface mode: source-side FBO. Read attachment rotates per
+    /// frame onto the slot's rectangle texture. 0 in shm mode.
+    read_fbo: gl.Uint = 0,
+    /// iosurface mode: destination-side FBO. Pre-attached at `attach`
+    /// to `tex_id`; never re-attached. 0 in shm mode.
+    draw_fbo: gl.Uint = 0,
     /// `null` before the first frame is uploaded; the frame_idx of
     /// the texture's current contents once a frame has been seen.
     /// Optional so a producer frame_idx of 0 doesn't collide with
@@ -85,11 +136,14 @@ pub const GameView = struct {
         self.detach();
     }
 
-    /// Open the named SHM region the engine allocated for this
-    /// session and stand up a matching `GL_TEXTURE_2D`. The GL
-    /// context must be current on the calling thread (which it
+    /// Open the named region the engine advertised and stand up a
+    /// matching `GL_TEXTURE_2D`. `format` is the `frame_offer.format`
+    /// field (typically `"bgra8"` or `"iosurface_bgra8"`); an empty
+    /// or unrecognised value falls back to the SHM CPU upload path.
+    ///
+    /// The GL context must be current on the calling thread (which it
     /// always is on the main thread for labelle-gui's frame loop).
-    pub fn attach(self: *Self, shm_name: []const u8) AttachError!void {
+    pub fn attach(self: *Self, shm_name: []const u8, format: []const u8) AttachError!void {
         // Auto-detach any prior session — the engine emits a fresh
         // `frame_offer` on resize / restart, and forcing the caller
         // to manually detach first would block routine resolution
@@ -99,6 +153,29 @@ pub const GameView = struct {
         const owned = self.allocator.dupeZ(u8, shm_name) catch return error.OutOfMemory;
         errdefer self.allocator.free(owned);
 
+        // Dispatch on the engine-advertised format. Non-macOS hosts
+        // ignore `iosurface_bgra8` and fall back to SHM so a mixed
+        // engine/editor pair doesn't deadlock — the engine producer
+        // returns `error.PlatformUnsupported` if it can't build the
+        // surface ring, so an iosurface-mode offer should only arrive
+        // on macOS in practice. The fallback is belt-and-braces.
+        const want_iosurface = std.mem.eql(u8, format, "iosurface_bgra8") and builtin.os.tag == .macos;
+
+        if (want_iosurface) {
+            try self.attachIosurface(owned);
+        } else {
+            try self.attachShm(owned);
+        }
+        self.owned_shm_name = owned;
+        self.last_frame_idx = null;
+        self.last_latency_ns = 0;
+        self.dropped = 0;
+        self.presented = 0;
+        self.latency_head = 0;
+        self.latency_count = 0;
+    }
+
+    fn attachShm(self: *Self, owned: [:0]u8) AttachError!void {
         var consumer = try shm.Consumer.init(owned);
         errdefer consumer.deinit();
 
@@ -108,8 +185,7 @@ pub const GameView = struct {
         // Build a zero-initialized texture; per-frame uploads will
         // `glTexSubImage2D` into it. `GL_RGBA8` matches the SHM's
         // RGBA8 pixel format. `GL_CLAMP_TO_EDGE` avoids edge-bleed
-        // when the panel renders the texture at a non-integer
-        // scale.
+        // when the panel renders the texture at a non-integer scale.
         var tex: gl.Uint = 0;
         gl.genTextures(1, &tex);
         gl.bindTexture(gl.TEXTURE_2D, tex);
@@ -129,24 +205,118 @@ pub const GameView = struct {
             null,
         );
 
-        self.consumer = consumer;
-        self.owned_shm_name = owned;
+        self.consumer = .{ .shm = consumer };
         self.tex_id = tex;
         self.tex_w = w;
         self.tex_h = h;
-        self.last_frame_idx = null;
-        self.last_latency_ns = 0;
-        self.dropped = 0;
-        self.presented = 0;
-        self.latency_head = 0;
-        self.latency_count = 0;
+    }
+
+    fn attachIosurface(self: *Self, owned: [:0]u8) AttachError!void {
+        // Non-macOS shouldn't reach here (`attach` gates on
+        // `builtin.os.tag == .macos`), but the consumer init itself
+        // guards too — returns `error.PlatformUnsupported` which
+        // bubbles up through `AttachError`.
+        var consumer = try iosurface.Consumer.init(owned);
+        errdefer consumer.deinit();
+
+        const w = consumer.width;
+        const h = consumer.height;
+        const ring = consumer.ring_size;
+
+        // Destination GL_TEXTURE_2D — the handle imgui_impl_opengl3
+        // ultimately samples. Per-frame FBO blit fills it from the
+        // rectangle texture matching the freshest IOSurface slot.
+        var tex: gl.Uint = 0;
+        gl.genTextures(1, &tex);
+        errdefer {
+            if (tex != 0) gl.deleteTextures(1, &tex);
+        }
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA8,
+            @intCast(w),
+            @intCast(h),
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            null,
+        );
+
+        // One GL_TEXTURE_RECTANGLE per ring slot, each pre-bound to
+        // its IOSurface. Stays bound for the consumer's lifetime —
+        // producer pixel writes become visible automatically because
+        // `CGLTexImageIOSurface2D` keeps the surface ↔ texture link
+        // live. Caller's per-frame `poll` only rebinds the FBO's
+        // source attachment to pick the current slot.
+        var rect_tex_ids: [iosurface.MAX_RING]gl.Uint = [_]gl.Uint{0} ** iosurface.MAX_RING;
+        var created: u32 = 0;
+        errdefer {
+            var i: u32 = 0;
+            while (i < created) : (i += 1) {
+                if (rect_tex_ids[i] != 0) gl.deleteTextures(1, &rect_tex_ids[i]);
+            }
+        }
+        while (created < ring) : (created += 1) {
+            gl.genTextures(1, &rect_tex_ids[created]);
+            gl.bindTexture(iosurface.GL_TEXTURE_RECTANGLE, rect_tex_ids[created]);
+            gl.texParameteri(iosurface.GL_TEXTURE_RECTANGLE, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+            gl.texParameteri(iosurface.GL_TEXTURE_RECTANGLE, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+            gl.texParameteri(iosurface.GL_TEXTURE_RECTANGLE, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(iosurface.GL_TEXTURE_RECTANGLE, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+            const surf = consumer.surfaceAt(created);
+            const rc = iosurface.bindSurface(surf, w, h);
+            if (rc != 0) {
+                std.log.warn("iosurface: CGLTexImageIOSurface2D slot={d} rc={d}", .{ created, rc });
+                return error.IosurfaceGlBindFailed;
+            }
+        }
+        gl.bindTexture(iosurface.GL_TEXTURE_RECTANGLE, 0);
+
+        // FBOs: pre-create both, pre-attach the destination 2D
+        // texture; the source attachment rotates per frame in `poll`.
+        var read_fbo: gl.Uint = 0;
+        var draw_fbo: gl.Uint = 0;
+        gl.genFramebuffers(1, &read_fbo);
+        errdefer {
+            if (read_fbo != 0) gl.deleteFramebuffers(1, &read_fbo);
+        }
+        gl.genFramebuffers(1, &draw_fbo);
+        errdefer {
+            if (draw_fbo != 0) gl.deleteFramebuffers(1, &draw_fbo);
+        }
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, draw_fbo);
+        gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+        const status = gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, 0);
+        if (status != gl.FRAMEBUFFER_COMPLETE) {
+            std.log.warn("iosurface: draw_fbo incomplete: 0x{x}", .{status});
+            return error.IosurfaceGlBindFailed;
+        }
+
+        self.consumer = .{ .iosurface = consumer };
+        self.tex_id = tex;
+        self.tex_w = w;
+        self.tex_h = h;
+        self.rect_tex_ids = rect_tex_ids;
+        self.rect_count = ring;
+        self.read_fbo = read_fbo;
+        self.draw_fbo = draw_fbo;
     }
 
     /// Tear down the consumer + GL texture. Safe to call when not
     /// attached; called by `deinit`.
     pub fn detach(self: *Self) void {
         if (self.consumer) |*c| {
-            c.deinit();
+            switch (c.*) {
+                .shm => |*sc| sc.deinit(),
+                .iosurface => |*ic| ic.deinit(),
+            }
             self.consumer = null;
         }
         if (self.owned_shm_name) |n| {
@@ -157,6 +327,23 @@ pub const GameView = struct {
             gl.deleteTextures(1, &self.tex_id);
             self.tex_id = 0;
         }
+        // iosurface auxiliary state — no-ops in shm mode (handles are 0).
+        var i: u32 = 0;
+        while (i < self.rect_count) : (i += 1) {
+            if (self.rect_tex_ids[i] != 0) {
+                gl.deleteTextures(1, &self.rect_tex_ids[i]);
+                self.rect_tex_ids[i] = 0;
+            }
+        }
+        self.rect_count = 0;
+        if (self.read_fbo != 0) {
+            gl.deleteFramebuffers(1, &self.read_fbo);
+            self.read_fbo = 0;
+        }
+        if (self.draw_fbo != 0) {
+            gl.deleteFramebuffers(1, &self.draw_fbo);
+            self.draw_fbo = 0;
+        }
         self.tex_w = 0;
         self.tex_h = 0;
     }
@@ -165,14 +352,22 @@ pub const GameView = struct {
         return self.consumer != null;
     }
 
-    /// Poll the SHM ring for a newer frame. If one is available,
-    /// upload it to the texture and update the stats. Call once per
-    /// editor frame from the main loop.
+    /// Poll the active consumer for a newer frame. If one is available,
+    /// either `glTexSubImage2D` (shm) or FBO-blit (iosurface) it onto
+    /// `tex_id` and update the stats. Call once per editor frame from
+    /// the main loop.
     ///
     /// Returns true when a new frame was uploaded — handy for tests
     /// + future "redraw only on new frame" optimization.
     pub fn poll(self: *Self) bool {
-        const consumer = if (self.consumer) |*c| c else return false;
+        const consumer_ptr = if (self.consumer) |*c| c else return false;
+        return switch (consumer_ptr.*) {
+            .shm => |*sc| self.pollShm(sc),
+            .iosurface => |*ic| self.pollIosurface(ic),
+        };
+    }
+
+    fn pollShm(self: *Self, consumer: *shm.Consumer) bool {
         const frame = consumer.latest() orelse return false;
 
         // Defensive: producer's resize should have triggered a re-
@@ -193,26 +388,78 @@ pub const GameView = struct {
             frame.pixels,
         );
 
+        self.recordFrameStats(frame.frame_idx, frame.produce_ns);
+        return true;
+    }
+
+    fn pollIosurface(self: *Self, consumer: *iosurface.Consumer) bool {
+        const frame = consumer.latest() orelse return false;
+        if (frame.slot >= self.rect_count) return false;
+
+        // Per Apple's CGLTexImageIOSurface2D contract: rebind the source
+        // texture before sampling so the GL driver picks up the
+        // producer's most recent IOSurface writes.
+        gl.bindTexture(iosurface.GL_TEXTURE_RECTANGLE, self.rect_tex_ids[frame.slot]);
+
+        // FBO blit: source = the slot's rectangle texture, dest = our
+        // GL_TEXTURE_2D `tex_id`. One GPU-side copy, no CPU upload —
+        // necessary because `imgui_impl_opengl3` hardcodes
+        // `glBindTexture(GL_TEXTURE_2D, ...)` and won't sample a
+        // RECTANGLE target directly. Pattern lifted verbatim from
+        // `imgui-preview-poc/src/editor.zig` (validated at 1080p+).
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, self.read_fbo);
+        gl.framebufferTexture2D(
+            gl.READ_FRAMEBUFFER,
+            gl.COLOR_ATTACHMENT0,
+            iosurface.GL_TEXTURE_RECTANGLE,
+            self.rect_tex_ids[frame.slot],
+            0,
+        );
+        gl.readBuffer(gl.COLOR_ATTACHMENT0);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, self.draw_fbo);
+        gl.drawBuffer(gl.COLOR_ATTACHMENT0);
+        gl.blitFramebuffer(
+            0,
+            0,
+            @intCast(frame.width),
+            @intCast(frame.height),
+            0,
+            0,
+            @intCast(frame.width),
+            @intCast(frame.height),
+            gl.COLOR_BUFFER_BIT,
+            gl.NEAREST,
+        );
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, 0);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, 0);
+        gl.bindTexture(iosurface.GL_TEXTURE_RECTANGLE, 0);
+
+        self.recordFrameStats(frame.frame_idx, frame.produce_ns);
+        return true;
+    }
+
+    /// Bookkeeping shared between the two upload paths: drop count,
+    /// latency ring, presented counter.
+    fn recordFrameStats(self: *Self, frame_idx: u64, produce_ns: u64) void {
         // Drop accounting: count producer frames we skipped between
         // the previous frame and this one. First frame after attach
         // (`last_frame_idx == null`) sets the counter but doesn't
         // count gaps — we have no prior baseline.
         if (self.last_frame_idx) |prior| {
-            if (frame.frame_idx > prior + 1) {
-                self.dropped += frame.frame_idx - prior - 1;
+            if (frame_idx > prior + 1) {
+                self.dropped += frame_idx - prior - 1;
             }
         }
-        self.last_frame_idx = frame.frame_idx;
+        self.last_frame_idx = frame_idx;
 
         const now_ns = shm.nowNs();
-        if (now_ns > frame.produce_ns) {
-            self.last_latency_ns = now_ns - frame.produce_ns;
+        if (now_ns > produce_ns) {
+            self.last_latency_ns = now_ns - produce_ns;
             self.latency_ring[self.latency_head] = self.last_latency_ns;
             self.latency_head = (self.latency_head + 1) % latency_ring_capacity;
             if (self.latency_count < latency_ring_capacity) self.latency_count += 1;
         }
         self.presented += 1;
-        return true;
     }
 
     /// Mean end-to-end latency in nanoseconds over the most recent

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -5,6 +5,7 @@
 //! until the test queue drains. Exit code reflects pass/fail.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const zglfw = @import("zglfw");
 const zopengl = @import("zopengl");
 const zgui = @import("zgui");
@@ -15,6 +16,7 @@ const prefab_mod = @import("modules/prefab.zig");
 const io_global = @import("io_global.zig");
 const engine_mod = @import("engine");
 const shm_mod = engine_mod.preview_mode_mod.preview_shm;
+const iosurface_producer_mod = engine_mod.preview_mode_mod.preview_iosurface;
 
 const gl_major = 4;
 const gl_minor = 1;
@@ -98,8 +100,15 @@ fn pieServicePending() void {
         g_pie_pending_detach = false;
     }
     if (g_pie_pending_attach) {
-        app.attachGameView(pie_shm_name) catch {};
+        // Shm transport: the synthetic producer publishes BGRA8/RGBA8
+        // bytes into the ring directly. The iosurface dispatch lives
+        // in its own dedicated test below.
+        app.attachGameView(pie_shm_name, "bgra8") catch {};
         g_pie_pending_attach = false;
+    }
+    if (g_pie_pending_ios_attach) {
+        app.attachGameView(pie_ios_shm_name, "iosurface_bgra8") catch {};
+        g_pie_pending_ios_attach = false;
     }
 }
 
@@ -115,6 +124,74 @@ fn piePreviewPublish(byte: u8) u64 {
     p.publish(true);
     return p.header.frame_count;
 }
+
+// ── iosurface synthetic producer (macOS-only) ──────────────────────
+//
+// Parallels the shm helpers above. Runs the engine's iosurface
+// producer in-process so the TE iosurface dispatch test can drive
+// `App.attachGameView(name, "iosurface_bgra8")` and observe the
+// consumer flip into the rectangle-texture + FBO blit path. Lookups
+// rely on `kIOSurfaceIsGlobal = true` (the engine producer sets it),
+// which works in-process and is what `iosurface.Consumer.init`
+// expects. On non-macOS hosts these globals stay null and the test
+// skips itself.
+
+var g_pie_ios_producer: ?iosurface_producer_mod.Producer = null;
+
+const pie_ios_shm_name: [:0]const u8 = "/lbl-gui-te-ios";
+
+fn pieIosStart(width: u32, height: u32) !void {
+    if (builtin.os.tag != .macos) return;
+    if (g_pie_ios_producer != null) {
+        g_pie_pending_detach = true;
+        if (g_pie_ios_producer) |*p| {
+            shm_mod.signalShutdown(p.shm_producer.header);
+            p.deinit();
+            g_pie_ios_producer = null;
+        }
+    }
+    g_pie_ios_producer = try iosurface_producer_mod.Producer.init(pie_ios_shm_name, .{
+        .width = width,
+        .height = height,
+        .ring_size = 3,
+    });
+    g_pie_pending_ios_attach = true;
+}
+
+fn pieIosStop() void {
+    if (builtin.os.tag != .macos) return;
+    g_pie_pending_detach = true;
+    if (g_pie_ios_producer) |*p| {
+        shm_mod.signalShutdown(p.shm_producer.header);
+        p.deinit();
+        g_pie_ios_producer = null;
+    }
+}
+
+/// Lock the next IOSurface, fill with a flat byte (B = G = R = A =
+/// byte → easy to recognise in a pixel inspector if a later test
+/// adds capture), publish. Returns the producer's frame_count.
+fn pieIosPublish(byte: u8) u64 {
+    if (builtin.os.tag != .macos) return 0;
+    const p = &(g_pie_ios_producer.?);
+    const locked = p.pixelsPtr() catch return p.shm_producer.header.frame_count;
+    // BGRA8 — bytes_per_row may pad past width*4.
+    const rows: usize = @intCast(p.height);
+    const row_bytes: usize = @intCast(p.width * 4);
+    var y: usize = 0;
+    while (y < rows) : (y += 1) {
+        const row_base: [*]u8 = locked.base + y * locked.bytes_per_row;
+        @memset(row_base[0..row_bytes], byte);
+    }
+    p.publish(true) catch {};
+    return p.shm_producer.header.frame_count;
+}
+
+/// Pending attach flag for the iosurface path — services on the GL
+/// thread via `pieServicePending`. Separate from the shm flag so the
+/// two paths can coexist in the same test binary without clobbering
+/// each other.
+var g_pie_pending_ios_attach: bool = false;
 
 pub fn main() !void {
     try zglfw.init();
@@ -193,6 +270,7 @@ pub fn main() !void {
     // defer, ensure the producer mapping is torn down before the
     // process exits so the next run gets a clean shm slot.
     defer piePreviewStop();
+    defer pieIosStop();
 
     _ = engine.registerTest("phase3", "view_compiler_output_toggle", @src(), struct {
         pub fn gui(_: *zgui.te.TestContext) !void {
@@ -763,6 +841,80 @@ pub fn main() !void {
             ctx.yield(2);
             _ = zgui.te.check(@src(), .{}, !a.game_view.isAttached(), "consumer reports detached after teardown");
             _ = zgui.te.check(@src(), .{}, a.game_view.tex_id == 0, "GL texture released on detach");
+        }
+    });
+
+    // ── iosurface dispatch (macOS-only) ────────────────────────────
+    //
+    // Asserts the format-dispatch wiring: when the engine emits
+    // `format = "iosurface_bgra8"`, App.attachGameView opens an
+    // `iosurface.Consumer` (not a `shm.Consumer`), allocates the
+    // rectangle textures + FBOs, and the per-frame FBO blit fills the
+    // GL_TEXTURE_2D that imgui samples. On non-macOS hosts the engine
+    // producer returns `error.PlatformUnsupported` at init, so this
+    // test skips cleanly.
+    _ = engine.registerTest("pie", "viewport/iosurface_dispatch", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            pieServicePending();
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            if (builtin.os.tag != .macos) {
+                _ = zgui.te.check(@src(), .{}, true, "iosurface path is macOS-only — skipped");
+                return;
+            }
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            pieIosStart(64, 64) catch |err| {
+                // CFAllocationFailed / IOSurfaceCreateFailed can happen
+                // under sandboxes that disable IOSurface — treat as a
+                // skip rather than a failure so CI on locked-down
+                // runners doesn't break.
+                std.log.warn("iosurface producer init failed: {s} — skipping", .{@errorName(err)});
+                _ = zgui.te.check(@src(), .{}, true, "iosurface producer unavailable on this host");
+                return;
+            };
+            defer pieIosStop();
+            ctx.yield(2); // service the deferred attach (GL work).
+
+            _ = zgui.te.check(@src(), .{}, a.game_view.isAttached(), "iosurface consumer attached");
+            _ = zgui.te.check(@src(), .{}, a.show_game_view, "Game View panel opened on iosurface attach");
+            // Rectangle textures + draw FBO only exist in iosurface
+            // mode — they're the smoking gun that we took the right
+            // dispatch branch.
+            _ = zgui.te.check(@src(), .{}, a.game_view.rect_count > 0, "rectangle textures allocated for iosurface ring");
+            _ = zgui.te.check(@src(), .{}, a.game_view.draw_fbo != 0, "draw FBO allocated for iosurface blit");
+            _ = zgui.te.check(@src(), .{}, a.game_view.tex_id != 0, "destination GL_TEXTURE_2D allocated");
+
+            // Drive a handful of publishes; assert frame_idx advances
+            // through the FBO blit (i.e. `poll()` walked the iosurface
+            // branch and reached `recordFrameStats`).
+            var prev_idx: ?u64 = null;
+            var saw_increase: bool = false;
+            var i: usize = 0;
+            while (i < 20) : (i += 1) {
+                _ = pieIosPublish(@intCast(i & 0xFF));
+                ctx.yield(1);
+                const cur = a.game_view.last_frame_idx orelse continue;
+                if (prev_idx) |p| {
+                    if (cur > p) saw_increase = true;
+                }
+                prev_idx = cur;
+            }
+            _ = zgui.te.check(@src(), .{}, prev_idx != null, "iosurface consumer saw at least one frame");
+            _ = zgui.te.check(@src(), .{}, saw_increase, "iosurface frame_idx advanced across the window");
+            _ = zgui.te.check(@src(), .{}, a.game_view.last_latency_ns > 0, "iosurface latency stat populated");
+
+            // Detach explicitly so the next test starts from clean
+            // GL state. detach() runs on the gui (GL) thread.
+            g_pie_pending_detach = true;
+            ctx.yield(2);
+            _ = zgui.te.check(@src(), .{}, !a.game_view.isAttached(), "iosurface consumer detached cleanly");
+            _ = zgui.te.check(@src(), .{}, a.game_view.rect_count == 0, "rectangle textures freed on detach");
+            _ = zgui.te.check(@src(), .{}, a.game_view.draw_fbo == 0, "draw FBO freed on detach");
         }
     });
 

--- a/src/iosurface.zig
+++ b/src/iosurface.zig
@@ -224,6 +224,13 @@ pub const Consumer = struct {
     }
 
     pub fn deinit(self: *Consumer) void {
+        // Same comptime-elimination pattern as `init` and `bindSurface`:
+        // without this gate the Linux/Windows analyzer walks the
+        // `CFRelease` call and the linker fails with an undefined
+        // symbol once any caller exists (PR #124's `GameView.detach`
+        // switch arm). The body only ever runs on macOS where
+        // `init` would succeed.
+        if (builtin.os.tag != .macos) return;
         var i: u32 = 0;
         while (i < self.ring_size) : (i += 1) {
             if (self.surfaces[i]) |s| CFRelease(@ptrCast(s));

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -103,13 +103,21 @@ pub const connecting_timeout_ms: i64 = 2_000;
 
 /// Callback slot — fires on the first `frame_offer` JSON frame the
 /// engine sends after the `hello` handshake. The App wires this to
-/// `attachGameView(shm_name)` (#107 → #112 end-to-end seam).
+/// `attachGameView(shm_name, format)` (#107 → #112 end-to-end seam).
 ///
-/// `shm_name` is borrowed — only valid for the call duration. Copy
-/// before storing.
+/// `shm_name` and `format` are borrowed — only valid for the call
+/// duration. Copy before storing.
+///
+/// `format` mirrors the engine's `frame_offer.format` field. Today's
+/// values:
+///   - `"bgra8"` (default) → shm CPU upload path (`preview_shm.Consumer`).
+///   - `"iosurface_bgra8"` → macOS zero-copy path (`iosurface.Consumer`).
+/// Unknown formats should fall back to the SHM path on the consumer
+/// side; `frame_offer` JSON without an explicit `format` key parses as
+/// `"bgra8"` for backward compat with engines that predate the field.
 pub const FrameOfferCallback = struct {
     ctx: *anyopaque,
-    func: *const fn (ctx: *anyopaque, shm_name: [:0]const u8, width: u32, height: u32) void,
+    func: *const fn (ctx: *anyopaque, shm_name: [:0]const u8, width: u32, height: u32, format: []const u8) void,
 };
 
 /// Callback invoked on `component_changed` binary frames (kind=3 of the
@@ -726,6 +734,13 @@ pub const PreviewSession = struct {
                 shm_name: []const u8 = "",
                 width: u32 = 0,
                 height: u32 = 0,
+                /// `bgra8` (default — SHM CPU upload path) vs
+                /// `iosurface_bgra8` (macOS zero-copy). Defaulted so
+                /// engines that predate the field keep working. The
+                /// borrowed slice into the parse arena is valid for
+                /// the call into `on_frame_offer.func`; copy on the
+                /// consumer side before storing.
+                format: []const u8 = "bgra8",
             };
             const m = std.json.parseFromSliceLeaky(Msg, alloc, line, .{
                 .ignore_unknown_fields = true,
@@ -741,7 +756,7 @@ pub const PreviewSession = struct {
                 @memcpy(name_buf[0..m.shm_name.len], m.shm_name);
                 name_buf[m.shm_name.len] = 0;
                 const name_z: [:0]const u8 = name_buf[0..m.shm_name.len :0];
-                cb.func(cb.ctx, name_z, m.width, m.height);
+                cb.func(cb.ctx, name_z, m.width, m.height, m.format);
             }
         } else if (std.mem.eql(u8, kind_only.kind, "frame_published")) {
             // Informational — editor consumer polls the SHM ring

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3037,26 +3037,31 @@ pub const PreviewTransportTests = struct {
         _ = close(fd);
     }
 
-    test "frame_offer fires on_frame_offer callback with shm_name + dims" {
+    test "frame_offer fires on_frame_offer callback with shm_name + dims + format" {
         const Capture = struct {
             var got_name: [64]u8 = [_]u8{0} ** 64;
             var got_name_len: usize = 0;
             var got_width: u32 = 0;
             var got_height: u32 = 0;
+            var got_format: [64]u8 = [_]u8{0} ** 64;
+            var got_format_len: usize = 0;
             var fired: bool = false;
 
-            fn cb(_: *anyopaque, name: [:0]const u8, w: u32, h: u32) void {
+            fn cb(_: *anyopaque, name: [:0]const u8, w: u32, h: u32, format: []const u8) void {
                 fired = true;
                 got_name_len = @min(name.len, got_name.len);
                 @memcpy(got_name[0..got_name_len], name[0..got_name_len]);
                 got_width = w;
                 got_height = h;
+                got_format_len = @min(format.len, got_format.len);
+                @memcpy(got_format[0..got_format_len], format[0..got_format_len]);
             }
         };
         Capture.fired = false;
         Capture.got_name_len = 0;
         Capture.got_width = 0;
         Capture.got_height = 0;
+        Capture.got_format_len = 0;
 
         var sess = preview.PreviewSession.init(std.testing.allocator);
         defer sess.deinit();
@@ -3069,7 +3074,7 @@ pub const PreviewTransportTests = struct {
         try waitUntilState(&sess, .running, 500);
 
         try sendJsonLine(fd,
-            "{\"kind\":\"frame_offer\",\"shm_name\":\"/lbl-test\",\"width\":640,\"height\":360,\"format\":\"rgba8\",\"ring_size\":3,\"slot_size_bytes\":921600}\n");
+            "{\"kind\":\"frame_offer\",\"shm_name\":\"/lbl-test\",\"width\":640,\"height\":360,\"format\":\"bgra8\",\"ring_size\":3,\"slot_size_bytes\":921600}\n");
 
         // poll for ~500 ms waiting for the callback
         var i: u32 = 0;
@@ -3081,6 +3086,51 @@ pub const PreviewTransportTests = struct {
         try std.testing.expectEqualStrings(Capture.got_name[0..Capture.got_name_len], "/lbl-test");
         try expect.equal(Capture.got_width, @as(u32, 640));
         try expect.equal(Capture.got_height, @as(u32, 360));
+        try std.testing.expectEqualStrings(Capture.got_format[0..Capture.got_format_len], "bgra8");
+
+        _ = close(fd);
+    }
+
+    test "frame_offer forwards format=iosurface_bgra8 to the callback" {
+        // The format-dispatch wiring lives in App.attachGameView / the
+        // GameView consumer; this test stops one level shy of that, at
+        // the JSON parser. We assert the parser hands the borrowed
+        // slice through verbatim — App reads it to pick shm vs iosurface
+        // transport (`src/game_view.zig`).
+        const Capture = struct {
+            var got_format: [64]u8 = [_]u8{0} ** 64;
+            var got_format_len: usize = 0;
+            var fired: bool = false;
+
+            fn cb(_: *anyopaque, _: [:0]const u8, _: u32, _: u32, format: []const u8) void {
+                fired = true;
+                got_format_len = @min(format.len, got_format.len);
+                @memcpy(got_format[0..got_format_len], format[0..got_format_len]);
+            }
+        };
+        Capture.fired = false;
+        Capture.got_format_len = 0;
+
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+        sess.on_frame_offer = .{ .ctx = &Capture.fired, .func = Capture.cb };
+
+        const fd = try dialEditor(sess.port.?);
+        try waitUntilState(&sess, .connecting, 500);
+        try sendJsonLine(fd, "{\"kind\":\"hello\",\"engine_version\":\"x\",\"pid\":1,\"protocol_version\":1}\n");
+        try waitUntilState(&sess, .running, 500);
+
+        try sendJsonLine(fd,
+            "{\"kind\":\"frame_offer\",\"shm_name\":\"/lbl-ios\",\"width\":1280,\"height\":720,\"format\":\"iosurface_bgra8\",\"ring_size\":3}\n");
+
+        var i: u32 = 0;
+        while (i < 250 and !Capture.fired) : (i += 1) {
+            sess.poll();
+            sleepMs(2);
+        }
+        try expect.toBeTrue(Capture.fired);
+        try std.testing.expectEqualStrings(Capture.got_format[0..Capture.got_format_len], "iosurface_bgra8");
 
         _ = close(fd);
     }


### PR DESCRIPTION
## Summary

Routes the editor's Game View consumer to either the SHM CPU upload path or the macOS IOSurface zero-copy path based on the engine's `frame_offer.format` field. The `iosurface.Consumer` module landed in #115 but nothing in the transport actually wired it up — every `frame_offer` fell into the SHM path. This PR closes the seam.

## Format dispatch

`frame_offer.format` (parsed in `src/preview.zig`, propagated through `FrameOfferCallback.func`, `App.attachGameView`, into `GameView.attach`):

- `"bgra8"` or missing → `shm.Consumer` + `glTexSubImage2D` per frame (unchanged from #111).
- `"iosurface_bgra8"` → `iosurface.Consumer` + FBO blit per frame, macOS-only. Non-macOS hosts silently fall back to SHM.

`GameView.consumer` is now a `ConsumerMode` tagged union (`shm` | `iosurface`). `attach` builds the right side and `poll` dispatches; `detach` cleans up either variant.

## FBO blit approach

`CGLTexImageIOSurface2D` binds the IOSurface to a `GL_TEXTURE_RECTANGLE` texture, but `imgui_impl_opengl3` hardcodes `GL_TEXTURE_2D` in its sampling path, so we can't pass the rectangle handle to `zgui.image(...)` directly.

Picked **`glBlitFramebuffer`** (not `glCopyImageSubData`) for the GPU-side copy:

- `glBlitFramebuffer` is GL 3.0+ core. Both labelle-gui's main loop (3.3) and `gui-tests`' loop (4.1) load it via zopengl with no extension dance.
- `glCopyImageSubData` is GL 4.3 / `GL_ARB_copy_image`. macOS' GL 4.1 core profile doesn't reach 4.3, and the extension isn't reliably exposed on the Apple driver. Adding an extension probe + fallback path felt over-engineered for a single GPU copy that the PoC already validated with `glBlitFramebuffer` at 1080p+ throughput.

Per frame: rebind the slot's rectangle texture to the read FBO's color attachment, blit into the pre-attached `GL_TEXTURE_2D` (draw FBO), unbind. Single GPU-side copy, no CPU upload. Pattern lifted directly from `imgui-preview-poc/src/editor.zig` (which solved this exact problem during the bench).

## Test coverage

**Unit tests (`zig build test` — 181/181 passing):**

- Extended `frame_offer fires on_frame_offer callback with shm_name + dims` to assert the new `format` parameter rides through.
- Added `frame_offer forwards format=iosurface_bgra8 to the callback` to lock in the iosurface dispatch at the parser boundary.

**TE tests (`zig build gui-test` — 13/13 passing):**

- New `pie/viewport/iosurface_dispatch` test. Stands up an in-process `engine.preview_mode_mod.preview_iosurface.Producer` (the engine module that landed alongside the consumer in v1.37.3+), attaches via the new dispatch with `format=iosurface_bgra8`, drives 20 publishes, and asserts:
  - `rect_count > 0` and `draw_fbo != 0` (smoking gun that the iosurface branch ran)
  - `last_frame_idx` advances monotonically (FBO blit completed and `recordFrameStats` ran)
  - `last_latency_ns > 0`
  - clean detach (rect textures + FBOs freed)
- Test is gated `if (builtin.os.tag != .macos) return` with a single passing assertion so non-mac CI shows a green skip.
- The four existing PIE viewport TE tests (`renders_on_attach`, `frame_idx_advances`, `latency_stat_visible`, `disconnect_handled_cleanly`) keep using the SHM path unchanged.

**Build wiring:** `gui_tests` exe now links `IOSurface` / `CoreFoundation` / `OpenGL` frameworks on macOS — same set as the production `exe`. Required because the iosurface test reaches `CGLTexImageIOSurface2D` / `CGLGetCurrentContext`.

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — 181/181 (incl. 2 updated/new `frame_offer` tests)
- [x] `zig build gui-test` — 13/13 (incl. new `pie/viewport/iosurface_dispatch`)
- [ ] Manual: spawn engine emitting `format=iosurface_bgra8` and verify Game View panel auto-opens with live pixels (requires engine-side producer wiring not yet on main; left as a follow-up smoke once #547 lands engine-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)