### PR TITLE
fix(preview): timeout bump + env propagation + frame_accept + crash logging

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -424,6 +424,12 @@ pub const App = struct {
         self.openGameViewTab() catch |err| {
             std.log.warn("attachGameView: openGameViewTab failed: {s}", .{@errorName(err)});
         };
+        // Reply with `frame_accept` so the engine flips its
+        // `frame_state` to `.accepted` and starts publishing —
+        // without this, `signalSlotReady`/`publishFrame*` bounce
+        // with `StreamNotActive` and the Game View stays at
+        // "waiting for first frame" forever.
+        self.preview.sendFrameAccept();
     }
 
     /// Push a `.game_view` tab onto `open_tabs` (or focus an existing

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -101,7 +101,15 @@ pub const Bye = struct {
     reason: ?[]u8 = null,
 };
 
-pub const connecting_timeout_ms: i64 = 2_000;
+/// How long to wait for the spawned `labelle run` subprocess to
+/// dial back into the listener before declaring the preview
+/// `.crashed`. The CLI runs `zig build` first (cold builds can take
+/// 30-60+ seconds for a sokol+imgui game), so the timeout must cover
+/// the build phase + the game's own startup, not just the network
+/// connect. A proper fix would distinguish "build pending" (child
+/// alive, no connection yet) from "really crashed" (child exited)
+/// — see #134-follow-up. For now, generous flat budget.
+pub const connecting_timeout_ms: i64 = 60_000;
 
 /// Callback slot — fires on the first `frame_offer` JSON frame the
 /// engine sends after the `hello` handshake. The App wires this to

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -41,10 +41,12 @@ const io_global = @import("io_global.zig");
 
 extern "c" fn close(fd: c_int) c_int;
 extern "c" fn read(fd: c_int, buf: [*]u8, len: usize) isize;
+extern "c" fn write(fd: c_int, buf: [*]const u8, len: usize) isize;
 extern "c" fn __error() *c_int;
 extern "c" fn __errno_location() *c_int;
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+extern "c" var environ: [*]?[*:0]const u8;
 
 fn libcErrno() c_int {
     return if (builtin.os.tag == .macos) __error().* else __errno_location().*;
@@ -364,11 +366,26 @@ pub const PreviewSession = struct {
         const addr_str = std.fmt.bufPrintZ(&addr_buf, "127.0.0.1:{d}", .{self.port.?}) catch
             return error.OutOfMemory;
 
-        // Push LABELLE_PREVIEW into the parent's env so the eventual
-        // game subprocess (spawned by the labelle CLI we're about to
-        // invoke) inherits it. `stop()` unsets it. Single preview
-        // session at a time so no race.
-        _ = setenv("LABELLE_PREVIEW", addr_str.ptr, 1);
+        // Build an env Map by cloning the current process environ
+        // and adding LABELLE_PREVIEW. Pass via SpawnOptions —
+        // mutating the parent's environ via libc setenv() was
+        // unreliable in practice (the spawned game's env didn't
+        // see LABELLE_PREVIEW even though PATH propagated correctly,
+        // suggesting std.process.spawn snapshots env in a way that
+        // doesn't pick up runtime setenv calls on Darwin).
+        _ = setenv("LABELLE_PREVIEW", addr_str.ptr, 1); // still set for the simpler propagation path
+        var env_map = std.process.Environ.Map.init(self.allocator);
+        defer env_map.deinit();
+        // Copy the current environ into the Map. extern environ is
+        // a null-terminated array of "KEY=VAL" strings.
+        var i: usize = 0;
+        while (environ[i]) |entry| : (i += 1) {
+            const s = std.mem.span(entry);
+            if (std.mem.indexOfScalar(u8, s, '=')) |eq| {
+                env_map.put(s[0..eq], s[eq + 1 ..]) catch return error.OutOfMemory;
+            }
+        }
+        env_map.put("LABELLE_PREVIEW", addr_str) catch return error.OutOfMemory;
 
         // `scene_buf` lives on this function's stack and is referenced
         // by `argv` until `std.process.spawn` returns. Spawn reads
@@ -384,6 +401,7 @@ pub const PreviewSession = struct {
 
         const child = std.process.spawn(io_global.io(), .{
             .argv = argv,
+            .environ_map = &env_map,
             .stdin = .ignore,
             .stdout = .inherit,
             .stderr = .pipe,
@@ -475,6 +493,23 @@ pub const PreviewSession = struct {
     }
 
     // ── Phase-3 uplink stubs (out of scope for #112) ──────────────
+    /// Send `{"kind":"frame_accept"}\n` to the engine, flipping its
+    /// `frame_state` to `.accepted` so subsequent `publishFrame*` /
+    /// `signalSlotReady` calls succeed instead of bouncing with
+    /// `StreamNotActive`. Caller invokes this after `on_frame_offer`
+    /// has run and the consumer side (SHM or IOSurface) has
+    /// successfully attached.
+    pub fn sendFrameAccept(self: *Self) void {
+        if (self.conn_fd < 0) return;
+        const msg: []const u8 = "{\"kind\":\"frame_accept\"}\n";
+        var off: usize = 0;
+        while (off < msg.len) {
+            const n = write(self.conn_fd, msg.ptr + off, msg.len - off);
+            if (n <= 0) return; // best-effort; drop on error
+            off += @intCast(n);
+        }
+    }
+
     pub fn watchEntity(self: *Self, entity_id: u64) !void {
         _ = self;
         _ = entity_id;
@@ -852,6 +887,11 @@ pub const PreviewSession = struct {
     }
 
     fn markCrashed(self: *Self, reason: []const u8) void {
+        std.log.warn("preview: markCrashed reason={s} state_before={s} stderr_capture={s}", .{
+            reason,
+            @tagName(self.state),
+            self.stderr_buf.items[0..@min(self.stderr_buf.items.len, 512)],
+        });
         if (self.bye_reason == null) {
             self.bye_reason = self.allocator.dupe(u8, reason) catch null;
         }


### PR DESCRIPTION
## Repro

Open flying-platform-labelle in the gui, click Run. Preview transitioned `.idle` → `.listening` → `.connecting` → `.crashed` within 2 seconds, displaying "Preview Crashed" before the labelle CLI subprocess had even finished `zig build`. Even after extending the timeout, subsequent issues (env propagation, missing protocol handshake) kept the Game View stuck at "(waiting for first frame)" forever.

## Fixes (4 commits)

### Commit 1: bump `connecting_timeout_ms` 2s → 60s

The original 2s was eating legitimate connections because `labelle run` builds the game before launching it (cold builds 30-60+s for a sokol+imgui game). Band-aid for the broader UX issue tracked in **#127** + **#136-followup** (proper `child.tryWait()` check).

### Commit 2: env propagation via `SpawnOptions.environ_map`

The first attempt set `LABELLE_PREVIEW` via libc `setenv` on the parent before spawning. Worked for the gui's own process but NOT for the spawned `labelle run` subprocess + game grandchild — `ps -Eww` on the game showed PATH propagated correctly but `LABELLE_PREVIEW` was missing, suggesting `std.process.spawn` on Darwin snapshots env in a way that doesn't pick up runtime libc setenv calls.

Fix: clone the current process's `environ` into `std.process.Environ.Map`, add `LABELLE_PREVIEW`, pass via `SpawnOptions.environ_map`.

### Commit 3: `Preview.sendFrameAccept()` — the missing protocol handshake

The engine sends `frame_offer` after `beginFrameStream*`, then waits for the editor's `{"kind":"frame_accept"}\n` before flipping `frame_state = .accepted`. Without that, every `signalSlotReady` / `publishFrame*` bounces with `StreamNotActive` and the Game View stays at "(waiting for first frame)" forever. The gui's transport had no `sendFrameAccept` at all.

`App.attachGameView` now calls `preview.sendFrameAccept()` after a successful consumer attach.

### Commit 4: `markCrashed` logs to `std.log.warn`

Previously `markCrashed` set state silently. Now it logs the reason + first 512 bytes of captured subprocess stderr — diagnosis without re-reproducing.

## Test plan

- [x] `zig build test` — green.
- [x] Manual smoke against flying-platform-labelle on macOS: click Run, watch the gui transition through `.listening` → `.connecting` → `.running`, Game View tab opens, IOSurface contents fill with real pixels.

## Follow-ups

- **#127** — preview spawn off the render thread + Compiler Output live tail.
- **#136-followup** — `child.tryWait()` for early-crash detection instead of flat 60s timeout.