### PR TITLE
test(preview): regression-lock spawn argv + env shape (#131)

### DIFF
--- a/src/preview.zig
+++ b/src/preview.zig
@@ -46,6 +46,52 @@ extern "c" fn __errno_location() *c_int;
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 
+/// Env var name the assembler-generated game's `main` reads via
+/// `_preview_getenv` to discover the editor's listener address.
+/// Exported so unit tests can read it back via `std.posix.getenv`
+/// after `setPreviewEnv` without re-stringifying the literal.
+pub const preview_env_var: [:0]const u8 = "LABELLE_PREVIEW";
+
+/// Build the argv slice for spawning `labelle run` for a given
+/// project directory. Returns a borrowed slice into the caller-
+/// provided buf. Separate from `start()` so unit tests can lock the
+/// shape (regression for #130 — the gui used to pass an undefined
+/// `--preview-mode` flag) without actually spawning a subprocess.
+///
+/// The CLI doesn't define `--preview-mode`; the preview address
+/// reaches the game via the `LABELLE_PREVIEW` env var instead (see
+/// `setPreviewEnv`).
+pub fn buildSpawnArgv(
+    dir_path: []const u8,
+    argv_buf: *[16][]const u8,
+) []const []const u8 {
+    argv_buf[0] = "labelle";
+    argv_buf[1] = "run";
+    argv_buf[2] = dir_path;
+    return argv_buf[0..3];
+}
+
+/// Set `LABELLE_PREVIEW=127.0.0.1:<port>` so the about-to-spawn
+/// child (and its eventual game subprocess, by POSIX fork+exec env
+/// inheritance) discovers the editor's listener. Returns the
+/// host:port string written into `addr_buf` as a borrowed
+/// NUL-terminated slice — valid while `addr_buf` is in scope.
+/// Extracted from `start()` so unit tests can lock the env shape
+/// without spawning a subprocess.
+pub fn setPreviewEnv(port: u16, addr_buf: *[32]u8) error{OutOfMemory}![:0]const u8 {
+    const addr_str = std.fmt.bufPrintZ(addr_buf, "127.0.0.1:{d}", .{port}) catch
+        return error.OutOfMemory;
+    _ = setenv(preview_env_var.ptr, addr_str.ptr, 1);
+    return addr_str;
+}
+
+/// Unset `LABELLE_PREVIEW`. Idempotent — safe to call when the var
+/// was never set (libc's `unsetenv` is a no-op in that case). Pair
+/// with `setPreviewEnv` inside `start()` / `stop()`.
+pub fn clearPreviewEnv() void {
+    _ = unsetenv(preview_env_var.ptr);
+}
+
 fn libcErrno() c_int {
     return if (builtin.os.tag == .macos) __error().* else __errno_location().*;
 }
@@ -317,23 +363,15 @@ pub const PreviewSession = struct {
         try self.bindListener();
         errdefer self.stop();
 
-        var addr_buf: [32]u8 = undefined;
-        const addr_str = std.fmt.bufPrintZ(&addr_buf, "127.0.0.1:{d}", .{self.port.?}) catch
-            return error.OutOfMemory;
-
         // Push LABELLE_PREVIEW into the parent's env so the eventual
         // game subprocess (spawned by the labelle CLI we're about
         // to invoke) inherits it. `stop()` unsets it. Single
         // preview session at a time so no race.
-        _ = setenv("LABELLE_PREVIEW", addr_str.ptr, 1);
+        var addr_buf: [32]u8 = undefined;
+        _ = try setPreviewEnv(self.port.?, &addr_buf);
 
         var argv_buf: [16][]const u8 = undefined;
-        const argv = blk: {
-            argv_buf[0] = "labelle";
-            argv_buf[1] = "run";
-            argv_buf[2] = dir_path;
-            break :blk argv_buf[0..3];
-        };
+        const argv = buildSpawnArgv(dir_path, &argv_buf);
 
         const child = std.process.spawn(io_global.io(), .{
             .argv = argv,
@@ -354,7 +392,7 @@ pub const PreviewSession = struct {
     pub fn stop(self: *Self) void {
         // Symmetric with `start()`'s setenv. Multiple stops are safe
         // (unsetenv on an unset var is a no-op).
-        _ = unsetenv("LABELLE_PREVIEW");
+        clearPreviewEnv();
         if (self.child) |*c| {
             c.kill(io_global.io());
             self.child = null;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3715,3 +3715,57 @@ pub const GameViewLatencyTests = struct {
         try expect.equal(gv.meanLatencyNs(), @as(u64, 5_000_000));
     }
 };
+
+pub const PreviewSpawnTests = struct {
+    // Regression-lock for #130 — the gui used to pass
+    // `--preview-mode 127.0.0.1:<port>` argv to `labelle run`, but
+    // the CLI doesn't define that flag. The fix moved the address
+    // to the `LABELLE_PREVIEW` env var. `PreviewTransportTests` /
+    // `PreviewBinaryPlaneTests` skip `start()` and dial the
+    // listener directly, so none of them would have caught the
+    // regression. These tests exercise the spawn-argv + env shape
+    // via the pure helpers extracted from `start()`.
+
+    // `std.posix.getenv` was dropped in Zig 0.16; go through libc
+    // directly. `LABELLE_PREVIEW` is ASCII so a borrowed slice into
+    // libc's env is safe for the duration of the read.
+    extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+
+    fn readPreviewEnv() ?[]const u8 {
+        const raw = getenv("LABELLE_PREVIEW") orelse return null;
+        return std.mem.span(raw);
+    }
+
+    test "buildSpawnArgv returns labelle/run/<dir>, no --preview-mode" {
+        var buf: [16][]const u8 = undefined;
+        const argv = preview.buildSpawnArgv("/tmp/proj", &buf);
+        try expect.equal(argv.len, @as(usize, 3));
+        try expect.toBeTrue(std.mem.eql(u8, argv[0], "labelle"));
+        try expect.toBeTrue(std.mem.eql(u8, argv[1], "run"));
+        try expect.toBeTrue(std.mem.eql(u8, argv[2], "/tmp/proj"));
+        // Regression-lock the bug from PR #130: argv MUST NOT
+        // include a `--preview-mode` flag — the labelle CLI doesn't
+        // define it.
+        for (argv) |a| try expect.toBeFalse(std.mem.eql(u8, a, "--preview-mode"));
+    }
+
+    test "setPreviewEnv formats 127.0.0.1:<port> and sets LABELLE_PREVIEW" {
+        var buf: [32]u8 = undefined;
+        const addr = try preview.setPreviewEnv(54321, &buf);
+        defer preview.clearPreviewEnv();
+        try expect.toBeTrue(std.mem.eql(u8, addr, "127.0.0.1:54321"));
+        const seen = readPreviewEnv() orelse "";
+        try expect.toBeTrue(std.mem.eql(u8, seen, "127.0.0.1:54321"));
+    }
+
+    test "clearPreviewEnv unsets LABELLE_PREVIEW (idempotent)" {
+        preview.clearPreviewEnv(); // no-op if unset
+        var buf: [32]u8 = undefined;
+        _ = try preview.setPreviewEnv(11111, &buf);
+        preview.clearPreviewEnv();
+        try expect.toBeTrue(readPreviewEnv() == null);
+        // Second call should also be safe.
+        preview.clearPreviewEnv();
+        try expect.toBeTrue(readPreviewEnv() == null);
+    }
+};


### PR DESCRIPTION
## Summary

Adds a unit test that locks down the argv + env shape `Preview.start()` constructs when the user clicks Run — the regression PR #130 fixed wasn't caught by existing tests because `PreviewTransportTests` / `PreviewBinaryPlaneTests` skip `start()` and dial the listener directly.

- Refactor `Preview.start()` to delegate argv + env construction to two pure helpers (`buildSpawnArgv`, `setPreviewEnv` / `clearPreviewEnv`). No observable behavior change vs #130 — same argv slice, same `setenv` / `unsetenv` writes, same spawn call.
- New `PreviewSpawnTests` scope in `src/tests.zig` with three tests:
  - argv is exactly `["labelle", "run", <dir>]` — explicit `for` loop asserting `--preview-mode` is **not** present.
  - `setPreviewEnv(54321, ...)` returns `"127.0.0.1:54321"` and `LABELLE_PREVIEW` reads back the same string via libc `getenv`.
  - `clearPreviewEnv()` unsets the var and is idempotent across re-entries.
- `std.posix.getenv` was dropped in Zig 0.16, so the readback path goes through libc `getenv` directly.

Base is `fix/preview-spawn-env-var` (PR #130) — merge order: #130 first, then this. Don't merge yet (per ticket).

Closes #131 once #130 lands.

## Test plan

- [x] `/Users/alexandrecalvao/.zvm/0.16.0/zig build test` — 187/187 green (3 new tests).
- [ ] CI green.
- [ ] Manual: revert PR #130's diff locally, re-run `zig build test`, confirm the new argv test fails (regression-lock works).