### PR TITLE
feat(preview): scene picker for Run (#132)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -154,6 +154,17 @@ pub const App = struct {
     /// action. The Preview panel reads this via its `Module.is_open`
     /// pointer; clicking Run preview also force-opens it.
     show_preview: bool = false,
+    /// Scene name (no extension) the user picked from the Run-button
+    /// dropdown (#132). When non-null, passed as `--scene=<name>` to
+    /// `labelle run`. `null` falls back to `project.labelle`'s
+    /// `initial_scene` field — the pre-#132 behavior.
+    ///
+    /// Borrowed from the active project's arena (scene name strings
+    /// returned by `Project.scenesAvailable`). Reset to null on project
+    /// transition (`closeAllTabs` codepath in `renderFrame`) so a stale
+    /// pointer from the old project's arena can't leak into a fresh
+    /// `preview.start` call.
+    preview_scene_override: ?[]const u8 = null,
 
     /// Game View panel state (#107). Owns the SHM consumer + GL
     /// texture for the live game frames. Toggleable from the View
@@ -703,6 +714,11 @@ pub const App = struct {
                 self.rebuildAtlasIndex();
                 self.rebuildGizmoIndex();
                 self.rebuildPrefabIndex();
+                // The override borrowed a string from the previous
+                // project's arena, which is freed on the transition.
+                // Drop it so the next Run uses `initial_scene` until
+                // the user picks again (#132).
+                self.preview_scene_override = null;
             }
         } else {
             self.rebuildAtlasIndex();
@@ -905,7 +921,7 @@ pub const App = struct {
             self.setStatus("Error syncing project files!");
             return;
         };
-        self.preview.start(proj) catch |err| {
+        self.preview.start(proj, self.preview_scene_override) catch |err| {
             std.log.err("Error starting preview: {}", .{err});
             self.setStatus("Error starting preview!");
             return;

--- a/src/modules/preview.zig
+++ b/src/modules/preview.zig
@@ -111,6 +111,8 @@ fn renderButtons(app: *App) void {
         if (zgui.button("Run preview##preview_run", .{ .w = 140 })) {
             if (has_project) app.startPreview();
         }
+        zgui.sameLine(.{});
+        renderScenePicker(app);
         if (!has_project) {
             zgui.sameLine(.{});
             zgui.textDisabled("(no project open)", .{});
@@ -118,6 +120,68 @@ fn renderButtons(app: *App) void {
     } else {
         if (zgui.button("Stop preview##preview_stop", .{ .w = 140 })) {
             app.stopPreview();
+        }
+    }
+}
+
+/// Scene picker dropdown to the right of "Run preview" (#132). Lists the
+/// project's `scenes/*.jsonc` files; the chosen entry sets
+/// `App.preview_scene_override`, which `startPreview` forwards to
+/// `labelle run --scene=<name>`. The `<initial>` entry resets the
+/// override to null so the next Run falls back to `project.labelle`'s
+/// `initial_scene` field.
+fn renderScenePicker(app: *App) void {
+    const proj = app.project_manager.current_project orelse {
+        // No project open — picker is meaningless. Don't crowd the
+        // panel; the "(no project open)" hint already shows.
+        return;
+    };
+
+    // Resolve the scene list lazily. `scenesAvailable` caches against
+    // the project's lifetime; the call is cheap on repeat renders.
+    const scenes = proj.scenesAvailable(app.allocator) catch &[_][]const u8{};
+
+    // Preview label — the picker shows `<initial>` when no override is
+    // set, otherwise the current chosen scene name. Bounded buffer so
+    // we can null-terminate for the C combo API.
+    var preview_buf: [160]u8 = undefined;
+    const preview_str: [:0]const u8 = blk: {
+        const src: []const u8 = app.preview_scene_override orelse "<initial>";
+        const n = @min(src.len, preview_buf.len - 1);
+        @memcpy(preview_buf[0..n], src[0..n]);
+        preview_buf[n] = 0;
+        break :blk preview_buf[0..n :0];
+    };
+
+    zgui.setNextItemWidth(160);
+    if (!zgui.beginCombo("##preview_scene", .{ .preview_value = preview_str.ptr })) return;
+    defer zgui.endCombo();
+
+    // `<initial>` resets the override to null — produces argv without
+    // `--scene=…` so the launcher honors `project.labelle`'s
+    // `initial_scene` field. This is the v1-shipping default; we want
+    // it to be the very first item so users can always get back to it.
+    if (zgui.selectable("<initial>", .{ .selected = app.preview_scene_override == null })) {
+        app.preview_scene_override = null;
+    }
+
+    for (scenes) |name| {
+        // Each entry needs a NUL-terminated label for selectable's
+        // C ABI. Names from `scenesAvailable` are arena-allocated
+        // without a NUL sentinel; copy into a per-iteration buffer.
+        var label_buf: [128]u8 = undefined;
+        if (name.len >= label_buf.len) continue;
+        @memcpy(label_buf[0..name.len], name);
+        label_buf[name.len] = 0;
+        const label = label_buf[0..name.len :0];
+
+        const selected =
+            app.preview_scene_override != null and
+            std.mem.eql(u8, app.preview_scene_override.?, name);
+        if (zgui.selectable(label, .{ .selected = selected })) {
+            // Borrow from the project arena — the slice lives until
+            // the next project transition (which clears the override).
+            app.preview_scene_override = name;
         }
     }
 }

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -171,6 +171,35 @@ const binary_header_bytes: usize = 6;
 /// component's serialized payload approaches that ceiling.
 const inbox_cap: usize = 16 * 1024;
 
+/// Compose the argv used to spawn `labelle run` for a preview session.
+/// Extracted so the shape is regression-locked under unit test without
+/// going through `std.process.spawn` (#131 / #132). The returned slice
+/// references `argv_buf`, `scene_buf`, and the caller's `dir_path` +
+/// `addr_str` — all must outlive the returned slice. Returns
+/// `error.OutOfMemory` only if `scene` doesn't fit in `scene_buf`.
+pub fn buildSpawnArgv(
+    argv_buf: *[16][]const u8,
+    scene_buf: *[128]u8,
+    dir_path: []const u8,
+    scene: ?[]const u8,
+) error{OutOfMemory}![]const []const u8 {
+    // Per #130: the labelle CLI doesn't define `--preview-mode`;
+    // the host:port is propagated via `LABELLE_PREVIEW` env var
+    // instead. So argv stays `["labelle", "run", <dir>]` plus the
+    // optional `--scene=<name>` from #132.
+    argv_buf[0] = "labelle";
+    argv_buf[1] = "run";
+    argv_buf[2] = dir_path;
+    var n: usize = 3;
+    if (scene) |s| {
+        const flag = std.fmt.bufPrint(scene_buf, "--scene={s}", .{s}) catch
+            return error.OutOfMemory;
+        argv_buf[n] = flag;
+        n += 1;
+    }
+    return argv_buf[0..n];
+}
+
 pub const PreviewSession = struct {
     allocator: std.mem.Allocator,
     state: State,
@@ -298,10 +327,11 @@ pub const PreviewSession = struct {
     }
 
     /// Production entry: bind + spawn `labelle run <project_dir>`
-    /// with `LABELLE_PREVIEW=127.0.0.1:<port>` in the env.
-    /// Captures the subprocess' stderr to surface on `.crashed`
-    /// (currently the engine doesn't expose useful stderr — that's
-    /// #79 territory — but the scaffolding is back in place).
+    /// (plus an optional `--scene=<name>` flag) with
+    /// `LABELLE_PREVIEW=127.0.0.1:<port>` in the env. Captures the
+    /// subprocess' stderr to surface on `.crashed` (currently the
+    /// engine doesn't expose useful stderr — that's #79 territory —
+    /// but the scaffolding is back in place).
     ///
     /// The labelle CLI's `run` subcommand doesn't define a
     /// `--preview-mode` flag (verified `labelle --help` — only
@@ -311,7 +341,12 @@ pub const PreviewSession = struct {
     /// the env in the parent process before spawning makes the
     /// child + CLI subprocess + game subprocess all inherit it
     /// (POSIX fork+exec env propagation).
-    pub fn start(self: *Self, proj: *const project.Project) PreviewError!void {
+    ///
+    /// `scene` is the optional scene picker override (#132). When
+    /// non-null, `--scene=<name>` is appended to the argv. `null`
+    /// (the default) leaves scene selection to `project.labelle`'s
+    /// `initial_scene` field.
+    pub fn start(self: *Self, proj: *const project.Project, scene: ?[]const u8) PreviewError!void {
         const dir_path = proj.dir orelse return error.NoProjectPath;
 
         try self.bindListener();
@@ -322,18 +357,22 @@ pub const PreviewSession = struct {
             return error.OutOfMemory;
 
         // Push LABELLE_PREVIEW into the parent's env so the eventual
-        // game subprocess (spawned by the labelle CLI we're about
-        // to invoke) inherits it. `stop()` unsets it. Single
-        // preview session at a time so no race.
+        // game subprocess (spawned by the labelle CLI we're about to
+        // invoke) inherits it. `stop()` unsets it. Single preview
+        // session at a time so no race.
         _ = setenv("LABELLE_PREVIEW", addr_str.ptr, 1);
 
+        // `scene_buf` lives on this function's stack and is referenced
+        // by `argv` until `std.process.spawn` returns. Spawn reads
+        // argv during the syscall, so the stack lifetime is fine —
+        // same pattern `addr_buf` already uses for the listener
+        // address. 128 bytes is generous for a scene name (the
+        // project tree's `isScenePath` only ever surfaces names that
+        // fit in a file path).
+        var scene_buf: [128]u8 = undefined;
         var argv_buf: [16][]const u8 = undefined;
-        const argv = blk: {
-            argv_buf[0] = "labelle";
-            argv_buf[1] = "run";
-            argv_buf[2] = dir_path;
-            break :blk argv_buf[0..3];
-        };
+        const argv = buildSpawnArgv(&argv_buf, &scene_buf, dir_path, scene) catch
+            return error.OutOfMemory;
 
         const child = std.process.spawn(io_global.io(), .{
             .argv = argv,

--- a/src/project.zig
+++ b/src/project.zig
@@ -99,6 +99,15 @@ pub const Project = struct {
     /// comma. Empty for projects authored by the gui.
     extras: []const []const u8,
     is_dirty: bool,
+    /// Cached result of `scenesAvailable`. Built lazily on first call;
+    /// owned by the project's arena and invalidated implicitly when the
+    /// Project is destroyed (project new/load/close bumps
+    /// `ProjectManager.generation` and recreates the Project). Walks
+    /// the top-level `<dir>/scenes/*.jsonc` only — subdirectory scenes
+    /// (e.g. `scenes/debug/main.jsonc`) are out of scope for the v1
+    /// picker; can grow later when the project tree starts exposing
+    /// nested scene folders.
+    scenes_cache: ?[]const []const u8 = null,
 
     const Self = @This();
 
@@ -120,6 +129,7 @@ pub const Project = struct {
             .config = .{ .name = name_copy },
             .extras = &.{},
             .is_dirty = true,
+            .scenes_cache = null,
         };
         return project;
     }
@@ -136,6 +146,72 @@ pub const Project = struct {
 
     pub fn getProjectDir(self: *const Self) ?[]const u8 {
         return self.dir;
+    }
+
+    /// Return the list of scene basenames (extension stripped) found at
+    /// `<dir>/scenes/*.jsonc`, sorted alphabetically. Cached against the
+    /// project's lifetime — the cache is built on the first call and
+    /// owned by `arena`. Project transitions (new/load/close) recreate
+    /// the Project entirely, so the cache invalidates implicitly.
+    ///
+    /// The `alloc` parameter is unused today (the arena is the real
+    /// owner) but exposed in the signature so future callers can pass a
+    /// short-lived allocator if cache-invalidation grows beyond
+    /// per-project lifetime — e.g. a "Refresh" button.
+    ///
+    /// Returns an empty slice if `dir` is null (unsaved project) or the
+    /// `scenes/` subdirectory is missing.
+    pub fn scenesAvailable(self: *Self, alloc: std.mem.Allocator) ![]const []const u8 {
+        _ = alloc;
+        if (self.scenes_cache) |c| return c;
+
+        const arena_alloc = self.arena.allocator();
+        const dir_path = self.dir orelse {
+            self.scenes_cache = &.{};
+            return &.{};
+        };
+
+        const scenes_dir_path = std.fs.path.join(arena_alloc, &.{ dir_path, ProjectFolders.scenes }) catch {
+            self.scenes_cache = &.{};
+            return &.{};
+        };
+
+        const io = io_global.io();
+        var scenes_dir = std.Io.Dir.cwd().openDir(io, scenes_dir_path, .{ .iterate = true }) catch {
+            // Missing scenes/ subdir is the default for new projects —
+            // not an error from the picker's perspective.
+            self.scenes_cache = &.{};
+            return &.{};
+        };
+        defer scenes_dir.close(io);
+
+        var names: std.ArrayListUnmanaged([]const u8) = .empty;
+        // Names live in the arena, so no separate cleanup needed on the
+        // success path — the arena deinit catches everything.
+
+        var it = scenes_dir.iterate();
+        while (it.next(io) catch null) |dirent| {
+            if (dirent.kind != .file) continue;
+            if (!std.mem.endsWith(u8, dirent.name, ".jsonc")) continue;
+            const stem = dirent.name[0 .. dirent.name.len - ".jsonc".len];
+            if (stem.len == 0) continue;
+            const copy = arena_alloc.dupe(u8, stem) catch continue;
+            names.append(arena_alloc, copy) catch continue;
+        }
+
+        const mut_slice: [][]const u8 = names.toOwnedSlice(arena_alloc) catch {
+            self.scenes_cache = &.{};
+            return &.{};
+        };
+        std.mem.sort([]const u8, mut_slice, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.lessThan(u8, a, b);
+            }
+        }.lessThan);
+
+        const slice: []const []const u8 = mut_slice;
+        self.scenes_cache = slice;
+        return slice;
     }
 };
 
@@ -277,6 +353,7 @@ pub const ProjectManager = struct {
             .config = parsed,
             .extras = extras,
             .is_dirty = false,
+            .scenes_cache = null,
         };
 
         if (self.current_project) |old| old.deinit();

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3130,6 +3130,200 @@ pub const PreferencesTests = struct {
     }
 };
 
+pub const ScenesAvailableTests = struct {
+    // `Project.scenesAvailable` is the data source for the Run-button
+    // scene picker (#132). The picker assumes basenames, alphabetical
+    // order, top-level `.jsonc` only. These tests lock those shape
+    // contracts so a future tweak (e.g. recursing into subdirs) flags
+    // up before it surprises the UI code.
+
+    fn createTempDir(allocator: std.mem.Allocator) ![]const u8 {
+        const tmp_base = "/tmp";
+        const ts = timestampSeconds();
+        // Disambiguate by both ts and an incrementing index so two tests
+        // running back-to-back inside the same second don't collide on
+        // the same temp dir.
+        const Counter = struct {
+            var i: u64 = 0;
+        };
+        Counter.i += 1;
+        const dir_name = try std.fmt.allocPrint(allocator, "{s}/labelle_scenes_{d}_{d}", .{ tmp_base, ts, Counter.i });
+        try std.Io.Dir.cwd().createDir(io_global.io(), dir_name, .default_dir);
+        return dir_name;
+    }
+
+    fn deleteTempDir(allocator: std.mem.Allocator, dir_path: []const u8) void {
+        std.Io.Dir.cwd().deleteTree(io_global.io(), dir_path) catch {};
+        allocator.free(dir_path);
+    }
+
+    fn touchFile(allocator: std.mem.Allocator, dir_path: []const u8, name: []const u8) !void {
+        const path = try std.fs.path.join(allocator, &.{ dir_path, name });
+        defer allocator.free(path);
+        try std.Io.Dir.cwd().writeFile(io_global.io(), .{
+            .sub_path = path,
+            .data = "{ \"entities\": {} }\n",
+        });
+    }
+
+    test "returns empty slice when project has no dir" {
+        const allocator = std.testing.allocator;
+        const proj = try project.Project.create(allocator, "no_dir");
+        defer proj.deinit();
+        const scenes = try proj.scenesAvailable(allocator);
+        try expect.equal(scenes.len, 0);
+    }
+
+    test "returns empty slice when scenes/ is missing" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.newProject("missing_scenes");
+        // Don't call saveProject — it scaffolds `scenes/`. Force-set the
+        // dir so the lookup runs.
+        pm.current_project.?.dir = try pm.current_project.?.arena.allocator().dupe(u8, temp_dir);
+
+        const scenes = try pm.current_project.?.scenesAvailable(allocator);
+        try expect.equal(scenes.len, 0);
+    }
+
+    test "lists *.jsonc files alphabetically by stem" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.newProject("scenes_test");
+        try pm.saveProject(temp_dir);
+
+        const scenes_dir = try std.fs.path.join(allocator, &.{ temp_dir, "scenes" });
+        defer allocator.free(scenes_dir);
+
+        // Drop files in a non-alphabetical order to prove the sort step
+        // runs.
+        try touchFile(allocator, scenes_dir, "main.jsonc");
+        try touchFile(allocator, scenes_dir, "debug.jsonc");
+        try touchFile(allocator, scenes_dir, "menu.jsonc");
+
+        const scenes = try pm.current_project.?.scenesAvailable(allocator);
+        try expect.equal(scenes.len, 3);
+        try std.testing.expectEqualStrings(scenes[0], "debug");
+        try std.testing.expectEqualStrings(scenes[1], "main");
+        try std.testing.expectEqualStrings(scenes[2], "menu");
+    }
+
+    test "ignores non-jsonc files and subdirectories" {
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.newProject("scenes_test");
+        try pm.saveProject(temp_dir);
+
+        const scenes_dir = try std.fs.path.join(allocator, &.{ temp_dir, "scenes" });
+        defer allocator.free(scenes_dir);
+
+        try touchFile(allocator, scenes_dir, "main.jsonc");
+        try touchFile(allocator, scenes_dir, "README.md");
+        try touchFile(allocator, scenes_dir, "main.json"); // wrong extension
+
+        // Subdir scenes are out of scope for the v1 picker — the
+        // launcher's `--scene=<name>` flag only accepts a single name,
+        // not a path. Drop a nested file to assert it's skipped.
+        const nested = try std.fs.path.join(allocator, &.{ scenes_dir, "debug" });
+        defer allocator.free(nested);
+        try std.Io.Dir.cwd().createDir(io_global.io(), nested, .default_dir);
+        try touchFile(allocator, nested, "main.jsonc");
+
+        const scenes = try pm.current_project.?.scenesAvailable(allocator);
+        try expect.equal(scenes.len, 1);
+        try std.testing.expectEqualStrings(scenes[0], "main");
+    }
+
+    test "caches the result across repeated calls" {
+        // The picker hits this on every render; make sure repeat calls
+        // return the same slice (identity check) rather than re-walking
+        // the filesystem and reallocating.
+        const allocator = std.testing.allocator;
+        const temp_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, temp_dir);
+
+        var pm = project.ProjectManager.init(allocator);
+        defer pm.deinit();
+        try pm.newProject("scenes_cache");
+        try pm.saveProject(temp_dir);
+
+        const scenes_dir = try std.fs.path.join(allocator, &.{ temp_dir, "scenes" });
+        defer allocator.free(scenes_dir);
+        try touchFile(allocator, scenes_dir, "main.jsonc");
+
+        const first = try pm.current_project.?.scenesAvailable(allocator);
+        const second = try pm.current_project.?.scenesAvailable(allocator);
+        try expect.equal(first.ptr, second.ptr);
+        try expect.equal(first.len, second.len);
+    }
+};
+
+pub const PreviewSpawnArgvTests = struct {
+    // Regression-lock the argv shape `preview.start` passes to
+    // `std.process.spawn` (#131 / #132). The launcher integration is
+    // covered by `zig build smoke`; this is the pure-formatter side.
+
+    test "no scene override matches the post-#130 argv shape (env-var, no --preview-mode)" {
+        var argv_buf: [16][]const u8 = undefined;
+        var scene_buf: [128]u8 = undefined;
+        const argv = try preview.buildSpawnArgv(
+            &argv_buf,
+            &scene_buf,
+            "/projects/game",
+            null,
+        );
+        try expect.equal(argv.len, 3);
+        try std.testing.expectEqualStrings(argv[0], "labelle");
+        try std.testing.expectEqualStrings(argv[1], "run");
+        try std.testing.expectEqualStrings(argv[2], "/projects/game");
+        // Regression-lock the bug from PR #130: argv MUST NOT include
+        // `--preview-mode` — the labelle CLI doesn't define it. The
+        // host:port goes through `LABELLE_PREVIEW` env var instead.
+        for (argv) |a| try expect.toBeFalse(std.mem.eql(u8, a, "--preview-mode"));
+    }
+
+    test "scene override appends --scene=<name>" {
+        var argv_buf: [16][]const u8 = undefined;
+        var scene_buf: [128]u8 = undefined;
+        const argv = try preview.buildSpawnArgv(
+            &argv_buf,
+            &scene_buf,
+            "/projects/game",
+            "level2",
+        );
+        try expect.equal(argv.len, 4);
+        try std.testing.expectEqualStrings(argv[3], "--scene=level2");
+    }
+
+    test "OOM when scene name overflows the scene buffer" {
+        // Names this long can't reach the launcher (the picker only
+        // surfaces filenames the OS already accepted), but the bounded
+        // buffer should reject them cleanly rather than truncating.
+        var argv_buf: [16][]const u8 = undefined;
+        var scene_buf: [128]u8 = undefined;
+        const oversize = "x" ** 200;
+        const got = preview.buildSpawnArgv(
+            &argv_buf,
+            &scene_buf,
+            "/d",
+            oversize[0..],
+        );
+        try std.testing.expectError(error.OutOfMemory, got);
+    }
+};
+
 pub const PreviewTransportTests = struct {
     // Drives `PreviewSession` end-to-end against an in-test fake
     // engine that dials the editor's listener and writes JSON


### PR DESCRIPTION
## Summary

- Adds a dropdown next to the Preview panel's Run button that lists scenes discovered under `<project>/scenes/*.jsonc`. The chosen scene forwards to `labelle run --scene=<name>`.
- Includes an `<initial>` entry that resets the override to null, falling back to `project.labelle`'s `initial_scene` field (the pre-#132 behavior — argv shape is unchanged when no scene is picked).
- Persistence is per-session for this PR; cross-session storage in `prefs.zig` can land as a follow-up.

## Key pieces

- `Project.scenesAvailable(alloc)` walks the top-level `scenes/` dir, returns basenames sorted alphabetically. Cached in the project arena so repeated calls (one per panel render) don't re-walk the filesystem. Project transitions recreate the Project, so the cache invalidates implicitly with `ProjectManager.generation`.
- `preview.start(proj, scene)` takes an optional scene name. The argv-shaping logic moved into a new pure helper `preview.buildSpawnArgv` so the shape is regression-locked without going through `std.process.spawn`. `addr_buf`/`scene_buf` continue to live on the stack of `start()`; spawn reads argv before returning, same lifetime story `addr_buf` already had.
- `App.preview_scene_override` borrows the chosen scene name from the active project's arena. Reset to null on `ProjectManager.generation` change (the existing project-transition codepath in `renderFrame`), so a stale pointer from the prior project's arena can't leak into a fresh `preview.start` call.
- `src/modules/preview.zig` renders the picker via `zgui.beginCombo` + `selectable`; the first item is always `<initial>`.

## Test plan

- [x] `zig build test` — 192/192 pass; new coverage:
  - `ScenesAvailableTests` — empty when no dir / no scenes folder, alphabetical sort, file-extension + subdir filtering, cache identity across calls.
  - `PreviewSpawnArgvTests` — no-scene argv shape matches the pre-#132 PR #130 shape exactly, `--scene=<name>` is appended when set, oversize names return `error.OutOfMemory` cleanly.
- [x] `zig build` — gui exe compiles.
- [x] `zig build gui-test` — 13/13 TE tests pass; no TE-level driving of the new combo (left for a follow-up if the harness gains a "click selectable inside a popup" helper).
- [ ] Manual smoke once reviewed: open `../flying-platform-labelle/`, pick a non-default scene from the dropdown, click Run, verify `--scene=<name>` shows up in the spawn (the launcher already routes it).

Closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)