### PR TITLE
feat(gui): Game View as a tab (#128)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -56,6 +56,12 @@ pub const OpenTab = union(enum) {
     /// `.flow.zon` schema.
     flow: flow_mod.FlowState,
     gizmo: gizmo_mod.GizmoState,
+    /// Live game view (#128). Routing marker only — the consumer +
+    /// GL texture state live on `App.game_view`. No per-tab struct
+    /// because there's only one preview session at a time, and the
+    /// tab body just dispatches into `modules/game_view.zig`'s
+    /// existing renderer.
+    game_view: void,
 
     pub fn deinit(self: *OpenTab, allocator: std.mem.Allocator) void {
         switch (self.*) {
@@ -63,6 +69,7 @@ pub const OpenTab = union(enum) {
             .prefab => |*p| p.deinit(allocator),
             .flow => |*f| f.deinit(allocator),
             .gizmo => |*g| g.deinit(allocator),
+            .game_view => {},
         }
     }
 
@@ -72,6 +79,7 @@ pub const OpenTab = union(enum) {
             .prefab => |*p| prefab_mod.render(p, app),
             .flow => |*f| flow_mod.render(f, app),
             .gizmo => |*g| gizmo_mod.render(g, app),
+            .game_view => game_view_mod.renderTab(app),
         }
     }
 
@@ -81,6 +89,7 @@ pub const OpenTab = union(enum) {
             .prefab => |*p| prefab_mod.savePrefab(p, app),
             .flow => |*f| flow_mod.saveFlow(f, app),
             .gizmo => |*g| gizmo_mod.saveGizmo(g, app),
+            .game_view => {},
         }
     }
 
@@ -90,6 +99,7 @@ pub const OpenTab = union(enum) {
             .prefab => |p| p.display_name,
             .flow => |f| f.display_name,
             .gizmo => |g| g.display_name,
+            .game_view => "▶ Game View",
         };
     }
 
@@ -99,6 +109,7 @@ pub const OpenTab = union(enum) {
             .prefab => |p| p.path,
             .flow => |f| f.path,
             .gizmo => |g| g.path,
+            .game_view => "<runtime>",
         };
     }
 
@@ -108,6 +119,7 @@ pub const OpenTab = union(enum) {
             .prefab => |p| p.is_dirty,
             .flow => |f| f.is_dirty,
             .gizmo => |g| g.is_dirty,
+            .game_view => false,
         };
     }
 };
@@ -388,7 +400,39 @@ pub const App = struct {
     /// zero-copy path. Anything else falls back to SHM.
     pub fn attachGameView(self: *Self, shm_name: []const u8, format: []const u8) !void {
         try self.game_view.attach(shm_name, format);
+        // Backwards-compat: the floating "Game View" panel registered
+        // via the Module Registry is still available for users who
+        // want a docked-elsewhere layout. The tab below is the
+        // default surface; both share `renderViewportContent` so
+        // they stay in lockstep.
         self.show_game_view = true;
+        // #128: also open the Game View as a tab in the main content
+        // area so users see the live frame inline with the editor
+        // tabs they were working in. Logged + swallowed because an
+        // OOM here shouldn't fail the attach — the panel still works.
+        self.openGameViewTab() catch |err| {
+            std.log.warn("attachGameView: openGameViewTab failed: {s}", .{@errorName(err)});
+        };
+    }
+
+    /// Push a `.game_view` tab onto `open_tabs` (or focus an existing
+    /// one) and queue a one-shot focus request so the next frame
+    /// brings it forward. Idempotent — multiple `frame_offer`s in a
+    /// session refocus instead of duplicating tabs. #128.
+    fn openGameViewTab(self: *Self) !void {
+        for (self.open_tabs.items, 0..) |t, i| {
+            switch (t) {
+                .game_view => {
+                    self.focus_tab_idx = i;
+                    return;
+                },
+                else => {},
+            }
+        }
+        try self.open_tabs.append(self.allocator, .{ .game_view = {} });
+        const new_idx = self.open_tabs.items.len - 1;
+        self.active_tab_idx = new_idx;
+        self.focus_tab_idx = new_idx;
     }
 
     /// Rebuild the atlas index from the active project's
@@ -572,6 +616,19 @@ pub const App = struct {
     /// about unsaved changes via `requestCloseTab` first.
     pub fn closeTab(self: *Self, idx: usize) void {
         if (idx >= self.open_tabs.items.len) return;
+        // #128: closing the Game View tab is the runtime-view "stop"
+        // affordance — there's no dirty-doc dialog; tear down the
+        // preview subprocess + consumer eagerly. Done before the
+        // tab is removed so `.game_view`-specific cleanup still has
+        // an attached consumer to work with.
+        switch (self.open_tabs.items[idx]) {
+            .game_view => {
+                self.preview.stop();
+                self.game_view.detach();
+                self.show_game_view = false;
+            },
+            else => {},
+        }
         var removed = self.open_tabs.orderedRemove(idx);
         removed.deinit(self.allocator);
 

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -193,6 +193,24 @@ fn pieIosPublish(byte: u8) u64 {
 /// each other.
 var g_pie_pending_ios_attach: bool = false;
 
+/// Pending close request for the Game View tab (#128). Set from the
+/// run-callback thread, serviced in the gui callback because
+/// `closeTab`'s `.game_view` arm calls `game_view.detach()` which is
+/// GL-thread work.
+var g_pending_game_view_close: bool = false;
+
+/// Count `.game_view` entries in `App.open_tabs`. Used by the #128
+/// tests to assert tab dedup without taking a dep on absolute index
+/// (other tests may leave document tabs lying around).
+fn countGameViewTabs(a: *App) usize {
+    var n: usize = 0;
+    for (a.open_tabs.items) |t| switch (t) {
+        .game_view => n += 1,
+        else => {},
+    };
+    return n;
+}
+
 pub fn main() !void {
     try zglfw.init();
     defer zglfw.terminate();
@@ -915,6 +933,137 @@ pub fn main() !void {
             _ = zgui.te.check(@src(), .{}, !a.game_view.isAttached(), "iosurface consumer detached cleanly");
             _ = zgui.te.check(@src(), .{}, a.game_view.rect_count == 0, "rectangle textures freed on detach");
             _ = zgui.te.check(@src(), .{}, a.game_view.draw_fbo == 0, "draw FBO freed on detach");
+        }
+    });
+
+    // ── Game View tab (#128) ───────────────────────────────────────
+    //
+    // `attachGameView` now pushes an `OpenTab.game_view` entry onto
+    // `open_tabs` (in addition to the legacy `show_game_view` panel
+    // toggle) so the live frame surfaces inside the main content
+    // area's TabBar. Closing the tab eagerly stops the preview
+    // subprocess + detaches the consumer.
+    //
+    // The actual `closeTab` invocation has to land on the gui (GL)
+    // thread because the `.game_view` arm calls `game_view.detach()`
+    // which deletes GL textures. The pattern matches the existing
+    // PIE viewport tests: set a flag on the run thread, service it
+    // on the gui-callback frame.
+    _ = engine.registerTest("pie", "tab/opens_on_attach", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            pieServicePending();
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            // Earlier PIE viewport tests may have attached + detached
+            // the consumer, which under #128 also pushes a `.game_view`
+            // tab onto `open_tabs`. The tab persists after detach
+            // (close-on-detach would be wrong: detach is normal during
+            // resize). Count `.game_view` tabs as the invariant, not
+            // total tab length, so this test stays robust to leftover
+            // tabs.
+            const game_view_tabs_before = countGameViewTabs(a);
+
+            piePreviewStart(64, 64) catch {
+                _ = zgui.te.check(@src(), .{}, false, "piePreviewStart must succeed");
+                return;
+            };
+            defer piePreviewStop();
+            ctx.yield(2);
+
+            _ = zgui.te.check(@src(), .{}, a.game_view.isAttached(), "consumer attached");
+            const expected_tabs: usize = if (game_view_tabs_before == 0) 1 else game_view_tabs_before;
+            _ = zgui.te.check(@src(), .{}, countGameViewTabs(a) == expected_tabs, "exactly one .game_view tab present (new or refocused)");
+
+            // Re-attach with the same name should refocus, not
+            // duplicate. attach() inside game_view.attach auto-detaches
+            // first — that's GL work, so route via the pending flag.
+            g_pie_pending_attach = true;
+            ctx.yield(2);
+            _ = zgui.te.check(@src(), .{}, countGameViewTabs(a) == expected_tabs, "re-attach refocuses instead of duplicating");
+
+            // Cleanup: tear down via the detach flag (GL work) so the
+            // next test starts clean. The .game_view tab will still be
+            // present in open_tabs after detach; the close-stops-preview
+            // test below exercises the close path.
+            g_pie_pending_detach = true;
+            ctx.yield(2);
+        }
+    });
+
+    _ = engine.registerTest("pie", "tab/close_stops_preview", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            pieServicePending();
+            // closeTab's .game_view arm runs game_view.detach (GL
+            // work) — service it here, on the GL thread, when the
+            // run callback flags an outstanding close request.
+            if (g_pending_game_view_close) {
+                g_pending_game_view_close = false;
+                if (g_app) |a| {
+                    var i: usize = 0;
+                    while (i < a.open_tabs.items.len) {
+                        switch (a.open_tabs.items[i]) {
+                            .game_view => {
+                                a.closeTab(i);
+                                break;
+                            },
+                            else => i += 1,
+                        }
+                    }
+                }
+            }
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+
+            piePreviewStart(64, 64) catch {
+                _ = zgui.te.check(@src(), .{}, false, "piePreviewStart must succeed");
+                return;
+            };
+            defer piePreviewStop();
+            ctx.yield(2);
+
+            // Pre-close sanity.
+            _ = zgui.te.check(@src(), .{}, a.game_view.isAttached(), "consumer attached pre-close");
+            var found_pre: bool = false;
+            for (a.open_tabs.items) |t| switch (t) {
+                .game_view => {
+                    found_pre = true;
+                    break;
+                },
+                else => {},
+            };
+            _ = zgui.te.check(@src(), .{}, found_pre, "game_view tab present pre-close");
+
+            // Drive the production close path through the gui frame
+            // so detach() lands on the GL thread.
+            g_pending_game_view_close = true;
+            ctx.yield(2);
+
+            _ = zgui.te.check(@src(), .{}, !a.game_view.isAttached(), "consumer detached on tab close");
+            _ = zgui.te.check(@src(), .{}, !a.show_game_view, "panel toggle reset on tab close");
+            _ = zgui.te.check(@src(), .{}, !a.preview.isActive(), "preview reports inactive after stop()");
+
+            // No .game_view tab remains. Other test-leftover tabs
+            // (scene, prefab) are out of scope here.
+            var still_there: bool = false;
+            for (a.open_tabs.items) |t| switch (t) {
+                .game_view => {
+                    still_there = true;
+                    break;
+                },
+                else => {},
+            };
+            _ = zgui.te.check(@src(), .{}, !still_there, "no .game_view tab remains after closeTab");
         }
     });
 

--- a/src/modules/game_view.zig
+++ b/src/modules/game_view.zig
@@ -40,6 +40,16 @@ fn render(app: *App) void {
     renderStats(app);
 }
 
+/// Tab-mode entry — called from `OpenTab.render` when the active tab
+/// is `.game_view`. The parent tab strip already wraps the body in a
+/// window, so no `zgui.begin`/`end` here. Stats live in their own
+/// floating window (still gated on `show_game_view`) so the user can
+/// dock them wherever; the tab body is just the live frame.
+pub fn renderTab(app: *App) void {
+    _ = app.game_view.poll();
+    renderViewportContent(app);
+}
+
 fn renderViewport(app: *App) void {
     zgui.setNextWindowSize(.{ .w = 720, .h = 460, .cond = .first_use_ever });
     if (!zgui.begin("Game View", .{ .popen = &app.show_game_view, .flags = .{} })) {
@@ -47,7 +57,12 @@ fn renderViewport(app: *App) void {
         return;
     }
     defer zgui.end();
+    renderViewportContent(app);
+}
 
+/// Inner content — drawn either inside the tab's container OR inside
+/// the standalone panel's begin/end. No window chrome here.
+fn renderViewportContent(app: *App) void {
     if (!app.game_view.isAttached()) {
         zgui.textWrapped(
             \\No engine attached.


### PR DESCRIPTION
## Summary

Moves the Game View from a togglable floating panel to a tab in the main content area's TabBar (#128). Real-game preview pixels now land inline with the scene/prefab/flow/gizmo editors instead of in a separate floating window.

- New `OpenTab.game_view: void` variant (routing marker — state lives on `App.game_view`). All dispatch methods wired: `displayName` returns `"▶ Game View"`, `path` returns `"<runtime>"`, `isDirty`/`save`/`deinit` are no-ops.
- `App.attachGameView` now pushes a `.game_view` tab onto `open_tabs` (or refocuses an existing one) on a successful attach; sets `focus_tab_idx` so the new tab takes focus next frame. Idempotent — multiple `frame_offer`s in a session refocus instead of duplicating.
- `App.closeTab`'s `.game_view` arm calls `self.preview.stop()` + `self.game_view.detach()` + clears `show_game_view` before destructing the union. No dirty-doc dialog — runtime view, not a document.
- `modules/game_view.zig` split into `renderViewportContent` (body) + `renderViewport` (floating-panel mode, with `zgui.begin/end`) + `renderTab` (tab-mode entry). Both paths share the inner content.

## Files touched

- `src/app.zig` — +57 LOC (OpenTab variant + dispatch arms, openGameViewTab helper, closeTab .game_view branch)
- `src/modules/game_view.zig` — +15 LOC (renderTab entry, content split)
- `src/gui_tests.zig` — +149 LOC (two TE tests + `countGameViewTabs` helper + `g_pending_game_view_close` flag)

## Panel-mode decision

Kept the floating panel (option a from the spec). The `Module` registration in `App.init`, `show_game_view` toggle, and View-menu entry all stay wired. Both surfaces share `renderViewportContent`, so cost is minimal. Users get the tab as the default surface from `frame_offer`; the floating panel remains available for users who want a docked-elsewhere layout. If product feedback later says the duplication is confusing, killing the panel is a small follow-up.

## TE tests added

- `pie/tab/opens_on_attach` — after `attachGameView`, a `.game_view` tab is present in `open_tabs`; a second attach refocuses (does not duplicate). Uses a `countGameViewTabs` helper to stay robust against tab leftovers from earlier PIE viewport tests.
- `pie/tab/close_stops_preview` — closing the `.game_view` tab via `closeTab` flips `game_view.isAttached()` to false, resets `show_game_view`, and leaves `preview.isActive()` false. Routed through a new `g_pending_game_view_close` flag because `closeTab`'s `.game_view` arm calls `detach()` (GL work) which needs the gui thread.

All 15 TE tests pass (was 13 — 2 new). All 181 `zig build test` cases still pass.

## Test plan

- [x] `zig build` succeeds
- [x] `zig build test` — 181/181 pass
- [x] `zig build gui-test` — 15/15 pass (including the two new `pie/tab/*` tests)
- [ ] Manual: `labelle run` from a real project — game spawns, `frame_offer` arrives, `.game_view` tab opens and shows live pixels
- [ ] Manual: × on the Game View tab kills the running game and the consumer detaches cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)