### PR TITLE
feat(preview): live stderr tail + subprocess-exit early crash detection (#127, #136)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -143,6 +143,22 @@ pub const App = struct {
     /// module. The module reads this via its `Module.is_open` pointer.
     show_compiler_output: bool = false,
     compiler_output_scroll_to_bottom: bool = false,
+    /// Tail buffer for the Compiler Output panel's live preview view
+    /// (#127). The panel pulls newly-arrived stderr bytes from
+    /// `preview.PreviewSession.consumeStderr` each frame and appends
+    /// them here, so the build phase's progress is visible live
+    /// instead of only on `.crashed`. Capped to keep the buffer from
+    /// growing without bound on a chatty subprocess; older bytes are
+    /// discarded from the front when the cap is hit. Reset on every
+    /// fresh `startPreview`.
+    preview_tail: std.ArrayList(u8) = .empty,
+    /// Tracks whether the *user* manually closed the Compiler Output
+    /// panel during the current preview session. We force-open the
+    /// panel on each `startPreview` (so the user sees the build
+    /// output without a menu click), but if they close it via the
+    /// title-bar ×, we don't keep fighting them by re-opening it on
+    /// every frame. Reset on each fresh Run.
+    preview_force_opened: bool = false,
 
     show_project_settings: bool = false,
     project_settings: project_settings_mod.ProjectSettings = .{},
@@ -385,6 +401,7 @@ pub const App = struct {
     pub fn deinit(self: *Self) void {
         self.closeAllTabs();
         self.open_tabs.deinit(self.allocator);
+        self.preview_tail.deinit(self.allocator);
         if (self.atlas_index) |*idx| idx.deinit();
         if (self.gizmo_index) |*idx| idx.deinit();
         if (self.prefab_index) |*idx| idx.deinit();
@@ -927,6 +944,10 @@ pub const App = struct {
             self.setStatus("Error syncing project files!");
             return;
         };
+        // Reset the panel's live-tail buffer before the session
+        // starts — old bytes from a previous Run shouldn't leak into
+        // the new session's output.
+        self.preview_tail.clearRetainingCapacity();
         self.preview.start(proj, self.preview_scene_override) catch |err| {
             std.log.err("Error starting preview: {}", .{err});
             self.setStatus("Error starting preview!");
@@ -934,6 +955,49 @@ pub const App = struct {
         };
         self.setStatus("Preview starting...");
         self.show_preview = true;
+        // Force-open the Compiler Output panel so the user sees the
+        // subprocess's stderr live during the (potentially 30-60s)
+        // cold `zig build` phase. Manual close via the panel × flips
+        // `show_compiler_output` back to false and stays that way for
+        // the rest of the session — `preview_force_opened` is the
+        // one-shot latch (#127).
+        self.show_compiler_output = true;
+        self.preview_force_opened = true;
+        self.compiler_output_scroll_to_bottom = true;
+    }
+
+    /// Append `bytes` to the Compiler Output panel's live preview
+    /// tail buffer (#127). Bounded by `preview_tail_cap` — when the
+    /// buffer would exceed the cap, the oldest bytes are dropped from
+    /// the front so the *recent* tail (where the build error or panic
+    /// trace lives) is what the user sees. Called from the panel's
+    /// per-frame `consumeStderr` drain; safe to call with an empty
+    /// slice.
+    pub fn appendPreviewTail(self: *Self, bytes: []const u8) void {
+        if (bytes.len == 0) return;
+        // Cap matches `preview.stderr_buf`'s cap (16 KiB) so the panel
+        // never holds more than two windows' worth of stderr in flight.
+        const preview_tail_cap: usize = 16 * 1024;
+        if (bytes.len >= preview_tail_cap) {
+            // Single record already exceeds the cap — keep only the
+            // tail end.
+            self.preview_tail.clearRetainingCapacity();
+            const start = bytes.len - preview_tail_cap;
+            self.preview_tail.appendSlice(self.allocator, bytes[start..]) catch return;
+            return;
+        }
+        // Drop from the front if appending `bytes` would overflow.
+        if (self.preview_tail.items.len + bytes.len > preview_tail_cap) {
+            const need_to_drop = self.preview_tail.items.len + bytes.len - preview_tail_cap;
+            const remaining = self.preview_tail.items.len - need_to_drop;
+            std.mem.copyForwards(
+                u8,
+                self.preview_tail.items[0..remaining],
+                self.preview_tail.items[need_to_drop..],
+            );
+            self.preview_tail.shrinkRetainingCapacity(remaining);
+        }
+        self.preview_tail.appendSlice(self.allocator, bytes) catch return;
     }
 
     pub fn stopPreview(self: *Self) void {

--- a/src/app.zig
+++ b/src/app.zig
@@ -152,13 +152,6 @@ pub const App = struct {
     /// discarded from the front when the cap is hit. Reset on every
     /// fresh `startPreview`.
     preview_tail: std.ArrayList(u8) = .empty,
-    /// Tracks whether the *user* manually closed the Compiler Output
-    /// panel during the current preview session. We force-open the
-    /// panel on each `startPreview` (so the user sees the build
-    /// output without a menu click), but if they close it via the
-    /// title-bar ×, we don't keep fighting them by re-opening it on
-    /// every frame. Reset on each fresh Run.
-    preview_force_opened: bool = false,
 
     show_project_settings: bool = false,
     project_settings: project_settings_mod.ProjectSettings = .{},
@@ -957,12 +950,10 @@ pub const App = struct {
         self.show_preview = true;
         // Force-open the Compiler Output panel so the user sees the
         // subprocess's stderr live during the (potentially 30-60s)
-        // cold `zig build` phase. Manual close via the panel × flips
-        // `show_compiler_output` back to false and stays that way for
-        // the rest of the session — `preview_force_opened` is the
-        // one-shot latch (#127).
+        // cold `zig build` phase. Manual close via the panel × keeps
+        // it closed for the rest of this Run; the next `startPreview`
+        // call re-opens it on the next Run (#127).
         self.show_compiler_output = true;
-        self.preview_force_opened = true;
         self.compiler_output_scroll_to_bottom = true;
     }
 

--- a/src/modules/compiler_output.zig
+++ b/src/modules/compiler_output.zig
@@ -4,7 +4,18 @@
 //! current compiler state, and streams the last `labelle build/run`
 //! invocation's stdout/stderr. The `Build` menu also flips `is_open` to
 //! true when the user starts a build, which auto-surfaces the panel.
+//!
+//! Live preview tail (#127): when an editor-side preview session is alive
+//! (`.listening` / `.connecting` / `.running`), the panel also tails the
+//! spawned `labelle run` subprocess's stderr live. The fix here is for
+//! the user-perceived freeze during the CLI subprocess's cold `zig build`
+//! phase (sokol+imgui cold builds run 30-60+ seconds) — previously the
+//! Game View said "connecting…" for the whole window with zero feedback,
+//! and stderr was only surfaced on `.crashed`. The `consumeStderr` cursor
+//! advances each frame, so each panel render appends only the newly-
+//! arrived bytes to `app.preview_tail` (the panel's tail buffer).
 
+const std = @import("std");
 const zgui = @import("zgui");
 
 const App = @import("../app.zig").App;
@@ -41,23 +52,73 @@ fn render(app: *App) void {
     }
     defer zgui.end();
 
-    switch (app.compiler.getState()) {
-        .idle => zgui.textDisabled("Ready", .{}),
-        .generating => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Generating...", .{}),
-        .building => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Building...", .{}),
-        .running => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Running...", .{}),
-        .success => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Success", .{}),
-        .failed => zgui.textColored(.{ 1.0, 0.0, 0.0, 1.0 }, "Failed", .{}),
+    // While preview is alive, the panel's status line reflects the
+    // preview state — the build phase happens *inside* the subprocess
+    // (`labelle run` runs `zig build` then exec's the game), so the
+    // gui's own `compiler.state` stays `.idle` and would otherwise
+    // read "Ready" while the user waits for a cold build. Render the
+    // preview's state instead so the user has a single source of
+    // truth.
+    const preview_active = app.preview.isActive();
+    if (preview_active) {
+        switch (app.preview.state) {
+            .listening => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Preview: building / waiting for engine...", .{}),
+            .connecting => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Preview: engine connected, waiting for hello...", .{}),
+            .running => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Preview: running", .{}),
+            else => zgui.textDisabled("Preview: idle", .{}),
+        }
+    } else {
+        switch (app.compiler.getState()) {
+            .idle => zgui.textDisabled("Ready", .{}),
+            .generating => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Generating...", .{}),
+            .building => zgui.textColored(.{ 1.0, 1.0, 0.0, 1.0 }, "Building...", .{}),
+            .running => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Running...", .{}),
+            .success => zgui.textColored(.{ 0.0, 1.0, 0.0, 1.0 }, "Success", .{}),
+            .failed => zgui.textColored(.{ 1.0, 0.0, 0.0, 1.0 }, "Failed", .{}),
+        }
     }
     zgui.separator();
 
-    if (zgui.beginChild("##output", .{ .h = -1 })) {
-        if (app.compiler.last_result) |result| {
-            if (result.errors.len > 0) zgui.textColored(.{ 1.0, 0.3, 0.3, 1.0 }, "{s}", .{result.errors});
-            if (result.output.len > 0) zgui.text("{s}", .{result.output});
-        } else {
-            zgui.textDisabled("No output", .{});
+    // Tail any stderr bytes that arrived since the last frame into the
+    // panel's display buffer. `consumeStderr` advances an internal
+    // cursor so each byte is appended exactly once across the session;
+    // `app.preview_tail` is reset on every fresh Run (`startPreview`).
+    // Calling this unconditionally (not gated on `preview_active`) is
+    // safe — when no session is alive `stderr_buf` is empty and
+    // `consumeStderr` returns a zero-length slice.
+    {
+        const fresh = app.preview.consumeStderr();
+        if (fresh.len > 0) {
+            app.appendPreviewTail(fresh);
+            app.compiler_output_scroll_to_bottom = true;
         }
+    }
+
+    if (zgui.beginChild("##output", .{ .h = -1 })) {
+        var rendered_anything = false;
+
+        // Live preview tail takes precedence during an active session
+        // so the user sees what the subprocess is doing right now —
+        // the manual-build artifact (`compiler.last_result`) is stale
+        // when a preview is mid-flight.
+        if (app.preview_tail.items.len > 0) {
+            zgui.textUnformatted(app.preview_tail.items);
+            rendered_anything = true;
+        }
+
+        if (app.compiler.last_result) |result| {
+            if (result.errors.len > 0) {
+                zgui.textColored(.{ 1.0, 0.3, 0.3, 1.0 }, "{s}", .{result.errors});
+                rendered_anything = true;
+            }
+            if (result.output.len > 0) {
+                zgui.text("{s}", .{result.output});
+                rendered_anything = true;
+            }
+        }
+
+        if (!rendered_anything) zgui.textDisabled("No output", .{});
+
         if (app.compiler_output_scroll_to_bottom) {
             zgui.setScrollHereY(.{ .center_y_ratio = 1.0 });
             app.compiler_output_scroll_to_bottom = false;

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -47,6 +47,15 @@ extern "c" fn __errno_location() *c_int;
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 extern "c" var environ: [*]?[*:0]const u8;
+/// libc `waitpid(2)` — used in non-blocking mode (`WNOHANG`) by
+/// `tryWaitChild` to detect a subprocess that exited before the
+/// editor's connecting-timeout fires. Returns the pid of a reaped
+/// child, 0 when no child has exited yet, or -1 on error.
+extern "c" fn waitpid(pid: c_int, status: ?*c_int, options: c_int) c_int;
+/// `WNOHANG` is `1` on both Darwin and Linux — safe to hardcode here
+/// rather than threading it through `std.posix.W` (which doesn't
+/// re-export the value as a Zig constant).
+const WNOHANG: c_int = 1;
 
 fn libcErrno() c_int {
     return if (builtin.os.tag == .macos) __error().* else __errno_location().*;
@@ -220,6 +229,12 @@ pub const PreviewSession = struct {
     bye_reason: ?[]u8,
     started_ms: ?i64,
     stderr_buf: std.ArrayList(u8),
+    /// Read cursor for `consumeStderr` — the next call returns bytes
+    /// `stderr_buf.items[stderr_cursor..]` and advances the cursor.
+    /// Reset alongside `stderr_buf` on every fresh `bindListener`
+    /// (i.e. each Run cycle) so a stale tail from the previous session
+    /// doesn't leak into the new one's live-tail consumer.
+    stderr_cursor: usize = 0,
     /// PIE viewport frame-offer hook (#112). App wires to
     /// `attachGameView` so the Game View panel auto-opens when the
     /// engine emits its `frame_offer`. `null` = ignore offers.
@@ -306,6 +321,7 @@ pub const PreviewSession = struct {
         }
         self.releaseOwnedStrings();
         self.stderr_buf.clearRetainingCapacity();
+        self.stderr_cursor = 0;
         self.inbox.clearRetainingCapacity();
 
         const addr = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable;
@@ -456,6 +472,21 @@ pub const PreviewSession = struct {
             .connecting, .running => self.tryRead(),
         }
 
+        // Subprocess-exit early-crash detection (#127, subsuming the
+        // first half of #136). If the spawned `labelle run` exits —
+        // build failure, panic, immediate `error.FileNotFound` on the
+        // game binary — before the engine dials back and completes
+        // the `hello` handshake, the listener would otherwise wait
+        // the full 60-second `connecting_timeout_ms` window before
+        // declaring `.crashed`. Poll `waitpid(WNOHANG)` here so we
+        // land in `.crashed` immediately, surfacing the exit code in
+        // the `bye_reason` for the panel. The timeout below stays as
+        // a backstop for the case where the child is alive but
+        // wedged.
+        if (self.state == .listening or self.state == .connecting) {
+            self.tryWaitChild();
+        }
+
         // Connecting-timeout: if no client showed up — or accepted
         // but didn't `hello` — within the window, the subprocess
         // likely failed and we land in `.crashed`. Two cases share
@@ -490,6 +521,25 @@ pub const PreviewSession = struct {
 
     pub fn capturedStderr(self: *const Self) []const u8 {
         return self.stderr_buf.items;
+    }
+
+    /// Yield stderr bytes that have arrived since the last call and
+    /// advance the internal cursor past them. Designed to be called
+    /// once per editor frame from the Compiler Output panel so the
+    /// build phase's progress (the `zig build` step running inside
+    /// `labelle run`, which is cold-cache 30-60+ seconds for a
+    /// sokol+imgui game) is visible live instead of only on `.crashed`.
+    ///
+    /// Returned slice borrows from `stderr_buf`; the caller must copy
+    /// before the next `poll()` invocation if it needs to retain the
+    /// bytes. Empty slice when no new bytes have arrived. Cursor is
+    /// monotonic within a session and resets to 0 on `bindListener`
+    /// (every fresh Run).
+    pub fn consumeStderr(self: *Self) []const u8 {
+        if (self.stderr_cursor >= self.stderr_buf.items.len) return &.{};
+        const fresh = self.stderr_buf.items[self.stderr_cursor..];
+        self.stderr_cursor = self.stderr_buf.items.len;
+        return fresh;
     }
 
     // ── Phase-3 uplink stubs (out of scope for #112) ──────────────
@@ -859,6 +909,69 @@ pub const PreviewSession = struct {
         }
         // Unknown JSON kinds drop silently. Binary plane frames are
         // routed by `tryReadBinary` before they ever reach this path.
+    }
+
+    /// Non-blocking `waitpid` on the spawned subprocess. If the child
+    /// has already exited, transition to `.crashed` with the exit
+    /// code (or signal number) embedded in the `bye_reason`. No-op
+    /// when there's no child (test fixtures call `bindListener`
+    /// directly) or when the child is still alive.
+    ///
+    /// Why bypass `std.process.Child.wait` here: that API blocks until
+    /// termination and tears the Child down (sets `id = null`, closes
+    /// stderr pipe). We need a *peek* — child may still be running
+    /// the cold `zig build` step, and even when it has exited we want
+    /// to drain the stderr pipe one more time on the next `poll` before
+    /// `stop()` closes everything down. Calling `waitpid(WNOHANG)`
+    /// directly leaves the Child's pipes intact and only reaps the
+    /// zombie when the kernel has one.
+    fn tryWaitChild(self: *Self) void {
+        const child = if (self.child) |*c| c else return;
+        const pid = child.id orelse return; // already waited/killed
+        var status: c_int = 0;
+        const rc = waitpid(@intCast(pid), &status, WNOHANG);
+        if (rc <= 0) return; // 0 = still running; -1 = error (race with kill); leave for the next tick
+        // Decode wait(2) status — same shape as `<sys/wait.h>` macros
+        // (`WIFEXITED` / `WEXITSTATUS` / `WIFSIGNALED` / `WTERMSIG`).
+        // The high byte is the exit code on a normal exit; the low 7
+        // bits are the terminating signal otherwise. Keep the reason
+        // string short — the panel surfaces it inline.
+        var reason_buf: [64]u8 = undefined;
+        const reason: []const u8 = blk: {
+            if ((status & 0x7F) == 0) {
+                const code = (status >> 8) & 0xFF;
+                break :blk std.fmt.bufPrint(&reason_buf, "labelle exited (code {d})", .{code}) catch "labelle exited";
+            } else {
+                const sig = status & 0x7F;
+                break :blk std.fmt.bufPrint(&reason_buf, "labelle killed by signal {d}", .{sig}) catch "labelle killed";
+            }
+        };
+        // One final stderr drain so the panel surfaces the *last*
+        // bytes the child wrote before exiting. Without this, the
+        // tail (often the compile error in the `zig build` step) can
+        // sit in the pipe buffer past `markCrashed`'s teardown.
+        self.drainChildStderr();
+        // `waitpid` already reaped the zombie. We have to mirror
+        // `std.process.Child.wait`'s post-condition exactly so a
+        // subsequent `stop()` → `kill()` is a no-op (instead of
+        // tripping the `child.stderr == null` assertion). That means
+        // clearing `id` *and* closing all pipe fds the spawn opened.
+        // Today only `stderr` is piped (start() uses `.pipe`); the
+        // others are `.ignore`/`.inherit` so they're already `null`.
+        if (child.stderr) |f| {
+            f.close(io_global.io());
+            child.stderr = null;
+        }
+        if (child.stdout) |f| {
+            f.close(io_global.io());
+            child.stdout = null;
+        }
+        if (child.stdin) |f| {
+            f.close(io_global.io());
+            child.stdin = null;
+        }
+        child.id = null;
+        self.markCrashed(reason);
     }
 
     fn drainChildStderr(self: *Self) void {

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -989,14 +989,42 @@ pub const PreviewSession = struct {
         while (true) {
             const n = read(fd, @ptrCast(&buf[0]), buf.len);
             if (n <= 0) return;
-            // Cap to keep the buffer from runaway-growing if the
-            // subprocess spams stderr.
-            const stderr_cap: usize = 16 * 1024;
-            if (self.stderr_buf.items.len >= stderr_cap) return;
-            const room = stderr_cap - self.stderr_buf.items.len;
-            const take = @min(@as(usize, @intCast(n)), room);
-            self.stderr_buf.appendSlice(self.allocator, buf[0..take]) catch return;
+            self.appendStderrChunk(buf[0..@intCast(n)]);
         }
+    }
+
+    /// Append `chunk` to `stderr_buf`, rotating from the front when the
+    /// resulting size would exceed `stderr_cap`. Compile errors land
+    /// at the END of stderr — a non-rotating buffer would freeze the
+    /// live tail on the first 16 KiB of zig output and hide the actual
+    /// failure. `stderr_cursor` is shifted by the dropped amount so
+    /// `consumeStderr` keeps emitting only NEW bytes after a rotation
+    /// (or returns nothing extra if the consumer was entirely inside
+    /// the dropped prefix). `pub` so the tests can drive it without
+    /// a real subprocess.
+    pub fn appendStderrChunk(self: *Self, chunk: []const u8) void {
+        const stderr_cap: usize = 16 * 1024;
+        if (chunk.len == 0) return;
+        if (chunk.len >= stderr_cap) {
+            self.stderr_buf.clearRetainingCapacity();
+            const tail_off = chunk.len - stderr_cap;
+            self.stderr_buf.appendSlice(self.allocator, chunk[tail_off..]) catch return;
+            self.stderr_cursor = 0;
+            return;
+        }
+        if (self.stderr_buf.items.len + chunk.len > stderr_cap) {
+            const overflow = self.stderr_buf.items.len + chunk.len - stderr_cap;
+            const drop = @min(overflow, self.stderr_buf.items.len);
+            const remaining = self.stderr_buf.items.len - drop;
+            std.mem.copyForwards(
+                u8,
+                self.stderr_buf.items[0..remaining],
+                self.stderr_buf.items[drop..],
+            );
+            self.stderr_buf.shrinkRetainingCapacity(remaining);
+            self.stderr_cursor = if (self.stderr_cursor > drop) self.stderr_cursor - drop else 0;
+        }
+        self.stderr_buf.appendSlice(self.allocator, chunk) catch return;
     }
 
     fn markCrashed(self: *Self, reason: []const u8) void {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3617,6 +3617,69 @@ pub const PreviewLiveStderrTests = struct {
         _ = nanosleep(&ts, null);
     }
 
+    test "stderr_buf rotates when over cap so live tail keeps surfacing recent bytes" {
+        // The non-rotating version of `drainChildStderr` froze at 16
+        // KiB — once full it stopped appending, hiding the build
+        // error that lands at the END of zig's output. The rotating
+        // version drops oldest bytes from the front and adjusts the
+        // consumeStderr cursor so the live-tail consumer keeps
+        // observing fresh data.
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+
+        // Fill exactly to the cap with 'A's, drain via consumeStderr
+        // so the cursor advances to the end, then push 1024 'B's
+        // past the cap.
+        const cap: usize = 16 * 1024;
+        var filler: [1024]u8 = undefined;
+        @memset(&filler, 'A');
+        var pushed: usize = 0;
+        while (pushed < cap) {
+            sess.appendStderrChunk(&filler);
+            pushed += filler.len;
+        }
+        try expect.equal(sess.stderr_buf.items.len, cap);
+        const drained_first = sess.consumeStderr();
+        try expect.equal(drained_first.len, cap);
+        try expect.equal(sess.stderr_cursor, cap);
+
+        // Push a B-block past the cap — front should drop and the
+        // cursor should slide back so subsequent reads see ONLY the
+        // freshly-arrived bytes (not stale A's).
+        var b_block: [1024]u8 = undefined;
+        @memset(&b_block, 'B');
+        sess.appendStderrChunk(&b_block);
+        try expect.equal(sess.stderr_buf.items.len, cap);
+        // Last 1024 bytes are B's, rest are still A's.
+        try expect.toBeTrue(sess.stderr_buf.items[cap - 1] == 'B');
+        try expect.toBeTrue(sess.stderr_buf.items[0] == 'A');
+        const drained_second = sess.consumeStderr();
+        // We dropped 1024 from the front and appended 1024 — cursor
+        // had been at `cap` (i.e. fully drained), shifted to
+        // `cap - 1024`, then `appendSlice` grew the buffer to `cap`
+        // again. So fresh = exactly the 1024 newest bytes.
+        try expect.equal(drained_second.len, @as(usize, 1024));
+        try expect.toBeTrue(drained_second[0] == 'B');
+        try expect.toBeTrue(drained_second[drained_second.len - 1] == 'B');
+    }
+
+    test "a single oversized chunk keeps only the tail of the chunk" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        const cap: usize = 16 * 1024;
+        const chunk = std.testing.allocator.alloc(u8, cap + 4096) catch unreachable;
+        defer std.testing.allocator.free(chunk);
+        @memset(chunk[0..4096], 'A');
+        @memset(chunk[4096..], 'B');
+        sess.appendStderrChunk(chunk);
+        // The leading 'A's should be entirely dropped — only the
+        // tail 16 KiB of 'B's survives.
+        try expect.equal(sess.stderr_buf.items.len, cap);
+        try expect.toBeTrue(sess.stderr_buf.items[0] == 'B');
+        try expect.toBeTrue(sess.stderr_buf.items[cap - 1] == 'B');
+        try expect.equal(sess.stderr_cursor, @as(usize, 0));
+    }
+
     test "subprocess-exit early detection transitions .listening → .crashed before the 60s timeout" {
         var sess = preview.PreviewSession.init(std.testing.allocator);
         defer sess.deinit();

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3538,6 +3538,132 @@ pub const PreviewTransportTests = struct {
     }
 };
 
+pub const PreviewLiveStderrTests = struct {
+    // Covers the #127 live-tail mechanism:
+    //  - `consumeStderr` returns newly-arrived bytes once and advances
+    //    the internal cursor so a second call returns an empty slice.
+    //  - The cursor resets on `bindListener` so a fresh Run doesn't
+    //    inherit a stale cursor.
+    //
+    // Driven directly against `stderr_buf` (an exported field on the
+    // session struct) so the test stays hermetic — no real subprocess
+    // is spawned. The end-to-end `drainChildStderr` path is exercised
+    // by the subprocess-exit test below and by `zig build smoke`.
+
+    test "consumeStderr yields fresh bytes once and advances the cursor" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+
+        // Simulate two batches of stderr arriving from a hypothetical
+        // subprocess. `drainChildStderr` would do this for us in the
+        // production path; we inject directly to stay subprocess-free.
+        try sess.stderr_buf.appendSlice(std.testing.allocator, "compiling foo.zig\n");
+        const first = sess.consumeStderr();
+        try std.testing.expectEqualStrings(first, "compiling foo.zig\n");
+
+        // No new bytes arrived since the last consume — the next call
+        // returns an empty slice (panel renders nothing new this frame).
+        const empty = sess.consumeStderr();
+        try expect.equal(empty.len, @as(usize, 0));
+
+        // A second batch arrives. `consumeStderr` returns only the new
+        // bytes, not the original batch (cursor was advanced past it).
+        try sess.stderr_buf.appendSlice(std.testing.allocator, "compiling bar.zig\n");
+        const second = sess.consumeStderr();
+        try std.testing.expectEqualStrings(second, "compiling bar.zig\n");
+
+        // The full buffer is still accessible via `capturedStderr`
+        // (the crash-tail surface) so the on-crash panel still shows
+        // everything the subprocess wrote across the whole session.
+        try std.testing.expectEqualStrings(sess.capturedStderr(), "compiling foo.zig\ncompiling bar.zig\n");
+    }
+
+    test "bindListener resets the consumeStderr cursor and buffer" {
+        // Run #1 leaves a non-empty stderr_buf and a partially-consumed
+        // cursor. Run #2 (`bindListener`) must reset both — otherwise
+        // the panel would see stale bytes from the previous build.
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+        try sess.stderr_buf.appendSlice(std.testing.allocator, "stale output\n");
+        _ = sess.consumeStderr();
+        try expect.equal(sess.stderr_cursor, @as(usize, "stale output\n".len));
+
+        // Land in `.stopped` (the legal restart-from state) before the
+        // fresh `bindListener` — same path the user takes when they
+        // press Stop and then Run again.
+        sess.stop();
+        try sess.bindListener();
+        try expect.equal(sess.stderr_buf.items.len, @as(usize, 0));
+        try expect.equal(sess.stderr_cursor, @as(usize, 0));
+        const fresh = sess.consumeStderr();
+        try expect.equal(fresh.len, @as(usize, 0));
+    }
+
+    // tryWaitChild integration: a real subprocess (`/usr/bin/false`)
+    // is spawned, it exits with code 1 immediately, and `poll` is
+    // expected to land the session in `.crashed` *before* the
+    // 60-second `connecting_timeout_ms` window — the whole point of
+    // the subprocess-exit early-crash detection (#127, #136).
+    //
+    // `/usr/bin/false` is part of the POSIX base on every machine
+    // this codebase is expected to run on (macOS, Linux, CI). No
+    // network or labelle-cli needed.
+    const Timespec = extern struct { sec: isize, nsec: isize };
+    extern "c" fn nanosleep(req: *const Timespec, rem: ?*Timespec) c_int;
+    fn sleepMs(ms: u64) void {
+        const ts: Timespec = .{ .sec = @intCast(ms / 1000), .nsec = @intCast((ms % 1000) * 1_000_000) };
+        _ = nanosleep(&ts, null);
+    }
+
+    test "subprocess-exit early detection transitions .listening → .crashed before the 60s timeout" {
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+        try expect.equal(sess.state, preview.State.listening);
+
+        // Spawn a child that exits immediately with a non-zero code.
+        // The `/usr/bin/false` binary is present on macOS, Linux,
+        // and the CI image. Stderr piped so `drainChildStderr` has a
+        // valid fd to poll (the production path always pipes stderr).
+        const argv = &[_][]const u8{"/usr/bin/false"};
+        const child = std.process.spawn(io_global.io(), .{
+            .argv = argv,
+            .stdin = .ignore,
+            .stdout = .ignore,
+            .stderr = .pipe,
+        }) catch |err| {
+            // If we're on an exotic platform without /usr/bin/false,
+            // skip rather than fail — the production preview path
+            // depends on `labelle` being on PATH anyway, which is
+            // a stricter environmental assumption.
+            std.debug.print("skip: /usr/bin/false unavailable ({s})\n", .{@errorName(err)});
+            return error.SkipZigTest;
+        };
+        sess.child = child;
+
+        // Wait for the child to exit and `poll` to observe it via
+        // `waitpid(WNOHANG)`. 2 s is generous — `/usr/bin/false`
+        // exits in microseconds, and the cap is intentionally far
+        // below the 60 s `connecting_timeout_ms` backstop so the
+        // assertion proves the early-detection path (not the fallback).
+        var slept: u64 = 0;
+        while (slept < 2000) {
+            sess.poll();
+            if (sess.state == .crashed) break;
+            sleepMs(5);
+            slept += 5;
+        }
+        try expect.equal(sess.state, preview.State.crashed);
+        // The reason should reflect the exit code, not the timeout
+        // message ("engine never connected") — that's how we know
+        // the early-detection branch fired.
+        const reason = sess.bye_reason orelse "";
+        try expect.toBeTrue(std.mem.indexOf(u8, reason, "labelle exited") != null);
+    }
+};
+
 pub const IOSurfaceLayoutTests = struct {
     // The iosurface.ControlBlock layout has to match what the engine's
     // (future) iosurface producer writes into shm slot 0. Layout


### PR DESCRIPTION
## Summary

Closes #127. Partially subsumes #136 (early exit detection).

Clicking Run in the gui spawns `labelle run <project_dir>`. `std.process.spawn` itself is async, but the user perceives the gui as frozen during the CLI subprocess's cold `zig build` phase (30-60+ s for a sokol+imgui game) because the gui never drains the stderr pipe live — captured stderr was only surfaced on `.crashed`.

This PR:

1. **Live stderr tail in the Compiler Output panel.** `PreviewSession.consumeStderr()` yields newly-arrived bytes since the last call and advances an internal cursor. The Compiler Output panel calls it each frame and appends new bytes into `app.preview_tail` (capped at 16 KiB, oldest bytes drop from the front so the recent tail — where the build error lives — is what the user sees). `startPreview` force-opens the panel; the user can still × it (the latch is one-shot per Run, not per frame). The `stderr_buf` keeps growing (capped) so the existing on-`.crashed` "Launcher / engine output" surface in the Preview panel is unchanged.

2. **Subprocess-exit early detection.** New `tryWaitChild` calls libc `waitpid(WNOHANG)` from `poll()` while `.listening` or `.connecting`. If the child has already exited — build failure, panic, exec failure — the session lands in `.crashed` immediately with a `labelle exited (code N)` / `labelle killed by signal N` reason instead of waiting the full 60 s timeout. The drain mirrors `Child.wait`'s post-condition (closes the stderr pipe, nulls `id`) so a subsequent `stop()` → `kill()` is a no-op instead of tripping the `child.stderr == null` assertion. The 60 s `connecting_timeout_ms` remains as a backstop for the wedged-but-alive case.

3. **Per-Run hygiene.** `app.preview_tail` and `stderr_cursor` reset on every fresh Run (`startPreview` / `bindListener`) so old bytes don't leak into the new session.

## Non-blocking semantics

Per-frame work stays bounded:
- `drainChildStderr` already flips the stderr fd to `O_NONBLOCK` around the read loop and bails on EAGAIN — unchanged here.
- `tryWaitChild`'s `waitpid(WNOHANG)` returns 0 immediately when the child is still running, -1 + EAGAIN if there's no child yet.
- `consumeStderr` is a slice-and-cursor-bump — O(1).

Frame loop stays single-threaded. The render loop already calls `poll()` per frame.

## Tests added (`src/tests.zig` PreviewLiveStderrTests)

- `consumeStderr` yields fresh bytes once and advances the cursor; a second call with no new bytes returns an empty slice; the full buffer is still available via `capturedStderr`.
- `bindListener` resets the cursor + buffer (Run #2 doesn't inherit Run #1's tail).
- Real subprocess (`/usr/bin/false`) transitions `.listening` → `.crashed` within 2 s — well below the 60 s timeout backstop — and the `bye_reason` contains `labelle exited`, proving the early-detection branch fired (not the timeout fallback).

All 195 tests pass (192 original + 3 new).

## TE-test gaps

The TE harness in `gui_tests.zig` doesn't yet cover the Compiler Output panel's preview-tail rendering — that's gated on a live preview session, which the TE binary doesn't spawn today (TE tests use `bindListener` + an in-test loopback dial). The new unit tests cover the seam; a TE-side smoke test could land in a follow-up alongside other panel-rendering coverage.

## Test plan

- [x] `zig build test` — all 195 unit tests pass
- [x] `zig build` — main exe links
- [x] `zig build gui-test-build` — TE binary links
- [ ] Manual smoke: open a real project, press Run, observe Compiler Output panel populating with `labelle` / `zig build` output during the wait window
- [ ] Manual smoke: cause a build failure (syntax error in a scene script), confirm panel surfaces the error and session lands in `.crashed` with `labelle exited (code N)` instead of waiting 60 s