### PR TITLE
feat: Atlas Viewer panel (#148)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -27,6 +27,7 @@ const flow_mod = @import("modules/flow.zig");
 const gizmo_mod = @import("modules/gizmo.zig");
 const entity_inspector_mod = @import("modules/entity_inspector.zig");
 const game_view_mod = @import("modules/game_view.zig");
+const atlas_viewer_mod = @import("modules/atlas_viewer.zig");
 const game_view = @import("game_view.zig");
 const io_global = @import("io_global.zig");
 const flow_runtime_mod = @import("modules/flow_runtime.zig");
@@ -183,6 +184,12 @@ pub const App = struct {
     show_game_view: bool = false,
     game_view: game_view.GameView = undefined,
 
+    /// Atlas Viewer panel toggle (#148).
+    show_atlas_viewer: bool = false,
+    /// Atlas Viewer panel state — selected atlas/sprite, zoom, and any
+    /// packed-and-opened atlases.
+    atlas_viewer: atlas_viewer_mod.AtlasViewer = .{},
+
     /// Phase 3 (#84): Entity Inspector panel toggle.
     show_entity_inspector: bool = false,
     /// Entity Inspector state — fed by `PreviewSession`'s
@@ -272,7 +279,7 @@ pub const App = struct {
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [8]module.Module = undefined,
+    modules: [9]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -368,6 +375,7 @@ pub const App = struct {
         app.modules[5] = entity_inspector_mod.makeModule(app);
         app.modules[6] = flow_runtime_mod.makeModule(app);
         app.modules[7] = game_view_mod.makeModule(app);
+        app.modules[8] = atlas_viewer_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
 
         // Honor LABELLE_GAME_VIEW_SHM as a manual attach path until

--- a/src/app.zig
+++ b/src/app.zig
@@ -407,6 +407,9 @@ pub const App = struct {
         if (self.gizmo_index) |*idx| idx.deinit();
         if (self.prefab_index) |*idx| idx.deinit();
         if (self.pending_open_prefab_path) |p| self.allocator.free(p);
+        // Modules that opted into Registry-managed cleanup via
+        // `on_deinit` (e.g. atlas_viewer's GL textures + heap state).
+        self.registry.deinitAll(self);
         // Phase 3 state. Entity Inspector frees its component table;
         // Flow Runtime frees its subscribed-flow name copies.
         self.entity_inspector.deinit();

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -289,8 +289,13 @@ fn jsonU32(v: ?std.json.Value) ?u32 {
 fn jsonI32(v: ?std.json.Value) ?i32 {
     const val = v orelse return null;
     return switch (val) {
-        .integer => |i| @intCast(i),
-        .float => |f| @intFromFloat(f),
+        .integer => |i| std.math.cast(i32, i),
+        .float => |f| if (std.math.isFinite(f) and
+            f >= @as(f64, @floatFromInt(std.math.minInt(i32))) and
+            f <= @as(f64, @floatFromInt(std.math.maxInt(i32))))
+            @intFromFloat(f)
+        else
+            null,
         else => null,
     };
 }

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -23,6 +23,18 @@ pub const Frame = struct {
     y: u32,
     w: u32,
     h: u32,
+    /// 90° rotation flag — TexturePacker can rotate frames to pack tighter.
+    rotated: bool = false,
+    /// Whether transparent margins were trimmed off the source image.
+    trimmed: bool = false,
+    /// Pivot as a fraction of the sprite (0..1); defaults to centre.
+    pivot: [2]f32 = .{ 0.5, 0.5 },
+    /// Untrimmed source dimensions. Equal to `w`/`h` when not trimmed.
+    source_w: u32 = 0,
+    source_h: u32 = 0,
+    /// Offset of the trimmed rect within the source (`spriteSourceSize`).
+    offset_x: i32 = 0,
+    offset_y: i32 = 0,
 };
 
 pub const SpriteRef = struct {
@@ -142,6 +154,19 @@ fn loadOne(allocator: std.mem.Allocator, project_dir: []const u8, r: Resource) !
     const tex_path = try std.fs.path.join(allocator, &.{ project_dir, r.texture });
     defer allocator.free(tex_path);
 
+    return loadFromPaths(allocator, r.name, json_path, tex_path);
+}
+
+/// Load a single atlas from explicit JSON + PNG paths (not project-
+/// relative). Used by the Atlas Viewer to show atlases that aren't in
+/// the project's `resources` — e.g. a freshly packed sheet. Caller
+/// frees the returned atlas via `Atlas.deinit`.
+pub fn loadFromPaths(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    json_path: []const u8,
+    tex_path: []const u8,
+) !Atlas {
     // Decode PNG. zstbi-backed; runs on the main thread for now —
     // editor atlases are small enough that synchronous load is fine.
     const tex_path_z = try allocator.dupeZ(u8, tex_path);
@@ -172,7 +197,7 @@ fn loadOne(allocator: std.mem.Allocator, project_dir: []const u8, r: Resource) !
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
     var atlas: Atlas = .{
-        .name = try allocator.dupe(u8, r.name),
+        .name = try allocator.dupe(u8, name),
         .texture_id = tex_id,
         .width = img.width,
         .height = img.height,
@@ -220,9 +245,35 @@ pub fn parseFramesFromJsonText(allocator: std.mem.Allocator, raw: []const u8, at
         const w = jsonU32(frame_v.object.get("w")) orelse continue;
         const h = jsonU32(frame_v.object.get("h")) orelse continue;
 
+        var frame: Frame = .{ .x = x, .y = y, .w = w, .h = h, .source_w = w, .source_h = h };
+        if (entry.object.get("rotated")) |v| {
+            if (v == .bool) frame.rotated = v.bool;
+        }
+        if (entry.object.get("trimmed")) |v| {
+            if (v == .bool) frame.trimmed = v.bool;
+        }
+        if (entry.object.get("pivot")) |pv| {
+            if (pv == .object) {
+                if (jsonF32(pv.object.get("x"))) |fx| frame.pivot[0] = fx;
+                if (jsonF32(pv.object.get("y"))) |fy| frame.pivot[1] = fy;
+            }
+        }
+        if (entry.object.get("sourceSize")) |sv| {
+            if (sv == .object) {
+                if (jsonU32(sv.object.get("w"))) |sw| frame.source_w = sw;
+                if (jsonU32(sv.object.get("h"))) |sh| frame.source_h = sh;
+            }
+        }
+        if (entry.object.get("spriteSourceSize")) |sss| {
+            if (sss == .object) {
+                if (jsonI32(sss.object.get("x"))) |ox| frame.offset_x = ox;
+                if (jsonI32(sss.object.get("y"))) |oy| frame.offset_y = oy;
+            }
+        }
+
         const name_copy = try allocator.dupe(u8, kv.key_ptr.*);
         errdefer allocator.free(name_copy);
-        try atlas.frames.put(allocator, name_copy, .{ .x = x, .y = y, .w = w, .h = h });
+        try atlas.frames.put(allocator, name_copy, frame);
     }
 }
 
@@ -231,6 +282,24 @@ fn jsonU32(v: ?std.json.Value) ?u32 {
     return switch (val) {
         .integer => |i| if (i >= 0) @intCast(i) else null,
         .float => |f| if (f >= 0) @intFromFloat(f) else null,
+        else => null,
+    };
+}
+
+fn jsonI32(v: ?std.json.Value) ?i32 {
+    const val = v orelse return null;
+    return switch (val) {
+        .integer => |i| @intCast(i),
+        .float => |f| @intFromFloat(f),
+        else => null,
+    };
+}
+
+fn jsonF32(v: ?std.json.Value) ?f32 {
+    const val = v orelse return null;
+    return switch (val) {
+        .float => |f| @floatCast(f),
+        .integer => |i| @floatFromInt(i),
         else => null,
     };
 }

--- a/src/gui_tests.zig
+++ b/src/gui_tests.zig
@@ -325,6 +325,32 @@ pub fn main() !void {
         }
     });
 
+    _ = engine.registerTest("phase3", "view_atlas_viewer_toggle", @src(), struct {
+        pub fn gui(_: *zgui.te.TestContext) !void {
+            if (g_app) |a| a.renderFrame(1.0 / 60.0);
+        }
+        pub fn run(ctx: *zgui.te.TestContext) !void {
+            const a = g_app orelse {
+                _ = zgui.te.check(@src(), .{}, false, "g_app must be set");
+                return;
+            };
+            ctx.setRef("//##MainMenuBar");
+
+            _ = zgui.te.check(@src(), .{}, !a.show_atlas_viewer, "panel starts closed");
+
+            // Open it — with no project loaded the panel takes the
+            // "no atlases" path; yielding a few frames exercises the
+            // render code and would trip any imgui assertion.
+            ctx.menuAction(.click, "View/Atlas Viewer");
+            ctx.yield(3);
+            _ = zgui.te.check(@src(), .{}, a.show_atlas_viewer, "View/Atlas Viewer opens panel");
+
+            ctx.menuAction(.click, "View/Atlas Viewer");
+            ctx.yield(1);
+            _ = zgui.te.check(@src(), .{}, !a.show_atlas_viewer, "View/Atlas Viewer closes panel");
+        }
+    });
+
     // Drop a scene file with a Sprite component into the temp project
     // so the Scene module's save test can exercise round-trip
     // preservation through the Save button.

--- a/src/modules/atlas_viewer.zig
+++ b/src/modules/atlas_viewer.zig
@@ -1,0 +1,298 @@
+//! Atlas Viewer panel — inspect packed sprite atlases (labelle-gui#148).
+//!
+//! Shows the project's atlases (live from `App.atlas_index`) plus any
+//! atlas packed-and-opened during this session. For the selected atlas
+//! it renders the sheet with per-frame rect overlays, a sprite list,
+//! and a detail readout (rect, pivot, trim, source size) for the
+//! selected sprite.
+//!
+//! "Pack folder…" shells out to `labelle pack` — the same subprocess
+//! pattern `compiler.zig` uses for `labelle build`/`run` — then loads
+//! the resulting `.atlas.png`/`.json` pair into the viewer.
+
+const std = @import("std");
+const zgui = @import("zgui");
+const nfd = @import("nfd");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const atlas = @import("../atlas.zig");
+const io_global = @import("../io_global.zig");
+
+/// Panel-local state. One instance lives on `App`.
+pub const AtlasViewer = struct {
+    /// Atlases opened outside the project (packed-and-viewed sheets).
+    /// Project atlases are read live from `App.atlas_index`.
+    loaded: std.ArrayListUnmanaged(atlas.Atlas) = .empty,
+    /// Index into the combined list: project atlases, then `loaded`.
+    selected: usize = 0,
+    /// Selected sprite — a frame key in the current atlas.
+    sprite_buf: [512]u8 = undefined,
+    sprite_len: usize = 0,
+    /// Pixels-per-texel for the sheet view.
+    zoom: f32 = 1.0,
+    /// Last pack/open result line.
+    status_buf: [256]u8 = undefined,
+    status_len: usize = 0,
+    status_ok: bool = true,
+
+    pub fn deinit(self: *AtlasViewer, allocator: std.mem.Allocator) void {
+        for (self.loaded.items) |*a| a.deinit(allocator);
+        self.loaded.deinit(allocator);
+    }
+
+    fn selectedSprite(self: *const AtlasViewer) []const u8 {
+        return self.sprite_buf[0..self.sprite_len];
+    }
+    fn setSprite(self: *AtlasViewer, name: []const u8) void {
+        const n = @min(name.len, self.sprite_buf.len);
+        @memcpy(self.sprite_buf[0..n], name[0..n]);
+        self.sprite_len = n;
+    }
+    fn setStatus(self: *AtlasViewer, ok: bool, comptime fmt: []const u8, args: anytype) void {
+        const s = std.fmt.bufPrint(&self.status_buf, fmt, args) catch self.status_buf[0..0];
+        self.status_len = s.len;
+        self.status_ok = ok;
+    }
+};
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "atlas_viewer",
+        .display_name = "Atlas Viewer",
+        .is_open = &app.show_atlas_viewer,
+        .render_panel = render,
+        .on_deinit = onDeinit,
+    };
+}
+
+fn onDeinit(app: *App) void {
+    app.atlas_viewer.deinit(app.allocator);
+}
+
+fn atlasAt(project: []const atlas.Atlas, loaded: []const atlas.Atlas, idx: usize) *const atlas.Atlas {
+    return if (idx < project.len) &project[idx] else &loaded[idx - project.len];
+}
+
+fn render(app: *App) void {
+    if (!zgui.begin("Atlas Viewer", .{ .popen = &app.show_atlas_viewer })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    const v = &app.atlas_viewer;
+
+    // ── Toolbar ──────────────────────────────────────────────────
+    if (zgui.button("Pack folder...", .{})) packFolder(app);
+    if (v.status_len > 0) {
+        zgui.sameLine(.{});
+        const col: [4]f32 = if (v.status_ok) .{ 0.6, 1.0, 0.6, 1.0 } else .{ 1.0, 0.5, 0.5, 1.0 };
+        zgui.textColored(col, "{s}", .{v.status_buf[0..v.status_len]});
+    }
+    zgui.separator();
+
+    const project_atlases: []const atlas.Atlas =
+        if (app.atlas_index) |*idx| idx.atlases.items else &.{};
+    const total = project_atlases.len + v.loaded.items.len;
+    if (total == 0) {
+        zgui.textDisabled("No atlases. Open a project with atlas resources, or pack a folder.", .{});
+        return;
+    }
+    if (v.selected >= total) v.selected = 0;
+    const cur = atlasAt(project_atlases, v.loaded.items, v.selected);
+
+    // ── Atlas picker + zoom ──────────────────────────────────────
+    if (zgui.button("<", .{})) v.selected = (v.selected + total - 1) % total;
+    zgui.sameLine(.{});
+    if (zgui.button(">", .{})) v.selected = (v.selected + 1) % total;
+    zgui.sameLine(.{});
+    const origin_tag: []const u8 = if (v.selected < project_atlases.len) "project" else "packed";
+    zgui.text("{s}  ({d}/{d}, {s})", .{ cur.name, v.selected + 1, total, origin_tag });
+
+    zgui.sameLine(.{});
+    zgui.text("   |   {d}x{d}, {d} sprites", .{ cur.width, cur.height, cur.frames.count() });
+
+    zgui.sameLine(.{});
+    if (zgui.button("-", .{ .w = 26 })) v.zoom = @max(0.1, v.zoom * 0.8);
+    zgui.sameLine(.{});
+    zgui.text("{d:.2}x", .{v.zoom});
+    zgui.sameLine(.{});
+    if (zgui.button("+", .{ .w = 26 })) v.zoom = @min(16.0, v.zoom * 1.25);
+    zgui.separator();
+
+    // ── Split: sprite list + detail | sheet ──────────────────────
+    _ = zgui.beginChild("##atlas-left", .{ .w = 240, .child_flags = .{ .border = true } });
+    renderSpriteList(app, v, cur);
+    zgui.endChild();
+
+    zgui.sameLine(.{});
+
+    _ = zgui.beginChild("##atlas-right", .{ .child_flags = .{ .border = true } });
+    renderSheet(v, cur);
+    zgui.endChild();
+}
+
+/// Left column: scrollable sprite list (upper) + selected-sprite
+/// detail (lower).
+fn renderSpriteList(app: *App, v: *AtlasViewer, cur: *const atlas.Atlas) void {
+    // Sorted frame names — hash-map order is otherwise arbitrary.
+    var names: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer names.deinit(app.allocator);
+    {
+        var it = cur.frames.iterator();
+        while (it.next()) |kv| names.append(app.allocator, kv.key_ptr.*) catch {};
+    }
+    std.mem.sort([]const u8, names.items, {}, lessName);
+
+    const detail_h: f32 = 140;
+    _ = zgui.beginChild("##sprite-list", .{ .h = -detail_h });
+    var lbl: [544]u8 = undefined;
+    for (names.items) |name| {
+        const selected = std.mem.eql(u8, name, v.selectedSprite());
+        const z = std.fmt.bufPrintZ(&lbl, "{s}", .{name}) catch continue;
+        if (zgui.selectable(z, .{ .selected = selected })) v.setSprite(name);
+    }
+    zgui.endChild();
+
+    zgui.separator();
+
+    // Detail readout for the selected sprite.
+    if (cur.frames.get(v.selectedSprite())) |f| {
+        zgui.textWrapped("{s}", .{v.selectedSprite()});
+        zgui.text("rect:   {d}, {d}  {d}x{d}", .{ f.x, f.y, f.w, f.h });
+        zgui.text("pivot:  {d:.3}, {d:.3}", .{ f.pivot[0], f.pivot[1] });
+        zgui.text("source: {d}x{d}", .{ f.source_w, f.source_h });
+        zgui.text("offset: {d}, {d}", .{ f.offset_x, f.offset_y });
+        zgui.text("rotated: {}   trimmed: {}", .{ f.rotated, f.trimmed });
+    } else {
+        zgui.textDisabled("No sprite selected", .{});
+    }
+}
+
+/// Right column: the atlas sheet with per-frame rect overlays. Clicking
+/// inside a frame selects that sprite.
+fn renderSheet(v: *AtlasViewer, cur: *const atlas.Atlas) void {
+    if (cur.texture_id == 0) {
+        zgui.textDisabled("Atlas has no texture", .{});
+        return;
+    }
+    const tw: f32 = @floatFromInt(cur.width);
+    const th: f32 = @floatFromInt(cur.height);
+    const sheet_w = tw * v.zoom;
+    const sheet_h = th * v.zoom;
+
+    const origin = zgui.getCursorScreenPos();
+    const dl = zgui.getWindowDrawList();
+    // Dark backing so transparent regions read as empty, not as the
+    // window background.
+    dl.addRectFilled(.{
+        .pmin = origin,
+        .pmax = .{ origin[0] + sheet_w, origin[1] + sheet_h },
+        .col = 0xff_1a_1a_1a,
+    });
+
+    const tex_ref: zgui.TextureRef = .{
+        .tex_data = null,
+        .tex_id = @enumFromInt(@as(u64, cur.texture_id)),
+    };
+    zgui.image(tex_ref, .{ .w = sheet_w, .h = sheet_h });
+
+    // Click-to-select: map the click to a texel, hit-test the frames.
+    if (zgui.isItemHovered(.{}) and zgui.isMouseClicked(.left)) {
+        const mp = zgui.getMousePos();
+        const tx = (mp[0] - origin[0]) / v.zoom;
+        const ty = (mp[1] - origin[1]) / v.zoom;
+        var it = cur.frames.iterator();
+        while (it.next()) |kv| {
+            const f = kv.value_ptr.*;
+            const fx: f32 = @floatFromInt(f.x);
+            const fy: f32 = @floatFromInt(f.y);
+            if (tx >= fx and ty >= fy and
+                tx < fx + @as(f32, @floatFromInt(f.w)) and
+                ty < fy + @as(f32, @floatFromInt(f.h)))
+            {
+                v.setSprite(kv.key_ptr.*);
+                break;
+            }
+        }
+    }
+
+    // Frame outlines; the selected frame gets a bright, thicker box.
+    var it = cur.frames.iterator();
+    while (it.next()) |kv| {
+        const f = kv.value_ptr.*;
+        const selected = std.mem.eql(u8, kv.key_ptr.*, v.selectedSprite());
+        const pmin: [2]f32 = .{
+            origin[0] + @as(f32, @floatFromInt(f.x)) * v.zoom,
+            origin[1] + @as(f32, @floatFromInt(f.y)) * v.zoom,
+        };
+        const pmax: [2]f32 = .{
+            pmin[0] + @as(f32, @floatFromInt(f.w)) * v.zoom,
+            pmin[1] + @as(f32, @floatFromInt(f.h)) * v.zoom,
+        };
+        dl.addRect(.{
+            .pmin = pmin,
+            .pmax = pmax,
+            .col = if (selected) 0xff_40_d2_ff else 0x60_ff_ff_ff,
+            .thickness = if (selected) 2.0 else 1.0,
+        });
+    }
+}
+
+fn lessName(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
+}
+
+/// Pick a folder, run `labelle pack` on it, and load the result.
+fn packFolder(app: *App) void {
+    const v = &app.atlas_viewer;
+
+    const maybe = nfd.openFolderDialog(null) catch {
+        v.setStatus(false, "folder dialog failed", .{});
+        return;
+    };
+    const folder = maybe orelse return;
+    defer nfd.freePath(folder);
+
+    const name = std.fs.path.basename(folder);
+    if (name.len == 0) {
+        v.setStatus(false, "could not derive an atlas name from the folder", .{});
+        return;
+    }
+
+    const result = std.process.run(app.allocator, io_global.io(), .{
+        .argv = &.{ "labelle", "pack", folder, "-o", name, "--out-dir", folder },
+    }) catch |err| {
+        v.setStatus(false, "labelle pack failed to launch: {s}", .{@errorName(err)});
+        return;
+    };
+    defer app.allocator.free(result.stdout);
+    defer app.allocator.free(result.stderr);
+
+    if (result.term != .exited or result.term.exited != 0) {
+        v.setStatus(false, "labelle pack failed (see terminal)", .{});
+        return;
+    }
+
+    const json_path = std.fmt.allocPrint(app.allocator, "{s}/{s}.atlas.json", .{ folder, name }) catch return;
+    defer app.allocator.free(json_path);
+    const png_path = std.fmt.allocPrint(app.allocator, "{s}/{s}.atlas.png", .{ folder, name }) catch return;
+    defer app.allocator.free(png_path);
+
+    var loaded = atlas.loadFromPaths(app.allocator, name, json_path, png_path) catch |err| {
+        v.setStatus(false, "packed ok, but loading the atlas failed: {s}", .{@errorName(err)});
+        return;
+    };
+    const sprite_count = loaded.frames.count();
+    v.loaded.append(app.allocator, loaded) catch {
+        loaded.deinit(app.allocator);
+        v.setStatus(false, "out of memory", .{});
+        return;
+    };
+
+    const project_count = if (app.atlas_index) |*idx| idx.atlases.items.len else 0;
+    v.selected = project_count + v.loaded.items.len - 1;
+    v.sprite_len = 0;
+    v.setStatus(true, "packed '{s}' — {d} sprites", .{ name, sprite_count });
+}

--- a/src/modules/atlas_viewer.zig
+++ b/src/modules/atlas_viewer.zig
@@ -26,6 +26,10 @@ pub const AtlasViewer = struct {
     loaded: std.ArrayListUnmanaged(atlas.Atlas) = .empty,
     /// Index into the combined list: project atlases, then `loaded`.
     selected: usize = 0,
+    /// `ProjectManager.generation` the `selected` index was last valid
+    /// against. When the project changes, the index points into a
+    /// different atlas set, so we reset selection + sprite.
+    last_generation: ?u64 = null,
     /// Selected sprite — a frame key in the current atlas.
     sprite_buf: [512]u8 = undefined,
     sprite_len: usize = 0,
@@ -53,6 +57,9 @@ pub const AtlasViewer = struct {
         const s = std.fmt.bufPrint(&self.status_buf, fmt, args) catch self.status_buf[0..0];
         self.status_len = s.len;
         self.status_ok = ok;
+    }
+    fn clearSprite(self: *AtlasViewer) void {
+        self.sprite_len = 0;
     }
 };
 
@@ -83,6 +90,17 @@ fn render(app: *App) void {
 
     const v = &app.atlas_viewer;
 
+    // Project transitions re-key `App.atlas_index`; the `selected`
+    // index then points into a different atlas set (or a now-shorter
+    // list). Reset selection + sprite when the generation changes so
+    // the viewer never shows an unintended atlas/sprite.
+    const generation = app.project_manager.generation;
+    if (v.last_generation != generation) {
+        v.last_generation = generation;
+        v.selected = 0;
+        v.clearSprite();
+    }
+
     // ── Toolbar ──────────────────────────────────────────────────
     if (zgui.button("Pack folder...", .{})) packFolder(app);
     if (v.status_len > 0) {
@@ -99,14 +117,25 @@ fn render(app: *App) void {
         zgui.textDisabled("No atlases. Open a project with atlas resources, or pack a folder.", .{});
         return;
     }
-    if (v.selected >= total) v.selected = 0;
-    const cur = atlasAt(project_atlases, v.loaded.items, v.selected);
+    if (v.selected >= total) {
+        v.selected = 0;
+        v.clearSprite();
+    }
 
     // ── Atlas picker + zoom ──────────────────────────────────────
-    if (zgui.button("<", .{})) v.selected = (v.selected + total - 1) % total;
+    // Resolve `cur` *after* the picker buttons so the header name,
+    // index, dimensions and sprite list all reflect the same atlas.
+    if (zgui.button("<", .{})) {
+        v.selected = (v.selected + total - 1) % total;
+        v.clearSprite();
+    }
     zgui.sameLine(.{});
-    if (zgui.button(">", .{})) v.selected = (v.selected + 1) % total;
+    if (zgui.button(">", .{})) {
+        v.selected = (v.selected + 1) % total;
+        v.clearSprite();
+    }
     zgui.sameLine(.{});
+    const cur = atlasAt(project_atlases, v.loaded.items, v.selected);
     const origin_tag: []const u8 = if (v.selected < project_atlases.len) "project" else "packed";
     zgui.text("{s}  ({d}/{d}, {s})", .{ cur.name, v.selected + 1, total, origin_tag });
 
@@ -275,9 +304,26 @@ fn packFolder(app: *App) void {
         return;
     }
 
-    const json_path = std.fmt.allocPrint(app.allocator, "{s}/{s}.atlas.json", .{ folder, name }) catch return;
+    const json_name = std.fmt.allocPrint(app.allocator, "{s}.atlas.json", .{name}) catch {
+        v.setStatus(false, "packed ok, but out of memory building the atlas path", .{});
+        return;
+    };
+    defer app.allocator.free(json_name);
+    const json_path = std.fs.path.join(app.allocator, &.{ folder, json_name }) catch {
+        v.setStatus(false, "packed ok, but out of memory building the atlas path", .{});
+        return;
+    };
     defer app.allocator.free(json_path);
-    const png_path = std.fmt.allocPrint(app.allocator, "{s}/{s}.atlas.png", .{ folder, name }) catch return;
+
+    const png_name = std.fmt.allocPrint(app.allocator, "{s}.atlas.png", .{name}) catch {
+        v.setStatus(false, "packed ok, but out of memory building the atlas path", .{});
+        return;
+    };
+    defer app.allocator.free(png_name);
+    const png_path = std.fs.path.join(app.allocator, &.{ folder, png_name }) catch {
+        v.setStatus(false, "packed ok, but out of memory building the atlas path", .{});
+        return;
+    };
     defer app.allocator.free(png_path);
 
     var loaded = atlas.loadFromPaths(app.allocator, name, json_path, png_path) catch |err| {
@@ -285,14 +331,36 @@ fn packFolder(app: *App) void {
         return;
     };
     const sprite_count = loaded.frames.count();
-    v.loaded.append(app.allocator, loaded) catch {
-        loaded.deinit(app.allocator);
-        v.setStatus(false, "out of memory", .{});
-        return;
-    };
 
+    // Re-packing the same folder must not accumulate duplicate atlases
+    // (and leak their GL textures). Replace any prior `loaded` entry
+    // with the same name in place.
+    var replaced = false;
+    for (v.loaded.items) |*existing| {
+        if (std.mem.eql(u8, existing.name, name)) {
+            existing.deinit(app.allocator);
+            existing.* = loaded;
+            replaced = true;
+            break;
+        }
+    }
+    if (!replaced) {
+        v.loaded.append(app.allocator, loaded) catch {
+            loaded.deinit(app.allocator);
+            v.setStatus(false, "out of memory", .{});
+            return;
+        };
+    }
+
+    // Select the freshly packed atlas. After a replace its slot is
+    // unchanged; locate it so the index is correct either way.
     const project_count = if (app.atlas_index) |*idx| idx.atlases.items.len else 0;
-    v.selected = project_count + v.loaded.items.len - 1;
-    v.sprite_len = 0;
+    for (v.loaded.items, 0..) |*a, i| {
+        if (std.mem.eql(u8, a.name, name)) {
+            v.selected = project_count + i;
+            break;
+        }
+    }
+    v.clearSprite();
     v.setStatus(true, "packed '{s}' — {d} sprites", .{ name, sprite_count });
 }


### PR DESCRIPTION
## Summary

Implements #148 — a togglable **Atlas Viewer** panel for inspecting packed sprite atlases.

- **Atlas list** — the project's atlases (live from `App.atlas_index`) plus any atlas packed during the session; `<`/`>` to cycle.
- **Sheet view** — the atlas texture with per-frame rect overlays; click a frame on the sheet or a row in the sprite list to select. Zoom with `-`/`+`.
- **Per-sprite detail** — rect, pivot, source size, offset, rotated/trimmed flags.
- **Pack-then-view** — "Pack folder…" picks a folder and shells out to `labelle pack` (the same subprocess pattern `compiler.zig` uses for `build`/`run`), then loads the resulting `.atlas.png`/`.json` into the viewer.

## Why subprocess, not a linked dependency

#148 originally proposed importing the packer as a library. The GUI already links **`zstbi`** (stb), and the packer vendors its own stb — linking both duplicate-defines the stb symbols. Invoking `labelle pack` as a subprocess sidesteps that entirely and matches how the GUI already drives the CLI. (The packer also moved back in-tree to `labelle-cli` — see labelle-cli#214.)

## Changes

- `src/atlas.zig` — `Frame` + the JSON parser gain `pivot`, `trimmed`, `rotated`, `spriteSourceSize` (previously only the x/y/w/h rect). Loader refactored into a reusable `loadFromPaths` so a single atlas can be loaded from explicit paths.
- `src/modules/atlas_viewer.zig` — new module/panel.
- `src/app.zig` — registers the module (`modules` `[8]`→`[9]`, `show_atlas_viewer` + `atlas_viewer` state).
- `src/gui_tests.zig` — TE test: open the panel via the View menu, render, close.

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — unit tests pass
- [x] `zig build gui-test` — 16/16 (incl. new `view_atlas_viewer_toggle`)
- [ ] **Visual check pending** — I could not interactively verify sheet/overlay rendering against a real project atlas; the TE test exercises the panel-open/render path but not the textured-sheet path with a loaded atlas.


Closes #148
