### PR TITLE
fix(preview): one Game View surface on attach (#145)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -421,16 +421,20 @@ pub const App = struct {
     /// zero-copy path. Anything else falls back to SHM.
     pub fn attachGameView(self: *Self, shm_name: []const u8, format: []const u8) !void {
         try self.game_view.attach(shm_name, format);
-        // Backwards-compat: the floating "Game View" panel registered
-        // via the Module Registry is still available for users who
-        // want a docked-elsewhere layout. The tab below is the
-        // default surface; both share `renderViewportContent` so
-        // they stay in lockstep.
-        self.show_game_view = true;
-        // #128: also open the Game View as a tab in the main content
-        // area so users see the live frame inline with the editor
-        // tabs they were working in. Logged + swallowed because an
-        // OOM here shouldn't fail the attach — the panel still works.
+        // #145: the docked tab is the default auto-open surface after
+        // a preview attach. The floating "Game View" panel registered
+        // via the Module Registry remains available as a manual
+        // opt-in via the View menu (users who want a docked-elsewhere
+        // layout). Both surfaces share `renderViewportContent` so
+        // whichever is toggled on stays in lockstep with the live
+        // attachment. We intentionally do NOT flip `show_game_view`
+        // here — doing so opened both surfaces simultaneously and
+        // rendered the same live frame twice (#145).
+        // #128: open the Game View as a tab in the main content area
+        // so users see the live frame inline with the editor tabs
+        // they were working in. Logged + swallowed because an OOM
+        // here shouldn't fail the attach — the floating panel still
+        // works as a fallback if the user opens it from the menu.
         self.openGameViewTab() catch |err| {
             std.log.warn("attachGameView: openGameViewTab failed: {s}", .{@errorName(err)});
         };

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -696,14 +696,17 @@ pub fn main() !void {
             ctx.yield(2);
 
             // Equivalent of TE window introspection: attachGameView
-            // toggles `show_game_view` on AND the consumer's
-            // isAttached() flips true. The Game View module's
-            // `render` is gated on `is_open.*` from
-            // Registry.renderAllPanels, so these two flags together
-            // are the editor-side proof that the panel rendered for
-            // this frame.
+            // pushes a `.game_view` tab AND the consumer's
+            // isAttached() flips true. The tab body is gated on the
+            // `.game_view` variant in `open_tabs` (rendered via
+            // `OpenTab.render`), so these two together are the
+            // editor-side proof that the live frame surfaces this
+            // frame. The floating Module-Registry panel is NOT
+            // auto-opened (#145) — it's the manual View-menu opt-in
+            // surface, so `show_game_view` stays false here.
             _ = zgui.te.check(@src(), .{}, a.game_view.isAttached(), "consumer attached after producer detected");
-            _ = zgui.te.check(@src(), .{}, a.show_game_view, "Game View panel auto-opens on attach");
+            _ = zgui.te.check(@src(), .{}, !a.show_game_view, "floating Game View panel stays closed (#145 — tab is the default surface)");
+            _ = zgui.te.check(@src(), .{}, countGameViewTabs(a) >= 1, "Game View tab auto-opened on attach");
 
             // Let the deferred detach land before the next test
             // observes a stale attachment.
@@ -791,7 +794,13 @@ pub fn main() !void {
             // window-text introspection so a literal substring
             // match isn't reachable from here — the underlying
             // state mirror is the next best thing.
-            _ = zgui.te.check(@src(), .{}, a.show_game_view, "Stats window's parent Game View panel is open");
+            // #145: floating panel doesn't auto-open; the tab is the
+            // default surface, and `renderViewportContent` (shared
+            // with the panel) is what populates `last_latency_ns`
+            // via `game_view.poll()`. The tab body renders through
+            // the same path as the panel, so the live-numbers proof
+            // is the latency stat, not which surface is on screen.
+            _ = zgui.te.check(@src(), .{}, countGameViewTabs(a) >= 1, "Game View tab open so Stats area shows live numbers");
             _ = zgui.te.check(@src(), .{}, a.game_view.isAttached(), "consumer attached so Stats window shows live numbers");
             _ = zgui.te.check(@src(), .{}, a.game_view.last_latency_ns > 0, "last_latency_ns populated from a real frame");
 
@@ -899,7 +908,9 @@ pub fn main() !void {
             ctx.yield(2); // service the deferred attach (GL work).
 
             _ = zgui.te.check(@src(), .{}, a.game_view.isAttached(), "iosurface consumer attached");
-            _ = zgui.te.check(@src(), .{}, a.show_game_view, "Game View panel opened on iosurface attach");
+            // #145: tab is the auto-open surface; floating panel stays closed.
+            _ = zgui.te.check(@src(), .{}, countGameViewTabs(a) >= 1, "Game View tab opened on iosurface attach");
+            _ = zgui.te.check(@src(), .{}, !a.show_game_view, "floating panel not auto-opened on iosurface attach (#145)");
             // Rectangle textures + draw FBO only exist in iosurface
             // mode — they're the smoking gun that we took the right
             // dispatch branch.
@@ -1050,7 +1061,7 @@ pub fn main() !void {
             ctx.yield(2);
 
             _ = zgui.te.check(@src(), .{}, !a.game_view.isAttached(), "consumer detached on tab close");
-            _ = zgui.te.check(@src(), .{}, !a.show_game_view, "panel toggle reset on tab close");
+            _ = zgui.te.check(@src(), .{}, !a.show_game_view, "floating panel stays closed across tab close (#145)");
             _ = zgui.te.check(@src(), .{}, !a.preview.isActive(), "preview reports inactive after stop()");
 
             // No .game_view tab remains. Other test-leftover tabs

--- a/src/modules/compiler_output.zig
+++ b/src/modules/compiler_output.zig
@@ -77,6 +77,10 @@ fn render(app: *App) void {
             .failed => zgui.textColored(.{ 1.0, 0.0, 0.0, 1.0 }, "Failed", .{}),
         }
     }
+    zgui.sameLine(.{});
+    if (zgui.smallButton("Copy")) {
+        copyOutputToClipboard(app);
+    }
     zgui.separator();
 
     // Tail any stderr bytes that arrived since the last frame into the
@@ -125,4 +129,18 @@ fn render(app: *App) void {
         }
     }
     zgui.endChild();
+}
+
+fn copyOutputToClipboard(app: *App) void {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(app.allocator);
+
+    buf.appendSlice(app.allocator, app.preview_tail.items) catch return;
+    if (app.compiler.last_result) |result| {
+        if (result.errors.len > 0) buf.appendSlice(app.allocator, result.errors) catch return;
+        if (result.output.len > 0) buf.appendSlice(app.allocator, result.output) catch return;
+    }
+    buf.append(app.allocator, 0) catch return;
+    const zterm = buf.items[0 .. buf.items.len - 1 :0];
+    zgui.setClipboardText(zterm);
 }

--- a/src/modules/game_view.zig
+++ b/src/modules/game_view.zig
@@ -60,6 +60,19 @@ fn renderViewport(app: *App) void {
     renderViewportContent(app);
 }
 
+// ── Drag-release tracking (cursor finding on labelle-gui#146) ──
+// `isMouseReleased` was previously nested under `isItemHovered`, so a
+// press-on-image → drag-off → release-outside sequence dropped the
+// `down=false` event and the engine saw the button stuck down forever.
+// We now track which buttons have an outstanding `down=true` that we
+// emitted, and flush a `down=false` on the release frame regardless of
+// hover. We also stash the last in-image IOSurface coords so the
+// release-outside path can resend `sendMousePos` for positional
+// context (the engine pairs button events with the most recent pos).
+var button_down_sent: [3]bool = .{ false, false, false };
+var last_in_image_sx: f32 = 0.0;
+var last_in_image_sy: f32 = 0.0;
+
 /// Inner content — drawn either inside the tab's container OR inside
 /// the standalone panel's begin/end. No window chrome here.
 fn renderViewportContent(app: *App) void {
@@ -126,9 +139,9 @@ fn renderViewportContent(app: *App) void {
     zgui.image(tex_ref, .{ .w = draw_w, .h = draw_h });
 
     // ── Mouse → game input uplink (#143) ──
-    // Only fire while the image is hovered. Convert screen → image
-    // → IOSurface coords (scale by tex / draw ratio). Without a clip
-    // check, clicks anywhere on the panel would bleed into the game.
+    // Hover-gated half: position uplink + click detection. Clicks only
+    // count when the press starts on the image — otherwise UI clicks
+    // anywhere on the editor would bleed into the game.
     if (zgui.isItemHovered(.{})) {
         const mp = zgui.getMousePos();
         const dx_img = mp[0] - img_screen_pos[0];
@@ -138,18 +151,42 @@ fn renderViewportContent(app: *App) void {
         const sx: f32 = dx_img * scale_x;
         const sy: f32 = dy_img * scale_y;
         app.preview.sendMousePos(sx, sy);
+        // Stash for the release-outside path below.
+        last_in_image_sx = sx;
+        last_in_image_sy = sy;
 
         // ImGui mouse buttons: 0 = left, 1 = right, 2 = middle.
-        // `isMouseClicked`/`isMouseReleased` fire on the exact frame
-        // of the transition, so each user press maps to one
-        // `mouse_button down=true` followed by `down=false`.
+        // `isMouseClicked` fires on the exact frame of the press
+        // transition; the matching `down=false` is sent below
+        // regardless of hover (cursor finding on labelle-gui#146).
         inline for (.{
             .{ .btn = zgui.MouseButton.left, .idx = @as(i32, 0) },
             .{ .btn = zgui.MouseButton.right, .idx = @as(i32, 1) },
             .{ .btn = zgui.MouseButton.middle, .idx = @as(i32, 2) },
         }) |entry| {
-            if (zgui.isMouseClicked(entry.btn)) app.preview.sendMouseButton(entry.idx, true);
-            if (zgui.isMouseReleased(entry.btn)) app.preview.sendMouseButton(entry.idx, false);
+            if (zgui.isMouseClicked(entry.btn)) {
+                app.preview.sendMouseButton(entry.idx, true);
+                button_down_sent[@intCast(entry.idx)] = true;
+            }
+        }
+    }
+
+    // Release flush — runs every frame, hover or not. If we ever sent
+    // a `down=true` via this tab and ImGui now reports the release,
+    // mirror a `down=false` so the engine doesn't keep the button
+    // stuck after a press-drag-off-release. Pair it with one final
+    // `sendMousePos` at the last in-image coord so the engine has
+    // positional context for the click (#146).
+    inline for (.{
+        .{ .btn = zgui.MouseButton.left, .idx = @as(i32, 0) },
+        .{ .btn = zgui.MouseButton.right, .idx = @as(i32, 1) },
+        .{ .btn = zgui.MouseButton.middle, .idx = @as(i32, 2) },
+    }) |entry| {
+        const slot: usize = @intCast(entry.idx);
+        if (button_down_sent[slot] and zgui.isMouseReleased(entry.btn)) {
+            app.preview.sendMousePos(last_in_image_sx, last_in_image_sy);
+            app.preview.sendMouseButton(entry.idx, false);
+            button_down_sent[slot] = false;
         }
     }
 }

--- a/src/modules/game_view.zig
+++ b/src/modules/game_view.zig
@@ -118,7 +118,40 @@ fn renderViewportContent(app: *App) void {
         .tex_data = null,
         .tex_id = @enumFromInt(@as(u64, app.game_view.tex_id)),
     };
+    // Capture the image's screen-rect *before* drawing so we can map
+    // mouse coords back into IOSurface space for the input-uplink
+    // (labelle-assembler#143). `getCursorScreenPos` returns the
+    // top-left of the next widget — that's the image origin.
+    const img_screen_pos = zgui.getCursorScreenPos();
     zgui.image(tex_ref, .{ .w = draw_w, .h = draw_h });
+
+    // ── Mouse → game input uplink (#143) ──
+    // Only fire while the image is hovered. Convert screen → image
+    // → IOSurface coords (scale by tex / draw ratio). Without a clip
+    // check, clicks anywhere on the panel would bleed into the game.
+    if (zgui.isItemHovered(.{})) {
+        const mp = zgui.getMousePos();
+        const dx_img = mp[0] - img_screen_pos[0];
+        const dy_img = mp[1] - img_screen_pos[1];
+        const scale_x = src_w / draw_w;
+        const scale_y = src_h / draw_h;
+        const sx: f32 = dx_img * scale_x;
+        const sy: f32 = dy_img * scale_y;
+        app.preview.sendMousePos(sx, sy);
+
+        // ImGui mouse buttons: 0 = left, 1 = right, 2 = middle.
+        // `isMouseClicked`/`isMouseReleased` fire on the exact frame
+        // of the transition, so each user press maps to one
+        // `mouse_button down=true` followed by `down=false`.
+        inline for (.{
+            .{ .btn = zgui.MouseButton.left, .idx = @as(i32, 0) },
+            .{ .btn = zgui.MouseButton.right, .idx = @as(i32, 1) },
+            .{ .btn = zgui.MouseButton.middle, .idx = @as(i32, 2) },
+        }) |entry| {
+            if (zgui.isMouseClicked(entry.btn)) app.preview.sendMouseButton(entry.idx, true);
+            if (zgui.isMouseReleased(entry.btn)) app.preview.sendMouseButton(entry.idx, false);
+        }
+    }
 }
 
 fn renderStats(app: *App) void {

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -560,6 +560,38 @@ pub const PreviewSession = struct {
         }
     }
 
+    /// Send `{"kind":"mouse_pos","x":X,"y":Y}\n` to the engine.
+    /// Drains best-effort; partial-write loss is acceptable for mouse
+    /// telemetry. Coordinates are in IOSurface pixel space (not screen
+    /// space) — the editor's Game View tab converts before calling.
+    /// labelle-assembler#143.
+    pub fn sendMousePos(self: *Self, x: f32, y: f32) void {
+        if (self.conn_fd < 0) return;
+        var buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "{{\"kind\":\"mouse_pos\",\"x\":{d:.2},\"y\":{d:.2}}}\n", .{ x, y }) catch return;
+        var off: usize = 0;
+        while (off < msg.len) {
+            const n = write(self.conn_fd, msg.ptr + off, msg.len - off);
+            if (n <= 0) return;
+            off += @intCast(n);
+        }
+    }
+
+    /// Send `{"kind":"mouse_button","button":B,"down":D}\n`.
+    /// `button` follows ImGuiMouseButton convention (0 = left, 1 = right,
+    /// 2 = middle). labelle-assembler#143.
+    pub fn sendMouseButton(self: *Self, button: i32, down: bool) void {
+        if (self.conn_fd < 0) return;
+        var buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "{{\"kind\":\"mouse_button\",\"button\":{d},\"down\":{s}}}\n", .{ button, if (down) "true" else "false" }) catch return;
+        var off: usize = 0;
+        while (off < msg.len) {
+            const n = write(self.conn_fd, msg.ptr + off, msg.len - off);
+            if (n <= 0) return;
+            off += @intCast(n);
+        }
+    }
+
     pub fn watchEntity(self: *Self, entity_id: u64) !void {
         _ = self;
         _ = entity_id;


### PR DESCRIPTION
Fixes #145.

On preview attach the editor was opening both a Game View dock tab and a floating ImGui window — two viewport surfaces for the same stream. The floating panel was a debug leftover from the preview-attach branch.

Removes the floating window path; the dock-tab Game View is now the single surface that the preview producer writes to.