### PR TITLE
feat(inspector): drag-to-resize splitter between viewport and inspector (#140)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -707,6 +707,19 @@ pub const App = struct {
         self.status_timer = config.ui.status_message_duration;
     }
 
+    /// Sync a new inspector-splitter width back to `self.prefs` and
+    /// persist. Called by the scene + prefab editors on drag-release
+    /// so the splitter widget itself can stay prefs-free. The equality
+    /// guard avoids churning the file when a click ends without an
+    /// actual drag.
+    pub fn saveInspectorWidth(self: *Self, width: f32) void {
+        if (self.prefs.inspector_width == width) return;
+        self.prefs.inspector_width = width;
+        prefs_mod.save(self.allocator, self.prefs) catch |err| {
+            std.log.warn("prefs: could not persist inspector_width: {s}", .{@errorName(err)});
+        };
+    }
+
     /// One UI frame. `dt_seconds` is the wall-clock time since the last
     /// frame, used to decrement transient timers (status messages, etc.)
     /// so they last a consistent duration regardless of frame rate.

--- a/src/app.zig
+++ b/src/app.zig
@@ -546,6 +546,10 @@ pub const App = struct {
 
         var state = try scene_mod.SceneState.open(self.allocator, path);
         errdefer state.deinit(self.allocator);
+        // Seed inspector width from prefs so the user's preferred
+        // split carries across sessions (#140). In-tab drags update
+        // both this field and prefs.
+        state.inspector_width = self.prefs.inspector_width;
         try self.open_tabs.append(self.allocator, .{ .scene = state });
         const new_idx = self.open_tabs.items.len - 1;
         self.active_tab_idx = new_idx;
@@ -562,6 +566,7 @@ pub const App = struct {
 
         var state = try prefab_mod.PrefabState.open(self.allocator, path);
         errdefer state.deinit(self.allocator);
+        state.inspector_width = self.prefs.inspector_width;
         try self.open_tabs.append(self.allocator, .{ .prefab = state });
         const new_idx = self.open_tabs.items.len - 1;
         self.active_tab_idx = new_idx;

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -116,7 +116,7 @@ pub fn render(s: *PrefabState, app: *App) void {
     // Two-column body, same shape as the scene editor.
     const total_w = zgui.getContentRegionAvail()[0];
     const sameline_gap = zgui.getStyle().item_spacing[0];
-    const viewport_w = @max(splitter.min_viewport_width, total_w - s.inspector_width - splitter.handle_w - 2 * sameline_gap);
+    const viewport_w = splitter.viewportWidth(total_w, s.inspector_width, sameline_gap);
 
     const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
     const gizmo_index_ptr: ?*const @import("../gizmos.zig").Index = if (app.gizmo_index) |*ix| ix else null;
@@ -144,7 +144,7 @@ pub fn render(s: *PrefabState, app: *App) void {
     }
     zgui.endChild();
     zgui.sameLine(.{});
-    splitter.render(&s.inspector_width, total_w, app);
+    if (splitter.render(&s.inspector_width, total_w)) app.saveInspectorWidth(s.inspector_width);
     zgui.sameLine(.{});
     if (zgui.beginChild("##prefab_inspector_col", .{
         .w = s.inspector_width,

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -22,8 +22,7 @@ const scene_io = @import("../scene_io.zig");
 const inspector = @import("inspector.zig");
 const viewport = @import("viewport.zig");
 
-const inspector_w: f32 = 300;
-const split_gap: f32 = 8;
+const splitter = @import("splitter.zig");
 
 pub const PrefabState = struct {
     arena: *std.heap.ArenaAllocator,
@@ -49,6 +48,10 @@ pub const PrefabState = struct {
     grid_step: f32 = 16,
     /// When true, child drag-to-move snaps to the grid above.
     snap_enabled: bool = false,
+    /// Inspector column width in pixels. Same shape as `SceneState`:
+    /// seeded from `app.prefs.inspector_width` on open, updated by
+    /// the splitter handler, written back to prefs on drag-release (#140).
+    inspector_width: f32 = @import("../prefs.zig").default_inspector_width,
 
     pub fn open(allocator: std.mem.Allocator, path: []const u8) !PrefabState {
         const arena = try allocator.create(std.heap.ArenaAllocator);
@@ -112,7 +115,8 @@ pub fn render(s: *PrefabState, app: *App) void {
 
     // Two-column body, same shape as the scene editor.
     const total_w = zgui.getContentRegionAvail()[0];
-    const viewport_w = @max(120.0, total_w - inspector_w - split_gap);
+    const sameline_gap = zgui.getStyle().item_spacing[0];
+    const viewport_w = @max(splitter.min_viewport_width, total_w - s.inspector_width - splitter.handle_w - 2 * sameline_gap);
 
     const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
     const gizmo_index_ptr: ?*const @import("../gizmos.zig").Index = if (app.gizmo_index) |*ix| ix else null;
@@ -140,8 +144,10 @@ pub fn render(s: *PrefabState, app: *App) void {
     }
     zgui.endChild();
     zgui.sameLine(.{});
+    splitter.render(&s.inspector_width, total_w, app);
+    zgui.sameLine(.{});
     if (zgui.beginChild("##prefab_inspector_col", .{
-        .w = 0,
+        .w = s.inspector_width,
         .h = 0,
         .child_flags = .{ .border = true },
     })) {

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -108,6 +108,13 @@ pub const SceneState = struct {
     /// When true, drag-to-move snaps to the grid above. Off by default
     /// so existing behavior is preserved.
     snap_enabled: bool = false,
+    /// Inspector column width in pixels. Per-tab so dragging the
+    /// splitter on one scene doesn't reflow others. Seeded from
+    /// `app.prefs.inspector_width` at open time; updated by the
+    /// splitter drag handler in `render`; written back to prefs on
+    /// drag-release so the chosen width persists across editor
+    /// restarts (#140).
+    inspector_width: f32 = @import("../prefs.zig").default_inspector_width,
 
     /// Load a scene from disk and wrap it in a fresh SceneState. The
     /// returned state owns an arena holding the path + display name,
@@ -140,8 +147,7 @@ pub const SceneState = struct {
 
 /// Returns the file basename with its `.jsonc` extension stripped.
 /// `path` must outlive the returned slice (we just slice into it).
-const inspector_w: f32 = 300;
-const split_gap: f32 = 8;
+const splitter = @import("splitter.zig");
 
 /// Render a single open scene as the content of a tab. Caller has
 /// already entered the tab item; we just paint the body. Layout is
@@ -197,9 +203,14 @@ pub fn render(s: *SceneState, app: *App) void {
     if (zgui.button("Save", .{})) saveScene(s, app);
     zgui.separator();
 
-    // Two-column body: viewport on the left, inspector on the right.
+    // Two-column body: viewport on the left, inspector on the right,
+    // splitter handle in the middle. The viewport eats the remainder
+    // after the inspector + handle + the two `sameLine` gaps take
+    // their share — clamped so shrinking the window doesn't squash
+    // it to nothing.
     const total_w = zgui.getContentRegionAvail()[0];
-    const viewport_w = @max(120.0, total_w - inspector_w - split_gap);
+    const sameline_gap = zgui.getStyle().item_spacing[0];
+    const viewport_w = @max(splitter.min_viewport_width, total_w - s.inspector_width - splitter.handle_w - 2 * sameline_gap);
 
     const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
     const gizmo_index_ptr: ?*const @import("../gizmos.zig").Index = if (app.gizmo_index) |*ix| ix else null;
@@ -212,8 +223,10 @@ pub fn render(s: *SceneState, app: *App) void {
     }
     zgui.endChild();
     zgui.sameLine(.{});
+    splitter.render(&s.inspector_width, total_w, app);
+    zgui.sameLine(.{});
     if (zgui.beginChild("##inspector_col", .{
-        .w = 0,
+        .w = s.inspector_width,
         .h = 0,
         .child_flags = .{ .border = true },
     })) {

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -145,8 +145,6 @@ pub const SceneState = struct {
     }
 };
 
-/// Returns the file basename with its `.jsonc` extension stripped.
-/// `path` must outlive the returned slice (we just slice into it).
 const splitter = @import("splitter.zig");
 
 /// Render a single open scene as the content of a tab. Caller has
@@ -210,7 +208,7 @@ pub fn render(s: *SceneState, app: *App) void {
     // it to nothing.
     const total_w = zgui.getContentRegionAvail()[0];
     const sameline_gap = zgui.getStyle().item_spacing[0];
-    const viewport_w = @max(splitter.min_viewport_width, total_w - s.inspector_width - splitter.handle_w - 2 * sameline_gap);
+    const viewport_w = splitter.viewportWidth(total_w, s.inspector_width, sameline_gap);
 
     const atlas_index_ptr: ?*const @import("../atlas.zig").Index = if (app.atlas_index) |*ix| ix else null;
     const gizmo_index_ptr: ?*const @import("../gizmos.zig").Index = if (app.gizmo_index) |*ix| ix else null;
@@ -223,7 +221,7 @@ pub fn render(s: *SceneState, app: *App) void {
     }
     zgui.endChild();
     zgui.sameLine(.{});
-    splitter.render(&s.inspector_width, total_w, app);
+    if (splitter.render(&s.inspector_width, total_w)) app.saveInspectorWidth(s.inspector_width);
     zgui.sameLine(.{});
     if (zgui.beginChild("##inspector_col", .{
         .w = s.inspector_width,

--- a/src/modules/splitter.zig
+++ b/src/modules/splitter.zig
@@ -4,27 +4,30 @@
 //! Rendered as a thin invisible button sitting in the `split_gap`
 //! between the two `beginChild` calls. When the user drags it with
 //! the left mouse button, the inspector width grows or shrinks; the
-//! viewport eats the remainder. On drag-release, the new width is
-//! persisted to prefs so it sticks across editor restarts.
+//! viewport eats the remainder. `render` returns `true` on the frame
+//! the drag releases — the caller persists the new width to prefs at
+//! its own discretion, keeping prefs I/O out of this widget.
 //!
 //! Caller layout shape:
 //!
+//!     const viewport_w = splitter.viewportWidth(total_w, state.inspector_width, sameline_gap);
 //!     beginChild "##viewport_col"  width = viewport_w
 //!     endChild
 //!     sameLine()
-//!     splitter.render(&state.inspector_width, total_w, app)   ← here
+//!     const released = splitter.render(&state.inspector_width, total_w);   ← here
 //!     sameLine()
 //!     beginChild "##inspector_col" width = state.inspector_width
 //!     endChild
+//!     if (released) save_prefs(...);
 //!
 //! Two clamps cooperate to keep both panes usable:
 //!
 //!  - Inspector width never drops below `prefs.min_inspector_width`
 //!    (and never exceeds `prefs.max_inspector_width`).
 //!  - Viewport width is then clamped to `min_viewport_width` by the
-//!    caller's existing `@max(min_viewport_width, total_w - inspector_w - gap)`
-//!    formula — if the window shrinks below the sum, the inspector
-//!    visually loses pixels rather than the viewport disappearing.
+//!    `viewportWidth` helper — if the window shrinks below the sum,
+//!    the inspector visually loses pixels rather than the viewport
+//!    disappearing.
 //!
 //! The clamp math itself lives in `clampInspectorWidth` so it's
 //! testable without an imgui draw context (see `tests.zig`).
@@ -33,7 +36,6 @@ const std = @import("std");
 const zgui = @import("zgui");
 
 const prefs_mod = @import("../prefs.zig");
-const App = @import("../app.zig").App;
 
 /// Horizontal pixels for the splitter handle. Wide enough to grab
 /// comfortably; narrow enough not to dominate the gap. The visual
@@ -46,6 +48,21 @@ pub const handle_w: f32 = 6;
 /// it here to decide how much the user can shrink the inspector
 /// without squashing the viewport beyond reason.
 pub const min_viewport_width: f32 = 120;
+
+/// Width to hand to `beginChild "##viewport_col"`. Both editors
+/// share this formula; centralizing it here means a layout tweak
+/// (extra `sameLine`, padding shift) lands in one place instead of
+/// drifting across call sites.
+pub fn viewportWidth(total_w: f32, inspector_width: f32, sameline_gap: f32) f32 {
+    return @max(min_viewport_width, total_w - inspector_width - handle_w - 2 * sameline_gap);
+}
+
+// zgui packs colors as ABGR: IM_COL32(R,G,B,A) = (A<<24) | (B<<16) | (G<<8) | R,
+// i.e. `0xAA_BB_GG_RR`. The splitter only ever paints white-with-alpha, so a
+// tiny helper keeps the literal alpha-byte readable at the call sites.
+fn whiteWithAlpha(alpha: u8) u32 {
+    return (@as(u32, alpha) << 24) | 0x00_ff_ff_ff;
+}
 
 /// Clamp a requested inspector width to the bounds the splitter
 /// enforces every frame. Pulled out of `render` so the clamp math
@@ -83,8 +100,9 @@ pub fn clampInspectorWidth(value: f32, available_w: f32, sameline_gap: f32) f32 
 }
 
 /// Render the splitter handle and apply drag deltas to
-/// `inspector_width.*`. On mouse-release after a drag, syncs the
-/// chosen width to `app.prefs` and persists it.
+/// `inspector_width.*`. Returns `true` on the frame the drag
+/// releases so the caller can persist the new width — the splitter
+/// itself never touches prefs or the filesystem.
 ///
 /// `available_w` is the total row width the two columns + handle
 /// share (typically the parent's `getContentRegionAvail()[0]`
@@ -96,9 +114,8 @@ pub fn clampInspectorWidth(value: f32, available_w: f32, sameline_gap: f32) f32 
 ///
 /// The caller is responsible for placing the handle on the right
 /// line via `sameLine()` (see the doc comment above for the layout
-/// shape). Returns nothing — width mutations are written through
-/// the pointer.
-pub fn render(inspector_width: *f32, available_w: f32, app: *App) void {
+/// shape).
+pub fn render(inspector_width: *f32, available_w: f32) bool {
     // Match the viewport/inspector children's height so the handle
     // spans the full split. Heights of 0 in beginChild mean "fill
     // remaining," and the children here use that — so the handle
@@ -122,7 +139,7 @@ pub fn render(inspector_width: *f32, available_w: f32, app: *App) void {
     const min = zgui.getItemRectMin();
     const max = zgui.getItemRectMax();
     if (hovered or active) {
-        const col: u32 = if (active) 0xff_ff_ff_ff else 0xa0_ff_ff_ff;
+        const col: u32 = if (active) whiteWithAlpha(0xff) else whiteWithAlpha(0xa0);
         dl.addRectFilled(.{ .pmin = min, .pmax = max, .col = col });
         zgui.setMouseCursor(.resize_ew);
     } else {
@@ -132,14 +149,13 @@ pub fn render(inspector_width: *f32, available_w: f32, app: *App) void {
         dl.addRectFilled(.{
             .pmin = .{ cx - 0.5, min[1] },
             .pmax = .{ cx + 0.5, max[1] },
-            .col = 0x40_ff_ff_ff,
+            .col = whiteWithAlpha(0x40),
         });
     }
 
     // Single source of truth for the clamp bounds this frame. Drag
     // handler and reactive resize handler both read from this — if
-    // the math changes, both paths see the change at once (gemini /
-    // PR review #142 catch).
+    // the math changes, both paths see the change at once.
     const sameline_gap = zgui.getStyle().item_spacing[0];
 
     // Drag handling: accumulate the per-frame X delta into the
@@ -158,17 +174,9 @@ pub fn render(inspector_width: *f32, available_w: f32, app: *App) void {
     // the inspector would only update on the next drag.
     inspector_width.* = clampInspectorWidth(inspector_width.*, available_w, sameline_gap);
 
-    // Persist on release. We compare against the prefs value so a
-    // hover-without-drag doesn't churn the file. The drag-released
-    // signal is the frame after isItemActive flips back to false
-    // while we still hold the button — but isItemDeactivated covers
-    // exactly that.
-    if (zgui.isItemDeactivated()) {
-        if (app.prefs.inspector_width != inspector_width.*) {
-            app.prefs.inspector_width = inspector_width.*;
-            prefs_mod.save(app.allocator, app.prefs) catch |err| {
-                std.log.warn("prefs: could not persist inspector_width: {s}", .{@errorName(err)});
-            };
-        }
-    }
+    // Drag-released signal: the frame after `isItemActive` flips back
+    // to false while the user still holds the button. The caller
+    // owns the persistence decision (e.g. compare against prefs and
+    // skip a no-op write).
+    return zgui.isItemDeactivated();
 }

--- a/src/modules/splitter.zig
+++ b/src/modules/splitter.zig
@@ -12,7 +12,7 @@
 //!     beginChild "##viewport_col"  width = viewport_w
 //!     endChild
 //!     sameLine()
-//!     splitter.render(&state.inspector_width, &app.prefs.inspector_width, app)   ← here
+//!     splitter.render(&state.inspector_width, total_w, app)   ← here
 //!     sameLine()
 //!     beginChild "##inspector_col" width = state.inspector_width
 //!     endChild
@@ -25,6 +25,9 @@
 //!    caller's existing `@max(min_viewport_width, total_w - inspector_w - gap)`
 //!    formula — if the window shrinks below the sum, the inspector
 //!    visually loses pixels rather than the viewport disappearing.
+//!
+//! The clamp math itself lives in `clampInspectorWidth` so it's
+//! testable without an imgui draw context (see `tests.zig`).
 
 const std = @import("std");
 const zgui = @import("zgui");
@@ -43,6 +46,41 @@ pub const handle_w: f32 = 6;
 /// it here to decide how much the user can shrink the inspector
 /// without squashing the viewport beyond reason.
 pub const min_viewport_width: f32 = 120;
+
+/// Clamp a requested inspector width to the bounds the splitter
+/// enforces every frame. Pulled out of `render` so the clamp math
+/// can be unit-tested without an imgui draw context (see
+/// `SplitterClampTests` in `tests.zig`).
+///
+/// The clamp is bounded by three numbers:
+///
+///   - `prefs_mod.min_inspector_width` — hard floor; the inspector
+///     never gets thinner than this so its widgets stay usable.
+///   - `prefs_mod.max_inspector_width` — hard static ceiling so a
+///     hand-edited prefs file with a wild value can't fill the
+///     screen with inspector chrome.
+///   - `available_w - min_viewport_width - handle_w - 2*sameline_gap`
+///     — dynamic ceiling that adapts to the current window width.
+///     When the editor shrinks, this reins the inspector back in on
+///     the same frame.
+///
+/// The dynamic ceiling AND the static ceiling are combined via
+/// `@min`, so whichever is tighter wins. The floor is enforced by
+/// `@max` against the dynamic upper so we never produce a value
+/// below the minimum even when the window is very small.
+pub fn clampInspectorWidth(value: f32, available_w: f32, sameline_gap: f32) f32 {
+    const dynamic_upper = available_w - min_viewport_width - handle_w - 2 * sameline_gap;
+    // `@max` against the floor keeps the upper bound from collapsing
+    // below the minimum when the window has no room for an inspector
+    // at all — better to render a tiny inspector and let the viewport
+    // get squashed than to flip the clamp range upside-down.
+    const upper = @max(prefs_mod.min_inspector_width, dynamic_upper);
+    return std.math.clamp(
+        value,
+        prefs_mod.min_inspector_width,
+        @min(prefs_mod.max_inspector_width, upper),
+    );
+}
 
 /// Render the splitter handle and apply drag deltas to
 /// `inspector_width.*`. On mouse-release after a drag, syncs the
@@ -98,41 +136,27 @@ pub fn render(inspector_width: *f32, available_w: f32, app: *App) void {
         });
     }
 
+    // Single source of truth for the clamp bounds this frame. Drag
+    // handler and reactive resize handler both read from this — if
+    // the math changes, both paths see the change at once (gemini /
+    // PR review #142 catch).
+    const sameline_gap = zgui.getStyle().item_spacing[0];
+
     // Drag handling: accumulate the per-frame X delta into the
     // stored width. `getMouseDragDelta` returns *cumulative* delta
     // since the press, so we reset after each consumption to avoid
-    // double-applying.
-    //
-    // Upper clamp is dynamic: never let the inspector grow past what
-    // the current row can fit while still leaving `min_viewport_width`
-    // for the other column. This keeps the splitter from dragging the
-    // inspector "out of the window" when the user shrinks the editor.
+    // double-applying. Inspector lives on the right of the splitter —
+    // a leftward drag (negative dx) widens it; rightward narrows it.
     if (active and zgui.isMouseDragging(.left, 0)) {
         const d = zgui.getMouseDragDelta(.left, .{});
-        // Inspector lives on the right of the splitter — a leftward
-        // drag (negative dx) widens it; rightward narrows it.
-        const sameline_gap = zgui.getStyle().item_spacing[0];
-        const upper = @max(prefs_mod.min_inspector_width, available_w - min_viewport_width - handle_w - 2 * sameline_gap);
-        inspector_width.* = std.math.clamp(
-            inspector_width.* - d[0],
-            prefs_mod.min_inspector_width,
-            @min(prefs_mod.max_inspector_width, upper),
-        );
+        inspector_width.* = clampInspectorWidth(inspector_width.* - d[0], available_w, sameline_gap);
         zgui.resetMouseDragDelta(.left);
     }
 
-    // Also re-clamp every frame so a window-shrink event correctly
-    // reins in an inspector that's now too wide for the row. Without
-    // this, the inspector would only update on the next drag.
-    {
-        const sameline_gap = zgui.getStyle().item_spacing[0];
-        const upper = @max(prefs_mod.min_inspector_width, available_w - min_viewport_width - handle_w - 2 * sameline_gap);
-        inspector_width.* = std.math.clamp(
-            inspector_width.*,
-            prefs_mod.min_inspector_width,
-            @min(prefs_mod.max_inspector_width, upper),
-        );
-    }
+    // Re-clamp every frame so a window-shrink event correctly reins
+    // in an inspector that's now too wide for the row. Without this,
+    // the inspector would only update on the next drag.
+    inspector_width.* = clampInspectorWidth(inspector_width.*, available_w, sameline_gap);
 
     // Persist on release. We compare against the prefs value so a
     // hover-without-drag doesn't churn the file. The drag-released

--- a/src/modules/splitter.zig
+++ b/src/modules/splitter.zig
@@ -1,0 +1,150 @@
+//! Vertical splitter between the viewport column and the inspector
+//! column in the scene + prefab editors (#140).
+//!
+//! Rendered as a thin invisible button sitting in the `split_gap`
+//! between the two `beginChild` calls. When the user drags it with
+//! the left mouse button, the inspector width grows or shrinks; the
+//! viewport eats the remainder. On drag-release, the new width is
+//! persisted to prefs so it sticks across editor restarts.
+//!
+//! Caller layout shape:
+//!
+//!     beginChild "##viewport_col"  width = viewport_w
+//!     endChild
+//!     sameLine()
+//!     splitter.render(&state.inspector_width, &app.prefs.inspector_width, app)   ← here
+//!     sameLine()
+//!     beginChild "##inspector_col" width = state.inspector_width
+//!     endChild
+//!
+//! Two clamps cooperate to keep both panes usable:
+//!
+//!  - Inspector width never drops below `prefs.min_inspector_width`
+//!    (and never exceeds `prefs.max_inspector_width`).
+//!  - Viewport width is then clamped to `min_viewport_width` by the
+//!    caller's existing `@max(min_viewport_width, total_w - inspector_w - gap)`
+//!    formula — if the window shrinks below the sum, the inspector
+//!    visually loses pixels rather than the viewport disappearing.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const prefs_mod = @import("../prefs.zig");
+const App = @import("../app.zig").App;
+
+/// Horizontal pixels for the splitter handle. Wide enough to grab
+/// comfortably; narrow enough not to dominate the gap. The visual
+/// handle is drawn inside this strip; the click target is the full
+/// width.
+pub const handle_w: f32 = 6;
+
+/// Minimum viewport width on the *other* side of the splitter. The
+/// caller's `viewport_w` formula already enforces this; we only use
+/// it here to decide how much the user can shrink the inspector
+/// without squashing the viewport beyond reason.
+pub const min_viewport_width: f32 = 120;
+
+/// Render the splitter handle and apply drag deltas to
+/// `inspector_width.*`. On mouse-release after a drag, syncs the
+/// chosen width to `app.prefs` and persists it.
+///
+/// `available_w` is the total row width the two columns + handle
+/// share (typically the parent's `getContentRegionAvail()[0]`
+/// captured before the viewport child is rendered). The splitter
+/// uses it to enforce a dynamic upper bound so the inspector can't
+/// be dragged past what the current window can hold — when the
+/// editor window shrinks, this also reins in a too-wide inspector
+/// on the same frame.
+///
+/// The caller is responsible for placing the handle on the right
+/// line via `sameLine()` (see the doc comment above for the layout
+/// shape). Returns nothing — width mutations are written through
+/// the pointer.
+pub fn render(inspector_width: *f32, available_w: f32, app: *App) void {
+    // Match the viewport/inspector children's height so the handle
+    // spans the full split. Heights of 0 in beginChild mean "fill
+    // remaining," and the children here use that — so the handle
+    // does the same via getContentRegionAvail.
+    const h = zgui.getContentRegionAvail()[1];
+    _ = zgui.invisibleButton("##inspector_splitter", .{
+        .w = handle_w,
+        .h = h,
+        .flags = .{ .mouse_button_left = true },
+    });
+
+    // Visual cue: always render a thin idle line down the middle of
+    // the handle strip so the user can see where the resize lives —
+    // matches the ImGui-native window-resize affordance the project
+    // tree side uses. On hover/active, fill the whole strip + swap
+    // the cursor to a horizontal-resize arrow so it's obvious it's
+    // grabbable.
+    const hovered = zgui.isItemHovered(.{});
+    const active = zgui.isItemActive();
+    const dl = zgui.getWindowDrawList();
+    const min = zgui.getItemRectMin();
+    const max = zgui.getItemRectMax();
+    if (hovered or active) {
+        const col: u32 = if (active) 0xff_ff_ff_ff else 0xa0_ff_ff_ff;
+        dl.addRectFilled(.{ .pmin = min, .pmax = max, .col = col });
+        zgui.setMouseCursor(.resize_ew);
+    } else {
+        // Idle: 1px vertical line centered in the strip. Subtle so it
+        // doesn't compete with content, but always there.
+        const cx = (min[0] + max[0]) * 0.5;
+        dl.addRectFilled(.{
+            .pmin = .{ cx - 0.5, min[1] },
+            .pmax = .{ cx + 0.5, max[1] },
+            .col = 0x40_ff_ff_ff,
+        });
+    }
+
+    // Drag handling: accumulate the per-frame X delta into the
+    // stored width. `getMouseDragDelta` returns *cumulative* delta
+    // since the press, so we reset after each consumption to avoid
+    // double-applying.
+    //
+    // Upper clamp is dynamic: never let the inspector grow past what
+    // the current row can fit while still leaving `min_viewport_width`
+    // for the other column. This keeps the splitter from dragging the
+    // inspector "out of the window" when the user shrinks the editor.
+    if (active and zgui.isMouseDragging(.left, 0)) {
+        const d = zgui.getMouseDragDelta(.left, .{});
+        // Inspector lives on the right of the splitter — a leftward
+        // drag (negative dx) widens it; rightward narrows it.
+        const sameline_gap = zgui.getStyle().item_spacing[0];
+        const upper = @max(prefs_mod.min_inspector_width, available_w - min_viewport_width - handle_w - 2 * sameline_gap);
+        inspector_width.* = std.math.clamp(
+            inspector_width.* - d[0],
+            prefs_mod.min_inspector_width,
+            @min(prefs_mod.max_inspector_width, upper),
+        );
+        zgui.resetMouseDragDelta(.left);
+    }
+
+    // Also re-clamp every frame so a window-shrink event correctly
+    // reins in an inspector that's now too wide for the row. Without
+    // this, the inspector would only update on the next drag.
+    {
+        const sameline_gap = zgui.getStyle().item_spacing[0];
+        const upper = @max(prefs_mod.min_inspector_width, available_w - min_viewport_width - handle_w - 2 * sameline_gap);
+        inspector_width.* = std.math.clamp(
+            inspector_width.*,
+            prefs_mod.min_inspector_width,
+            @min(prefs_mod.max_inspector_width, upper),
+        );
+    }
+
+    // Persist on release. We compare against the prefs value so a
+    // hover-without-drag doesn't churn the file. The drag-released
+    // signal is the frame after isItemActive flips back to false
+    // while we still hold the button — but isItemDeactivated covers
+    // exactly that.
+    if (zgui.isItemDeactivated()) {
+        if (app.prefs.inspector_width != inspector_width.*) {
+            app.prefs.inspector_width = inspector_width.*;
+            prefs_mod.save(app.allocator, app.prefs) catch |err| {
+                std.log.warn("prefs: could not persist inspector_width: {s}", .{@errorName(err)});
+            };
+        }
+    }
+}

--- a/src/prefs.zig
+++ b/src/prefs.zig
@@ -35,11 +35,29 @@ pub const max_font_scale: f32 = 3.0;
 /// monitors.
 pub const default_font_scale: f32 = 1.5;
 
+/// Bounds for the editor inspector-column width. The lower bound keeps
+/// the inspector usable (input fields stay readable); the upper bound
+/// stops a malformed file from hiding the viewport entirely. Per-tab
+/// clamping in the splitter handler also enforces a viewport-side
+/// minimum so the two never fight.
+pub const min_inspector_width: f32 = 200;
+pub const max_inspector_width: f32 = 800;
+/// Default applied on first launch and to fresh tabs when no
+/// user-chosen width has been saved yet. Matches the previous
+/// hardcoded value so the visual remains unchanged on first open.
+pub const default_inspector_width: f32 = 300;
+
 pub const Preferences = struct {
     /// Multiplier applied on top of the DPI-derived font size at
     /// startup. Larger values produce bigger text. The ImGui atlas is
     /// sized at startup so a change requires a restart to take effect.
     font_scale: f32 = default_font_scale,
+    /// Width in pixels of the inspector column in the scene / prefab
+    /// editor tabs. Updated when the user drags the splitter; new
+    /// tabs read this on open so the chosen width persists across
+    /// editor restarts (#140). Each open tab keeps its own copy so
+    /// in-session drags don't reflow other tabs.
+    inspector_width: f32 = default_inspector_width,
 };
 
 /// Replacement for `std.fs.getAppDataDir` which was removed in 0.16.
@@ -129,6 +147,7 @@ pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) Preferences 
 
     return .{
         .font_scale = std.math.clamp(parsed.font_scale, min_font_scale, max_font_scale),
+        .inspector_width = std.math.clamp(parsed.inspector_width, min_inspector_width, max_inspector_width),
     };
 }
 
@@ -160,18 +179,20 @@ pub fn save(allocator: std.mem.Allocator, prefs: Preferences) !void {
 pub fn saveToPath(allocator: std.mem.Allocator, path: []const u8, prefs: Preferences) !void {
     const clamped: Preferences = .{
         .font_scale = std.math.clamp(prefs.font_scale, min_font_scale, max_font_scale),
+        .inspector_width = std.math.clamp(prefs.inspector_width, min_inspector_width, max_inspector_width),
     };
 
     // Hand-rolled emission keeps the file readable and avoids pulling in
-    // `std.zon.stringify`'s broader formatting choices. We only have one
-    // field and the format is dirt-simple.
+    // `std.zon.stringify`'s broader formatting choices. Tiny fixed
+    // schema; grows by hand if a new field lands.
     var buf: [256]u8 = undefined;
     const body = try std.fmt.bufPrint(&buf,
         \\.{{
         \\    .font_scale = {d},
+        \\    .inspector_width = {d},
         \\}}
         \\
-    , .{clamped.font_scale});
+    , .{ clamped.font_scale, clamped.inspector_width });
 
     const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
     defer allocator.free(tmp_path);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -21,6 +21,7 @@ const prefab_contents = @import("modules/inspector/prefab_contents.zig");
 const io_global = @import("io_global.zig");
 const game_view = @import("game_view.zig");
 const test_fixtures = @import("test_fixtures.zig");
+const splitter = @import("modules/splitter.zig");
 
 /// Wall-clock seconds since the Unix epoch; replacement for the
 /// `std.time.timestamp` helper removed in Zig 0.16. Used only to
@@ -4126,5 +4127,54 @@ pub const GameViewLatencyTests = struct {
         // Slots [1..120) are zero-initialized; only slot 0 counts.
         gv.latency_count = 1;
         try expect.equal(gv.meanLatencyNs(), @as(u64, 5_000_000));
+    }
+};
+
+pub const SplitterClampTests = struct {
+    // The splitter's clamp math is pure (no imgui draw context),
+    // so we exercise it directly. Three bounds cooperate — static
+    // ceiling (`prefs.max_inspector_width`), dynamic ceiling derived
+    // from window width, static floor (`prefs.min_inspector_width`).
+    // Each test pins one bound in the driver's seat. Spacing of 8
+    // matches ImGui's default `item_spacing.x` so the dynamic_upper
+    // computation in `clampInspectorWidth` matches real frames.
+    const default_gap: f32 = 8;
+
+    test "typical case passes through unchanged" {
+        // Plenty of room on a 1600px row → requested 400 is well within
+        // both static and dynamic ceilings. Returned verbatim.
+        const result = splitter.clampInspectorWidth(400, 1600, default_gap);
+        try expect.equal(result, @as(f32, 400));
+    }
+
+    test "shrunk window: dynamic ceiling clamps before the static max" {
+        // 600px row, requested 700. The dynamic ceiling is
+        // 600 - min_viewport_width(120) - handle_w(6) - 2*8 = 458.
+        // 700 → clamped to 458, well below the static 800 ceiling.
+        const result = splitter.clampInspectorWidth(700, 600, default_gap);
+        try expect.equal(result, @as(f32, 458));
+    }
+
+    test "huge window: static max_inspector_width wins" {
+        // 4000px row, requested 1500. Dynamic ceiling allows ~3858,
+        // but the static max (800) wins as the tighter cap.
+        const result = splitter.clampInspectorWidth(1500, 4000, default_gap);
+        try expect.equal(result, @as(f32, prefs.max_inspector_width));
+    }
+
+    test "below minimum clamps to the floor" {
+        // Requested 50 (way under the floor). Returned 200, the static
+        // minimum, regardless of how much room the row has.
+        const result = splitter.clampInspectorWidth(50, 1600, default_gap);
+        try expect.equal(result, @as(f32, prefs.min_inspector_width));
+    }
+
+    test "extremely narrow window keeps floor stable" {
+        // 100px row — narrower than `min_viewport_width + handle_w`.
+        // Dynamic ceiling would go negative; the @max-with-floor in
+        // `clampInspectorWidth` keeps the bound at min_inspector_width
+        // so the clamp range stays consistent. Result: the floor.
+        const result = splitter.clampInspectorWidth(500, 100, default_gap);
+        try expect.equal(result, @as(f32, prefs.min_inspector_width));
     }
 };


### PR DESCRIPTION
## Summary

Closes #140. Replaces the hardcoded `inspector_w: f32 = 300` in `scene.zig` and `prefab.zig` with a per-tab `inspector_width` driven by a new shared splitter widget. Per-tab width is seeded from `prefs.inspector_width` on tab open, updated live as the user drags, and persisted to prefs on drag-release so the chosen width carries across editor restarts.

### Changes

- **`src/modules/splitter.zig`** (new) — vertical handle between viewport and inspector `beginChild` calls. Idle: faint 1px line so the affordance is discoverable. Hover/active: brighter fill + cursor swaps to `resize_ew`, matching the visual language of the project tree's native resize edge.
- **Dynamic clamp** — every frame, width is clamped to fit `available_w - min_viewport_width - handle_w - 2*item_spacing`. Shrinking the editor window pulls a too-wide inspector back into bounds on the same frame.
- **`src/prefs.zig`** — new `inspector_width` field (default 300, clamped 200..800). Schema grows by one line; older files tolerated by the existing `ignore_unknown_fields` path.
- **`src/app.zig`** — `openScene` / `openPrefab` seed `state.inspector_width` from prefs.
- **Persistence** — splitter writes back on `isItemDeactivated` and calls `prefs_mod.save`. I/O failures log, don't crash.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — 200/200
- [x] Visual against `flying-platform-labelle/scenes/main.jsonc`:
  - Handle visible idle, brightens on hover, cursor swaps to ↔
  - Drag widens / narrows the inspector live
  - Shrinking the editor window reins the inspector back inside on the same frame
  - Width persists across editor relaunches
  - Same behavior in the prefab editor tab

## Out of scope

- Horizontal splitter (above/below the viewport).
- Per-project default override (could ride on `project.labelle` later).
- Min/max overrides in the Preferences dialog.