### PR TITLE
Flows editor: .flow.jsonc read/write + Subflow & Param nodes

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -24,6 +24,7 @@ const preview_mod = @import("modules/preview.zig");
 const scene_mod = @import("modules/scene.zig");
 const prefab_mod = @import("modules/prefab.zig");
 const flow_mod = @import("modules/flow.zig");
+const flow_doc_mod = @import("modules/flow_doc.zig");
 const gizmo_mod = @import("modules/gizmo.zig");
 const entity_inspector_mod = @import("modules/entity_inspector.zig");
 const game_view_mod = @import("modules/game_view.zig");
@@ -51,10 +52,13 @@ const SCENE_NAME_BUF_LEN = 128;
 pub const OpenTab = union(enum) {
     scene: scene_mod.SceneState,
     prefab: prefab_mod.PrefabState,
-    /// Visual-scripting "flow graph" editor — spike for issue #45.
-    /// `save`/`isDirty` are no-ops until Phase 1 lands the
-    /// `.flow.zon` schema.
+    /// Read-only Flow *viewer* — a `.zig` script projected into a
+    /// node graph via `std.zig.Ast` (issues #48/#49). `save`/`isDirty`
+    /// are no-ops.
     flow: flow_mod.FlowState,
+    /// `.flow.jsonc` flow-graph *editor* (RFC: Flows as `.flow.jsonc`,
+    /// issue #153). Authors the flat `nodes`+`edges` content format.
+    flow_doc: flow_doc_mod.FlowDocState,
     gizmo: gizmo_mod.GizmoState,
     /// Live game view (#128). Routing marker only — the consumer +
     /// GL texture state live on `App.game_view`. No per-tab struct
@@ -68,6 +72,7 @@ pub const OpenTab = union(enum) {
             .scene => |*s| s.deinit(allocator),
             .prefab => |*p| p.deinit(allocator),
             .flow => |*f| f.deinit(allocator),
+            .flow_doc => |*f| f.deinit(allocator),
             .gizmo => |*g| g.deinit(allocator),
             .game_view => {},
         }
@@ -78,6 +83,7 @@ pub const OpenTab = union(enum) {
             .scene => |*s| scene_mod.render(s, app),
             .prefab => |*p| prefab_mod.render(p, app),
             .flow => |*f| flow_mod.render(f, app),
+            .flow_doc => |*f| flow_doc_mod.render(f, app),
             .gizmo => |*g| gizmo_mod.render(g, app),
             .game_view => game_view_mod.renderTab(app),
         }
@@ -88,6 +94,7 @@ pub const OpenTab = union(enum) {
             .scene => |*s| scene_mod.saveScene(s, app),
             .prefab => |*p| prefab_mod.savePrefab(p, app),
             .flow => |*f| flow_mod.saveFlow(f, app),
+            .flow_doc => |*f| flow_doc_mod.saveFlowDoc(f, app),
             .gizmo => |*g| gizmo_mod.saveGizmo(g, app),
             .game_view => {},
         }
@@ -98,6 +105,7 @@ pub const OpenTab = union(enum) {
             .scene => |s| s.display_name,
             .prefab => |p| p.display_name,
             .flow => |f| f.display_name,
+            .flow_doc => |f| f.display_name,
             .gizmo => |g| g.display_name,
             .game_view => "▶ Game View",
         };
@@ -108,6 +116,7 @@ pub const OpenTab = union(enum) {
             .scene => |s| s.path,
             .prefab => |p| p.path,
             .flow => |f| f.path,
+            .flow_doc => |f| f.path,
             .gizmo => |g| g.path,
             .game_view => "<runtime>",
         };
@@ -118,6 +127,7 @@ pub const OpenTab = union(enum) {
             .scene => |s| s.is_dirty,
             .prefab => |p| p.is_dirty,
             .flow => |f| f.is_dirty,
+            .flow_doc => |f| f.is_dirty,
             .gizmo => |g| g.is_dirty,
             .game_view => false,
         };
@@ -623,6 +633,27 @@ pub const App = struct {
         var state = try flow_mod.FlowState.open(self.allocator, path);
         errdefer state.deinit(self.allocator);
         try self.open_tabs.append(self.allocator, .{ .flow = state });
+        const new_idx = self.open_tabs.items.len - 1;
+        self.active_tab_idx = new_idx;
+        self.focus_tab_idx = new_idx;
+    }
+
+    /// Open a `.flow.jsonc` file (under `<project>/scripts/flows/`) as
+    /// the flow-graph *editor* tab — the authoring counterpart to
+    /// `openFlow`. The file is parsed by `src/flow_io.zig` into the
+    /// flat `nodes`+`edges` model and edited in `modules/flow_doc.zig`.
+    /// See the Flows-as-`.flow.jsonc` RFC and issue #153.
+    pub fn openFlowDoc(self: *Self, path: []const u8) !void {
+        for (self.open_tabs.items, 0..) |t, i| {
+            if (std.mem.eql(u8, t.path(), path)) {
+                self.focus_tab_idx = i;
+                return;
+            }
+        }
+
+        var state = try flow_doc_mod.FlowDocState.open(self.allocator, path);
+        errdefer state.deinit(self.allocator);
+        try self.open_tabs.append(self.allocator, .{ .flow_doc = state });
         const new_idx = self.open_tabs.items.len - 1;
         self.active_tab_idx = new_idx;
         self.focus_tab_idx = new_idx;

--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -213,6 +213,11 @@ pub const ParseError = error{
     DuplicateNodeId,
     BadNodeType,
     BadEdge,
+    /// A top-level key (`name`, `event`, `params`, `nodes`, `edges`) or a
+    /// nested field held a value of the wrong JSON type. The parser
+    /// rejects malformed schema rather than silently substituting a
+    /// default — a silent default would mask data the author intended.
+    BadSchema,
 } || std.json.ParseError(std.json.Scanner) || std.mem.Allocator.Error;
 
 /// Read and parse a `.flow.jsonc` file from disk.
@@ -250,31 +255,34 @@ pub fn parse(child_allocator: std.mem.Allocator, raw: []const u8) !FlowDoc {
 
     // ── name ──
     if (root.get("name")) |v| {
-        if (v == .string) doc.name = try a.dupe(u8, v.string);
+        if (v != .string) return ParseError.BadSchema;
+        doc.name = try a.dupe(u8, v.string);
     }
 
     // ── event ──
     if (root.get("event")) |v| {
-        if (v == .object) doc.event = try parseEvent(a, v.object);
+        if (v != .object) return ParseError.BadSchema;
+        doc.event = try parseEvent(a, v.object);
     }
 
     // ── params ──
     if (root.get("params")) |v| {
-        if (v == .array) doc.params = try parseParams(a, v.array);
+        if (v != .array) return ParseError.BadSchema;
+        doc.params = try parseParams(a, v.array);
     }
 
     // ── nodes ──
     if (root.get("nodes")) |v| {
-        if (v == .array) {
-            const r = try parseNodes(a, v.array);
-            doc.nodes = r.nodes;
-            doc.max_node_id = r.max_id;
-        }
+        if (v != .array) return ParseError.BadSchema;
+        const r = try parseNodes(a, v.array);
+        doc.nodes = r.nodes;
+        doc.max_node_id = r.max_id;
     }
 
     // ── edges ──
     if (root.get("edges")) |v| {
-        if (v == .array) doc.edges = try parseEdges(a, v.array);
+        if (v != .array) return ParseError.BadSchema;
+        doc.edges = try parseEdges(a, v.array);
     }
 
     return doc;
@@ -287,9 +295,8 @@ fn parseEvent(a: std.mem.Allocator, obj: std.json.ObjectMap) !Event {
     while (it.next()) |entry| {
         const key = entry.key_ptr.*;
         if (std.mem.eql(u8, key, "type")) {
-            if (entry.value_ptr.* == .string) {
-                ev.type_name = try a.dupe(u8, entry.value_ptr.string);
-            }
+            if (entry.value_ptr.* != .string) return ParseError.BadSchema;
+            ev.type_name = try a.dupe(u8, entry.value_ptr.string);
             continue;
         }
         try extras.append(a, .{
@@ -305,13 +312,18 @@ fn parseEvent(a: std.mem.Allocator, obj: std.json.ObjectMap) !Event {
 fn parseParams(a: std.mem.Allocator, arr: std.json.Array) ![]Param {
     var out: std.ArrayList(Param) = .empty;
     for (arr.items) |item| {
-        if (item != .object) continue;
+        if (item != .object) return ParseError.BadSchema;
         const o = item.object;
-        const name = if (o.get("name")) |n| (if (n == .string) n.string else "") else "";
-        const type_name = if (o.get("type")) |t| (if (t == .string) t.string else "f32") else "f32";
+        // `name` and `type` are required identifier strings — a missing
+        // or wrong-typed field is malformed schema, not a defaultable
+        // omission.
+        const name_v = o.get("name") orelse return ParseError.BadSchema;
+        if (name_v != .string) return ParseError.BadSchema;
+        const type_v = o.get("type") orelse return ParseError.BadSchema;
+        if (type_v != .string) return ParseError.BadSchema;
         var p: Param = .{
-            .name = try a.dupe(u8, name),
-            .type_name = try a.dupe(u8, type_name),
+            .name = try a.dupe(u8, name_v.string),
+            .type_name = try a.dupe(u8, type_v.string),
         };
         if (o.get("default")) |d| {
             p.default_text = try jsonValueToText(a, d);
@@ -326,6 +338,7 @@ const NodesResult = struct { nodes: []Node, max_id: u32 };
 fn parseNodes(a: std.mem.Allocator, arr: std.json.Array) !NodesResult {
     var out: std.ArrayList(Node) = .empty;
     var seen: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer seen.deinit(a);
     var max_id: u32 = 0;
 
     for (arr.items) |item| {
@@ -333,10 +346,7 @@ fn parseNodes(a: std.mem.Allocator, arr: std.json.Array) !NodesResult {
         const o = item.object;
 
         const id_v = o.get("id") orelse return ParseError.MissingNodeId;
-        const id: u32 = switch (id_v) {
-            .integer => |n| std.math.cast(u32, n) orelse return ParseError.MissingNodeId,
-            else => return ParseError.MissingNodeId,
-        };
+        const id = jsonIntId(id_v) orelse return ParseError.MissingNodeId;
         if (seen.contains(id)) return ParseError.DuplicateNodeId;
         try seen.put(a, id, {});
         if (id > max_id) max_id = id;
@@ -368,28 +378,27 @@ fn parseNodes(a: std.mem.Allocator, arr: std.json.Array) !NodesResult {
                 std.mem.eql(u8, key, "type") or
                 std.mem.eql(u8, key, "pos")) continue;
 
+            // A modeled structural key with the wrong JSON type is
+            // malformed schema. Tolerating it would route the value
+            // into `extras` and emit a duplicate key on the next save.
             if (kind == .subflow and std.mem.eql(u8, key, "flow")) {
-                if (entry.value_ptr.* == .string) {
-                    node.flow_ref = try a.dupe(u8, entry.value_ptr.string);
-                }
+                if (entry.value_ptr.* != .string) return ParseError.BadSchema;
+                node.flow_ref = try a.dupe(u8, entry.value_ptr.string);
                 continue;
             }
             if (kind == .subflow and std.mem.eql(u8, key, "bindings")) {
-                if (entry.value_ptr.* == .object) {
-                    node.bindings = try parseBindings(a, entry.value_ptr.object);
-                }
+                if (entry.value_ptr.* != .object) return ParseError.BadSchema;
+                node.bindings = try parseBindings(a, entry.value_ptr.object);
                 continue;
             }
             if (kind == .param and std.mem.eql(u8, key, "param")) {
-                if (entry.value_ptr.* == .string) {
-                    node.param_ref = try a.dupe(u8, entry.value_ptr.string);
-                }
+                if (entry.value_ptr.* != .string) return ParseError.BadSchema;
+                node.param_ref = try a.dupe(u8, entry.value_ptr.string);
                 continue;
             }
             if (kind == .output and std.mem.eql(u8, key, "name")) {
-                if (entry.value_ptr.* == .string) {
-                    node.output_name = try a.dupe(u8, entry.value_ptr.string);
-                }
+                if (entry.value_ptr.* != .string) return ParseError.BadSchema;
+                node.output_name = try a.dupe(u8, entry.value_ptr.string);
                 continue;
             }
 
@@ -416,13 +425,14 @@ fn parseBindings(a: std.mem.Allocator, obj: std.json.ObjectMap) ![]Binding {
             .value_text = try jsonValueToText(a, entry.value_ptr.*),
         });
     }
-    // Sort by name for a stable writer order.
-    std.mem.sort(Binding, out.items, {}, struct {
-        fn lt(_: void, x: Binding, y: Binding) bool {
-            return std.mem.lessThan(u8, x.name, y.name);
-        }
-    }.lt);
+    // Sort by name for a stable writer order. The writer re-sorts too
+    // (the editor can reorder bindings between parse and save).
+    std.mem.sort(Binding, out.items, {}, bindingLessThan);
     return out.toOwnedSlice(a);
+}
+
+fn bindingLessThan(_: void, x: Binding, y: Binding) bool {
+    return std.mem.lessThan(u8, x.name, y.name);
 }
 
 fn parseEdges(a: std.mem.Allocator, arr: std.json.Array) ![]Edge {
@@ -449,13 +459,34 @@ const Endpoint = struct { node: u32, pin: []const u8 };
 
 fn parseEndpoint(a: std.mem.Allocator, obj: std.json.ObjectMap) !Endpoint {
     const node_v = obj.get("node") orelse return ParseError.BadEdge;
-    const node: u32 = switch (node_v) {
-        .integer => |n| std.math.cast(u32, n) orelse return ParseError.BadEdge,
-        else => return ParseError.BadEdge,
-    };
+    const node = jsonIntId(node_v) orelse return ParseError.BadEdge;
     const pin_v = obj.get("pin") orelse return ParseError.BadEdge;
     if (pin_v != .string) return ParseError.BadEdge;
     return .{ .node = node, .pin = try a.dupe(u8, pin_v.string) };
+}
+
+/// Read a JSON number expected to be a non-negative `u32` node id.
+/// Accepts a plain integer, and also a float (or `number_string`) that
+/// has no fractional part — hand-authored files and exporters often
+/// write `1.0` where the writer would emit `1`. Returns null when the
+/// value is not a whole number in `u32` range.
+fn jsonIntId(v: std.json.Value) ?u32 {
+    switch (v) {
+        .integer => |n| return std.math.cast(u32, n),
+        .float => |f| {
+            if (@floor(f) != f or f < 0 or f > std.math.maxInt(u32)) return null;
+            return @intFromFloat(f);
+        },
+        .number_string => |s| {
+            const n = std.fmt.parseInt(i64, s, 10) catch {
+                const f = std.fmt.parseFloat(f64, s) catch return null;
+                if (@floor(f) != f or f < 0 or f > std.math.maxInt(u32)) return null;
+                return @intFromFloat(f);
+            };
+            return std.math.cast(u32, n);
+        },
+        else => return null,
+    }
 }
 
 fn jsonNumberAsF32(v: std.json.Value) ?f32 {
@@ -542,6 +573,40 @@ fn writeJsonString(a: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8)
         }
     }
     try out.append(a, '"');
+}
+
+/// Normalise free-form editor input into canonical JSON value text
+/// safe to splice into a `.flow.jsonc` file.
+///
+/// `default`s and `Subflow` bindings are typed into a text box by the
+/// user; that raw text must never reach the writer verbatim, or a save
+/// can produce invalid JSON (e.g. an unquoted word, an unterminated
+/// string). The rule:
+///   - If `input` parses as a single JSON value, return its canonical
+///     text (the same form `jsonValueToText` produces — sorted object
+///     keys, escaped strings, compact).
+///   - Otherwise treat `input` as a plain string literal and return it
+///     JSON-quoted and escaped.
+///
+/// This means `25` → `25`, `10.5` → `10.5`, `true` → `true`,
+/// `"hi"` → `"hi"`, but a bare `hello` → `"hello"` and a stray `"`
+/// → `"\""` rather than corrupting the file. The result is owned by
+/// `a`. An empty / whitespace-only input yields `""` (empty JSON
+/// string) so the field still round-trips as valid JSON.
+pub fn normalizeValueText(a: std.mem.Allocator, input: []const u8) ![]const u8 {
+    const trimmed = std.mem.trim(u8, input, " \t\r\n");
+    if (trimmed.len == 0) {
+        return a.dupe(u8, "\"\"");
+    }
+    var parsed = std.json.parseFromSlice(std.json.Value, a, trimmed, .{}) catch {
+        // Not valid JSON — fall back to a quoted string literal.
+        var out: std.ArrayList(u8) = .empty;
+        errdefer out.deinit(a);
+        try writeJsonString(a, &out, trimmed);
+        return out.toOwnedSlice(a);
+    };
+    defer parsed.deinit();
+    return jsonValueToText(a, parsed.value);
 }
 
 fn sortKeyValues(items: []KeyValue) void {
@@ -667,8 +732,15 @@ fn renderNode(a: std.mem.Allocator, out: *std.ArrayList(u8), n: Node) !void {
             try out.appendSlice(a, ", \"flow\": ");
             try writeJsonString(a, out, n.flow_ref);
             if (n.bindings.len > 0) {
+                // The editor may have renamed or appended bindings since
+                // parse, leaving `n.bindings` unsorted. Sort a local copy
+                // here so the on-disk key order is deterministic and a
+                // re-save is idempotent regardless of edit history.
+                const sorted = try a.dupe(Binding, n.bindings);
+                defer a.free(sorted);
+                std.mem.sort(Binding, sorted, {}, bindingLessThan);
                 try out.appendSlice(a, ", \"bindings\": { ");
-                for (n.bindings, 0..) |b, i| {
+                for (sorted, 0..) |b, i| {
                     if (i > 0) try out.appendSlice(a, ", ");
                     try writeJsonString(a, out, b.name);
                     try out.appendSlice(a, ": ");
@@ -843,4 +915,97 @@ test "empty graph round-trips" {
 test "displayNameFromPath strips extension" {
     try std.testing.expectEqualStrings("enemy_tick", displayNameFromPath("a/b/enemy_tick.flow.jsonc"));
     try std.testing.expectEqualStrings("other.zig", displayNameFromPath("x/other.zig"));
+}
+
+test "parser rejects malformed schema instead of defaulting" {
+    // Wrong-typed top-level keys must error, not silently default.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "name": 42, "nodes": [], "edges": [] }
+    ));
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "nodes": {}, "edges": [] }
+    ));
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "event": "OnCreate", "nodes": [], "edges": [] }
+    ));
+    // Non-string event type.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "event": { "type": 3 }, "nodes": [], "edges": [] }
+    ));
+    // Param missing required name/type.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "params": [ { "type": "f32" } ], "nodes": [], "edges": [] }
+    ));
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "params": [ { "name": 1, "type": "f32" } ], "nodes": [], "edges": [] }
+    ));
+    // Subflow `flow` with the wrong type would otherwise leak into extras.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "nodes": [ { "id": 1, "type": "Subflow", "flow": 9 } ], "edges": [] }
+    ));
+}
+
+test "node and edge ids tolerate float-formatted integers" {
+    const src =
+        \\{
+        \\  "nodes": [ { "id": 1.0, "type": "BinOp" }, { "id": 2.0, "type": "BinOp" } ],
+        \\  "edges": [ { "from": { "node": 1.0, "pin": "x" }, "to": { "node": 2.0, "pin": "a" } } ]
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    try std.testing.expectEqual(@as(u32, 1), doc.nodes[0].id);
+    try std.testing.expectEqual(@as(u32, 2), doc.max_node_id);
+    try std.testing.expectEqual(@as(u32, 1), doc.edges[0].from_node);
+    // A genuine fractional id is still rejected.
+    try std.testing.expectError(ParseError.MissingNodeId, parse(std.testing.allocator,
+        \\{ "nodes": [ { "id": 1.5, "type": "BinOp" } ], "edges": [] }
+    ));
+}
+
+test "normalizeValueText keeps valid JSON, quotes anything else" {
+    const a = std.testing.allocator;
+    const cases = [_]struct { in: []const u8, out: []const u8 }{
+        .{ .in = "25", .out = "25" },
+        .{ .in = "  10.5 ", .out = "10.5" },
+        .{ .in = "true", .out = "true" },
+        .{ .in = "\"hi\"", .out = "\"hi\"" },
+        .{ .in = "hello", .out = "\"hello\"" }, // bare word → quoted
+        .{ .in = "\"", .out = "\"\\\"\"" }, // stray quote → escaped
+        .{ .in = "", .out = "\"\"" }, // blank → empty JSON string
+        .{ .in = "  ", .out = "\"\"" },
+    };
+    for (cases) |c| {
+        const got = try normalizeValueText(a, c.in);
+        defer a.free(got);
+        try std.testing.expectEqualStrings(c.out, got);
+    }
+}
+
+test "binding order is deterministic after an edit reorders the slice" {
+    const src =
+        \\{
+        \\  "nodes": [
+        \\    { "id": 1, "type": "Subflow", "flow": "f",
+        \\      "bindings": { "a": 1, "b": 2 }, "pos": [0, 0] }
+        \\  ],
+        \\  "edges": []
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+
+    // Simulate an editor edit that leaves the slice out of sorted order.
+    try std.testing.expectEqual(@as(usize, 2), doc.nodes[0].bindings.len);
+    std.mem.swap(Binding, &doc.nodes[0].bindings[0], &doc.nodes[0].bindings[1]);
+
+    // The writer must still emit a sorted, idempotent result.
+    const text1 = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text1);
+    var doc2 = try parse(std.testing.allocator, text1);
+    defer doc2.deinit();
+    const text2 = try render(std.testing.allocator, doc2);
+    defer std.testing.allocator.free(text2);
+    try std.testing.expectEqualStrings(text1, text2);
+    try std.testing.expect(std.mem.indexOf(u8, text1, "\"a\": 1, \"b\": 2") != null);
 }

--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -1,0 +1,846 @@
+//! Read/write loader for `.flow.jsonc` flow graphs (RFC: Flows as
+//! `.flow.jsonc`, issue #153).
+//!
+//! Flow graphs are *editor-authored content* — a flat `nodes` + `edges`
+//! graph, parsed at build time by flow-codegen into Zig and never read
+//! by the shipped game. The on-disk schema (RFC §2/§3):
+//!
+//! ```jsonc
+//! {
+//!   "name": "enemy_tick",              // optional registry key
+//!   "event": { "type": "OnCreate", "arg_entity": "entity" },
+//!   "params": [                        // optional subgraph interface
+//!     { "name": "damage", "type": "f32", "default": 10.0 }
+//!   ],
+//!   "nodes": [
+//!     { "id": 1, "type": "GetComponent", "pos": [0,0], "component": "Position" }
+//!   ],
+//!   "edges": [
+//!     { "from": { "node": 1, "pin": "x" }, "to": { "node": 3, "pin": "a" } }
+//!   ]
+//! }
+//! ```
+//!
+//! This module owns three things the editor needs:
+//!
+//!  1. **A typed model** (`FlowDoc`) of the schema — `name`, `event`,
+//!     `params`, `nodes`, `edges`. Node types the editor understands
+//!     structurally are `Subflow`, `Param`, and `Output` (RFC §3); every
+//!     other node `type` rides along with its unknown keys captured
+//!     verbatim so an editor save never drops data flow-codegen needs.
+//!  2. **A JSONC reader** — strips `//` line comments (the engine's
+//!     scenes/prefabs do the same) then parses with `std.json`.
+//!  3. **A deterministic writer** — stable key order, fixed two-space
+//!     indent. The same file re-saved byte-for-byte produces the same
+//!     bytes, so editor round-trips keep diffs minimal (RFC open
+//!     question §3, "editor round-trip").
+//!
+//! Determinism rule: every object's keys are emitted in a fixed order
+//! (defined per struct below), node `extras` keys are emitted sorted,
+//! and numbers are formatted canonically (integers without a decimal
+//! point, floats with the minimal representation `std.fmt` gives). A
+//! file authored by hand with a different key order will normalise to
+//! the canonical order on its first editor save — a one-time diff,
+//! stable thereafter.
+
+const std = @import("std");
+const io_global = @import("io_global.zig");
+const scene_io = @import("scene_io.zig");
+
+/// Maximum file size we will read. Flow graphs are tiny hand-authored
+/// documents; 4 MiB is far above anything realistic and guards against
+/// a pathological file.
+const max_flow_bytes: usize = 4 * 1024 * 1024;
+
+/// File extension that marks a flow graph. Used by the project tree
+/// router and the tab display-name helper.
+pub const extension = ".flow.jsonc";
+
+// ─── Typed model ───────────────────────────────────────────────────────
+
+/// A node's structurally-understood `type`. `other` covers every node
+/// `type` the editor doesn't model (BinOp, GetComponent, Literal, …) —
+/// those still round-trip via `Node.extras`, the editor just can't add
+/// or edit their type-specific fields beyond raw key/value.
+pub const NodeKind = enum {
+    /// References another flow by name and binds its `params` (RFC §3).
+    subflow,
+    /// Reads a declared subgraph parameter, exposing it as a pin output.
+    param,
+    /// Names one of the subgraph's result pins.
+    output,
+    /// Any other node type — kind preserved as a string in `type_name`.
+    other,
+
+    pub fn fromTypeName(name: []const u8) NodeKind {
+        if (std.mem.eql(u8, name, "Subflow")) return .subflow;
+        if (std.mem.eql(u8, name, "Param")) return .param;
+        if (std.mem.eql(u8, name, "Output")) return .output;
+        return .other;
+    }
+
+    /// Canonical `type` string for a structurally-understood kind.
+    /// `.other` has no canonical name — callers use `Node.type_name`.
+    pub fn typeName(self: NodeKind) ?[]const u8 {
+        return switch (self) {
+            .subflow => "Subflow",
+            .param => "Param",
+            .output => "Output",
+            .other => null,
+        };
+    }
+};
+
+/// One literal binding on a `Subflow` node — a parameter *name* paired
+/// with a JSON-native literal (RFC §3, `bindings`). Stored as the
+/// verbatim JSON text of the value so any literal type round-trips
+/// without the editor needing to model it.
+pub const Binding = struct {
+    name: []const u8,
+    /// Canonical JSON text of the bound value (e.g. `25`, `10.5`,
+    /// `"hello"`, `true`). Produced by `jsonValueToText`.
+    value_text: []const u8,
+};
+
+/// One declared subgraph parameter (RFC §3, top-level `params`). Its
+/// `name` becomes an input pin on every `Subflow` node referencing the
+/// flow; `type` is a Zig type name; `default` is an optional
+/// JSON-native literal used when a param pin is neither wired nor bound.
+pub const Param = struct {
+    name: []const u8,
+    /// Zig type name, e.g. `"f32"`, `"i32"`, `"bool"`.
+    type_name: []const u8,
+    /// Canonical JSON text of the default value, or null when the
+    /// parameter has no default (then it must be wired or bound).
+    default_text: ?[]const u8 = null,
+};
+
+/// One node in the flat graph. Fields the editor models structurally
+/// live in typed fields; everything else (a node `type`'s own keys, or
+/// keys on a modeled node we don't recognise) is captured in `extras`
+/// so a save round-trips.
+pub const Node = struct {
+    id: u32,
+    /// The raw `type` string from the file. Always set, even for
+    /// structurally-modeled kinds (it equals `kind.typeName()` then).
+    type_name: []const u8,
+    kind: NodeKind,
+    /// Editor canvas position. Defaults to the origin when the file
+    /// omits `pos` (a fresh hand-authored node).
+    pos: [2]f32 = .{ 0, 0 },
+
+    // ── Subflow-specific ──
+    /// The referenced flow's effective name. Empty for non-Subflow.
+    flow_ref: []const u8 = "",
+    /// Literal param bindings (RFC §3). Empty for non-Subflow.
+    bindings: []Binding = &.{},
+
+    // ── Param-specific ──
+    /// The declared parameter this node reads. Empty for non-Param.
+    param_ref: []const u8 = "",
+
+    // ── Output-specific ──
+    /// The result-pin name this node names. Empty for non-Output.
+    output_name: []const u8 = "",
+
+    /// Verbatim key/value pairs not modeled above. Keys are emitted in
+    /// sorted order so the writer is deterministic. Values are canonical
+    /// JSON text.
+    extras: []KeyValue = &.{},
+};
+
+/// A captured-verbatim object entry — a key plus the canonical JSON
+/// text of its value.
+pub const KeyValue = struct {
+    key: []const u8,
+    value_text: []const u8,
+};
+
+/// One graph edge — same `{node, pin}` shape on both ends as `.flow.zon`
+/// used (RFC §2, `links` → `edges` is a rename only).
+pub const Edge = struct {
+    from_node: u32,
+    from_pin: []const u8,
+    to_node: u32,
+    to_pin: []const u8,
+};
+
+/// The flow's entry point. `type` is a lifecycle event name (e.g.
+/// `OnCreate`) or `OnCall` for a subgraph (RFC §3). `arg_entity` and any
+/// other event keys are captured in `extras` so they round-trip.
+pub const Event = struct {
+    type_name: []const u8 = "OnCreate",
+    extras: []KeyValue = &.{},
+};
+
+/// A fully parsed flow graph plus the arena that owns every slice and
+/// string it points at. Caller frees via `deinit`.
+pub const FlowDoc = struct {
+    arena: *std.heap.ArenaAllocator,
+    /// Optional top-level `name` (registry key). Null → effective name
+    /// is the filename basename (RFC §5).
+    name: ?[]const u8 = null,
+    event: Event = .{},
+    params: []Param = &.{},
+    nodes: []Node = &.{},
+    edges: []Edge = &.{},
+    /// Highest node id seen — the editor allocates fresh ids above this.
+    max_node_id: u32 = 0,
+
+    pub fn deinit(self: *FlowDoc) void {
+        const child = self.arena.child_allocator;
+        self.arena.deinit();
+        child.destroy(self.arena);
+    }
+
+    pub fn allocator(self: *FlowDoc) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+
+    /// Allocate a fresh node id one above the current maximum. Bumps
+    /// `max_node_id` so successive calls don't collide.
+    pub fn nextNodeId(self: *FlowDoc) u32 {
+        self.max_node_id += 1;
+        return self.max_node_id;
+    }
+};
+
+// ─── Reader ─────────────────────────────────────────────────────────────
+
+pub const ParseError = error{
+    NotAnObject,
+    MissingNodeId,
+    DuplicateNodeId,
+    BadNodeType,
+    BadEdge,
+} || std.json.ParseError(std.json.Scanner) || std.mem.Allocator.Error;
+
+/// Read and parse a `.flow.jsonc` file from disk.
+pub fn loadFromFile(child_allocator: std.mem.Allocator, path: []const u8) !FlowDoc {
+    const raw = try std.Io.Dir.cwd().readFileAlloc(
+        io_global.io(),
+        path,
+        child_allocator,
+        .limited(max_flow_bytes),
+    );
+    defer child_allocator.free(raw);
+    return parse(child_allocator, raw);
+}
+
+/// Parse JSONC `raw` into a `FlowDoc`. The returned doc owns an arena;
+/// `raw` is not borrowed past this call.
+pub fn parse(child_allocator: std.mem.Allocator, raw: []const u8) !FlowDoc {
+    const arena = try child_allocator.create(std.heap.ArenaAllocator);
+    errdefer child_allocator.destroy(arena);
+    arena.* = std.heap.ArenaAllocator.init(child_allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    // `std.json` rejects comments — strip `//`-to-EOL first, the same
+    // pre-pass `scene_io` runs for scenes and prefabs.
+    const stripped = try scene_io.stripLineComments(a, raw);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, a, stripped, .{});
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return ParseError.NotAnObject;
+    const root = parsed.value.object;
+
+    var doc: FlowDoc = .{ .arena = arena };
+
+    // ── name ──
+    if (root.get("name")) |v| {
+        if (v == .string) doc.name = try a.dupe(u8, v.string);
+    }
+
+    // ── event ──
+    if (root.get("event")) |v| {
+        if (v == .object) doc.event = try parseEvent(a, v.object);
+    }
+
+    // ── params ──
+    if (root.get("params")) |v| {
+        if (v == .array) doc.params = try parseParams(a, v.array);
+    }
+
+    // ── nodes ──
+    if (root.get("nodes")) |v| {
+        if (v == .array) {
+            const r = try parseNodes(a, v.array);
+            doc.nodes = r.nodes;
+            doc.max_node_id = r.max_id;
+        }
+    }
+
+    // ── edges ──
+    if (root.get("edges")) |v| {
+        if (v == .array) doc.edges = try parseEdges(a, v.array);
+    }
+
+    return doc;
+}
+
+fn parseEvent(a: std.mem.Allocator, obj: std.json.ObjectMap) !Event {
+    var ev: Event = .{};
+    var extras: std.ArrayList(KeyValue) = .empty;
+    var it = obj.iterator();
+    while (it.next()) |entry| {
+        const key = entry.key_ptr.*;
+        if (std.mem.eql(u8, key, "type")) {
+            if (entry.value_ptr.* == .string) {
+                ev.type_name = try a.dupe(u8, entry.value_ptr.string);
+            }
+            continue;
+        }
+        try extras.append(a, .{
+            .key = try a.dupe(u8, key),
+            .value_text = try jsonValueToText(a, entry.value_ptr.*),
+        });
+    }
+    sortKeyValues(extras.items);
+    ev.extras = try extras.toOwnedSlice(a);
+    return ev;
+}
+
+fn parseParams(a: std.mem.Allocator, arr: std.json.Array) ![]Param {
+    var out: std.ArrayList(Param) = .empty;
+    for (arr.items) |item| {
+        if (item != .object) continue;
+        const o = item.object;
+        const name = if (o.get("name")) |n| (if (n == .string) n.string else "") else "";
+        const type_name = if (o.get("type")) |t| (if (t == .string) t.string else "f32") else "f32";
+        var p: Param = .{
+            .name = try a.dupe(u8, name),
+            .type_name = try a.dupe(u8, type_name),
+        };
+        if (o.get("default")) |d| {
+            p.default_text = try jsonValueToText(a, d);
+        }
+        try out.append(a, p);
+    }
+    return out.toOwnedSlice(a);
+}
+
+const NodesResult = struct { nodes: []Node, max_id: u32 };
+
+fn parseNodes(a: std.mem.Allocator, arr: std.json.Array) !NodesResult {
+    var out: std.ArrayList(Node) = .empty;
+    var seen: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    var max_id: u32 = 0;
+
+    for (arr.items) |item| {
+        if (item != .object) return ParseError.BadNodeType;
+        const o = item.object;
+
+        const id_v = o.get("id") orelse return ParseError.MissingNodeId;
+        const id: u32 = switch (id_v) {
+            .integer => |n| std.math.cast(u32, n) orelse return ParseError.MissingNodeId,
+            else => return ParseError.MissingNodeId,
+        };
+        if (seen.contains(id)) return ParseError.DuplicateNodeId;
+        try seen.put(a, id, {});
+        if (id > max_id) max_id = id;
+
+        const type_v = o.get("type") orelse return ParseError.BadNodeType;
+        if (type_v != .string) return ParseError.BadNodeType;
+        const type_name = try a.dupe(u8, type_v.string);
+        const kind = NodeKind.fromTypeName(type_name);
+
+        var node: Node = .{ .id = id, .type_name = type_name, .kind = kind };
+
+        // pos
+        if (o.get("pos")) |pv| {
+            if (pv == .array and pv.array.items.len >= 2) {
+                node.pos = .{
+                    jsonNumberAsF32(pv.array.items[0]) orelse 0,
+                    jsonNumberAsF32(pv.array.items[1]) orelse 0,
+                };
+            }
+        }
+
+        // Per-kind structural fields. Keys consumed here are *not*
+        // pushed into extras.
+        var extras: std.ArrayList(KeyValue) = .empty;
+        var it = o.iterator();
+        while (it.next()) |entry| {
+            const key = entry.key_ptr.*;
+            if (std.mem.eql(u8, key, "id") or
+                std.mem.eql(u8, key, "type") or
+                std.mem.eql(u8, key, "pos")) continue;
+
+            if (kind == .subflow and std.mem.eql(u8, key, "flow")) {
+                if (entry.value_ptr.* == .string) {
+                    node.flow_ref = try a.dupe(u8, entry.value_ptr.string);
+                }
+                continue;
+            }
+            if (kind == .subflow and std.mem.eql(u8, key, "bindings")) {
+                if (entry.value_ptr.* == .object) {
+                    node.bindings = try parseBindings(a, entry.value_ptr.object);
+                }
+                continue;
+            }
+            if (kind == .param and std.mem.eql(u8, key, "param")) {
+                if (entry.value_ptr.* == .string) {
+                    node.param_ref = try a.dupe(u8, entry.value_ptr.string);
+                }
+                continue;
+            }
+            if (kind == .output and std.mem.eql(u8, key, "name")) {
+                if (entry.value_ptr.* == .string) {
+                    node.output_name = try a.dupe(u8, entry.value_ptr.string);
+                }
+                continue;
+            }
+
+            try extras.append(a, .{
+                .key = try a.dupe(u8, key),
+                .value_text = try jsonValueToText(a, entry.value_ptr.*),
+            });
+        }
+        sortKeyValues(extras.items);
+        node.extras = try extras.toOwnedSlice(a);
+
+        try out.append(a, node);
+    }
+
+    return .{ .nodes = try out.toOwnedSlice(a), .max_id = max_id };
+}
+
+fn parseBindings(a: std.mem.Allocator, obj: std.json.ObjectMap) ![]Binding {
+    var out: std.ArrayList(Binding) = .empty;
+    var it = obj.iterator();
+    while (it.next()) |entry| {
+        try out.append(a, .{
+            .name = try a.dupe(u8, entry.key_ptr.*),
+            .value_text = try jsonValueToText(a, entry.value_ptr.*),
+        });
+    }
+    // Sort by name for a stable writer order.
+    std.mem.sort(Binding, out.items, {}, struct {
+        fn lt(_: void, x: Binding, y: Binding) bool {
+            return std.mem.lessThan(u8, x.name, y.name);
+        }
+    }.lt);
+    return out.toOwnedSlice(a);
+}
+
+fn parseEdges(a: std.mem.Allocator, arr: std.json.Array) ![]Edge {
+    var out: std.ArrayList(Edge) = .empty;
+    for (arr.items) |item| {
+        if (item != .object) return ParseError.BadEdge;
+        const o = item.object;
+        const from = o.get("from") orelse return ParseError.BadEdge;
+        const to = o.get("to") orelse return ParseError.BadEdge;
+        if (from != .object or to != .object) return ParseError.BadEdge;
+        const fe = try parseEndpoint(a, from.object);
+        const te = try parseEndpoint(a, to.object);
+        try out.append(a, .{
+            .from_node = fe.node,
+            .from_pin = fe.pin,
+            .to_node = te.node,
+            .to_pin = te.pin,
+        });
+    }
+    return out.toOwnedSlice(a);
+}
+
+const Endpoint = struct { node: u32, pin: []const u8 };
+
+fn parseEndpoint(a: std.mem.Allocator, obj: std.json.ObjectMap) !Endpoint {
+    const node_v = obj.get("node") orelse return ParseError.BadEdge;
+    const node: u32 = switch (node_v) {
+        .integer => |n| std.math.cast(u32, n) orelse return ParseError.BadEdge,
+        else => return ParseError.BadEdge,
+    };
+    const pin_v = obj.get("pin") orelse return ParseError.BadEdge;
+    if (pin_v != .string) return ParseError.BadEdge;
+    return .{ .node = node, .pin = try a.dupe(u8, pin_v.string) };
+}
+
+fn jsonNumberAsF32(v: std.json.Value) ?f32 {
+    return switch (v) {
+        .integer => |n| @floatFromInt(n),
+        .float => |f| @floatCast(f),
+        else => null,
+    };
+}
+
+// ─── Canonical JSON value text ─────────────────────────────────────────
+
+/// Render a `std.json.Value` to canonical JSON text — the form the
+/// writer splices verbatim. Determinism rules:
+///   - object keys sorted ascending,
+///   - integers without a fractional part,
+///   - floats via `std.fmt`'s shortest round-trippable form,
+///   - strings escaped per JSON,
+///   - no insignificant whitespace inside the value (compact form).
+pub fn jsonValueToText(a: std.mem.Allocator, v: std.json.Value) ![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(a);
+    try writeJsonValue(a, &out, v);
+    return out.toOwnedSlice(a);
+}
+
+fn writeJsonValue(a: std.mem.Allocator, out: *std.ArrayList(u8), v: std.json.Value) !void {
+    switch (v) {
+        .null => try out.appendSlice(a, "null"),
+        .bool => |b| try out.appendSlice(a, if (b) "true" else "false"),
+        .integer => |n| try out.print(a, "{d}", .{n}),
+        .float => |f| try out.print(a, "{d}", .{f}),
+        .number_string => |s| try out.appendSlice(a, s),
+        .string => |s| try writeJsonString(a, out, s),
+        .array => |arr| {
+            try out.append(a, '[');
+            for (arr.items, 0..) |item, i| {
+                if (i > 0) try out.append(a, ',');
+                try writeJsonValue(a, out, item);
+            }
+            try out.append(a, ']');
+        },
+        .object => |obj| {
+            // Sort keys for determinism.
+            var keys: std.ArrayList([]const u8) = .empty;
+            defer keys.deinit(a);
+            var it = obj.iterator();
+            while (it.next()) |e| try keys.append(a, e.key_ptr.*);
+            std.mem.sort([]const u8, keys.items, {}, struct {
+                fn lt(_: void, x: []const u8, y: []const u8) bool {
+                    return std.mem.lessThan(u8, x, y);
+                }
+            }.lt);
+            try out.append(a, '{');
+            for (keys.items, 0..) |k, i| {
+                if (i > 0) try out.append(a, ',');
+                try writeJsonString(a, out, k);
+                try out.append(a, ':');
+                try writeJsonValue(a, out, obj.get(k).?);
+            }
+            try out.append(a, '}');
+        },
+    }
+}
+
+fn writeJsonString(a: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8) !void {
+    try out.append(a, '"');
+    for (s) |c| {
+        switch (c) {
+            '"' => try out.appendSlice(a, "\\\""),
+            '\\' => try out.appendSlice(a, "\\\\"),
+            '\n' => try out.appendSlice(a, "\\n"),
+            '\r' => try out.appendSlice(a, "\\r"),
+            '\t' => try out.appendSlice(a, "\\t"),
+            0x08 => try out.appendSlice(a, "\\b"),
+            0x0C => try out.appendSlice(a, "\\f"),
+            else => {
+                if (c < 0x20) {
+                    try out.print(a, "\\u{x:0>4}", .{c});
+                } else {
+                    try out.append(a, c);
+                }
+            },
+        }
+    }
+    try out.append(a, '"');
+}
+
+fn sortKeyValues(items: []KeyValue) void {
+    std.mem.sort(KeyValue, items, {}, struct {
+        fn lt(_: void, x: KeyValue, y: KeyValue) bool {
+            return std.mem.lessThan(u8, x.key, y.key);
+        }
+    }.lt);
+}
+
+// ─── Writer ─────────────────────────────────────────────────────────────
+
+const indent_unit = "  ";
+
+/// Render `doc` back to deterministic `.flow.jsonc` text. Key order is
+/// fixed: top-level is `name`, `event`, `params`, `nodes`, `edges`; each
+/// node is `id`, `type`, `pos`, then kind fields, then sorted `extras`.
+/// Re-rendering the output of `parse` is idempotent.
+pub fn render(child_allocator: std.mem.Allocator, doc: FlowDoc) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(child_allocator);
+    const a = child_allocator;
+
+    try out.appendSlice(a, "{\n");
+
+    // name (optional)
+    if (doc.name) |name| {
+        try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, "\"name\": ");
+        try writeJsonString(a, &out, name);
+        try out.appendSlice(a, ",\n");
+    }
+
+    // event
+    try out.appendSlice(a, indent_unit);
+    try out.appendSlice(a, "\"event\": { \"type\": ");
+    try writeJsonString(a, &out, doc.event.type_name);
+    for (doc.event.extras) |kv| {
+        try out.appendSlice(a, ", ");
+        try writeJsonString(a, &out, kv.key);
+        try out.appendSlice(a, ": ");
+        try out.appendSlice(a, kv.value_text);
+    }
+    try out.appendSlice(a, " },\n");
+
+    // params (optional — omitted entirely when empty)
+    if (doc.params.len > 0) {
+        try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, "\"params\": [\n");
+        for (doc.params, 0..) |p, i| {
+            try out.appendSlice(a, indent_unit ** 2);
+            try out.appendSlice(a, "{ \"name\": ");
+            try writeJsonString(a, &out, p.name);
+            try out.appendSlice(a, ", \"type\": ");
+            try writeJsonString(a, &out, p.type_name);
+            if (p.default_text) |d| {
+                try out.appendSlice(a, ", \"default\": ");
+                try out.appendSlice(a, d);
+            }
+            try out.appendSlice(a, " }");
+            if (i + 1 < doc.params.len) try out.append(a, ',');
+            try out.append(a, '\n');
+        }
+        try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, "],\n");
+    }
+
+    // nodes
+    try out.appendSlice(a, indent_unit);
+    try out.appendSlice(a, "\"nodes\": [");
+    if (doc.nodes.len == 0) {
+        try out.appendSlice(a, "],\n");
+    } else {
+        try out.append(a, '\n');
+        for (doc.nodes, 0..) |n, i| {
+            try renderNode(a, &out, n);
+            if (i + 1 < doc.nodes.len) try out.append(a, ',');
+            try out.append(a, '\n');
+        }
+        try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, "],\n");
+    }
+
+    // edges
+    try out.appendSlice(a, indent_unit);
+    try out.appendSlice(a, "\"edges\": [");
+    if (doc.edges.len == 0) {
+        try out.appendSlice(a, "]\n");
+    } else {
+        try out.append(a, '\n');
+        for (doc.edges, 0..) |e, i| {
+            try out.appendSlice(a, indent_unit ** 2);
+            try out.print(a, "{{ \"from\": {{ \"node\": {d}, \"pin\": ", .{e.from_node});
+            try writeJsonString(a, &out, e.from_pin);
+            try out.print(a, " }}, \"to\": {{ \"node\": {d}, \"pin\": ", .{e.to_node});
+            try writeJsonString(a, &out, e.to_pin);
+            try out.appendSlice(a, " } }");
+            if (i + 1 < doc.edges.len) try out.append(a, ',');
+            try out.append(a, '\n');
+        }
+        try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, "]\n");
+    }
+
+    try out.appendSlice(a, "}\n");
+    return out.toOwnedSlice(a);
+}
+
+fn renderNode(a: std.mem.Allocator, out: *std.ArrayList(u8), n: Node) !void {
+    try out.appendSlice(a, indent_unit ** 2);
+    try out.print(a, "{{ \"id\": {d}, \"type\": ", .{n.id});
+    try writeJsonString(a, out, n.type_name);
+
+    // pos — always emitted so a fresh node's origin is explicit.
+    try out.appendSlice(a, ", \"pos\": [");
+    try writeCoord(a, out, n.pos[0]);
+    try out.appendSlice(a, ", ");
+    try writeCoord(a, out, n.pos[1]);
+    try out.append(a, ']');
+
+    switch (n.kind) {
+        .subflow => {
+            try out.appendSlice(a, ", \"flow\": ");
+            try writeJsonString(a, out, n.flow_ref);
+            if (n.bindings.len > 0) {
+                try out.appendSlice(a, ", \"bindings\": { ");
+                for (n.bindings, 0..) |b, i| {
+                    if (i > 0) try out.appendSlice(a, ", ");
+                    try writeJsonString(a, out, b.name);
+                    try out.appendSlice(a, ": ");
+                    try out.appendSlice(a, b.value_text);
+                }
+                try out.appendSlice(a, " }");
+            }
+        },
+        .param => {
+            try out.appendSlice(a, ", \"param\": ");
+            try writeJsonString(a, out, n.param_ref);
+        },
+        .output => {
+            try out.appendSlice(a, ", \"name\": ");
+            try writeJsonString(a, out, n.output_name);
+        },
+        .other => {},
+    }
+
+    for (n.extras) |kv| {
+        try out.appendSlice(a, ", ");
+        try writeJsonString(a, out, kv.key);
+        try out.appendSlice(a, ": ");
+        try out.appendSlice(a, kv.value_text);
+    }
+
+    try out.appendSlice(a, " }");
+}
+
+/// Write a canvas coordinate: integral values lose the `.0` so a
+/// hand-authored `[0, 0]` round-trips unchanged.
+fn writeCoord(a: std.mem.Allocator, out: *std.ArrayList(u8), v: f32) !void {
+    const rounded = @round(v);
+    if (rounded == v and @abs(v) < 1e9) {
+        try out.print(a, "{d}", .{@as(i64, @intFromFloat(rounded))});
+    } else {
+        try out.print(a, "{d}", .{v});
+    }
+}
+
+/// Write `doc` back to disk at `path`, truncating any existing file.
+pub fn saveToFile(child_allocator: std.mem.Allocator, path: []const u8, doc: FlowDoc) !void {
+    const text = try render(child_allocator, doc);
+    defer child_allocator.free(text);
+    try std.Io.Dir.cwd().writeFile(io_global.io(), .{
+        .sub_path = path,
+        .data = text,
+    });
+}
+
+// ─── Path helpers ──────────────────────────────────────────────────────
+
+/// `foo.flow.jsonc` → `foo`. Falls back to the plain basename when the
+/// extension doesn't match.
+pub fn displayNameFromPath(path: []const u8) []const u8 {
+    const base = std.fs.path.basename(path);
+    if (std.mem.endsWith(u8, base, extension)) {
+        return base[0 .. base.len - extension.len];
+    }
+    return base;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────
+
+test "parse flat schema" {
+    const src =
+        \\{
+        \\  // a comment
+        \\  "name": "enemy_tick",
+        \\  "event": { "type": "OnCreate", "arg_entity": "entity" },
+        \\  "nodes": [
+        \\    { "id": 1, "type": "GetComponent", "pos": [0, 0], "component": "Position" },
+        \\    { "id": 3, "type": "BinOp", "op": "add", "pos": [10, 20] }
+        \\  ],
+        \\  "edges": [
+        \\    { "from": { "node": 1, "pin": "x" }, "to": { "node": 3, "pin": "a" } }
+        \\  ]
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+
+    try std.testing.expectEqualStrings("enemy_tick", doc.name.?);
+    try std.testing.expectEqualStrings("OnCreate", doc.event.type_name);
+    try std.testing.expectEqual(@as(usize, 2), doc.nodes.len);
+    try std.testing.expectEqual(@as(u32, 3), doc.max_node_id);
+    try std.testing.expectEqual(@as(usize, 1), doc.edges.len);
+    try std.testing.expectEqualStrings("BinOp", doc.nodes[1].type_name);
+    try std.testing.expectEqual(NodeKind.other, doc.nodes[1].kind);
+    try std.testing.expectEqual(@as(f32, 10), doc.nodes[1].pos[0]);
+}
+
+test "parse subflow / param / output" {
+    const src =
+        \\{
+        \\  "name": "combat_subgraph",
+        \\  "event": { "type": "OnCall" },
+        \\  "params": [ { "name": "damage", "type": "f32", "default": 10.0 } ],
+        \\  "nodes": [
+        \\    { "id": 2, "type": "Param", "param": "damage", "pos": [0, 0] },
+        \\    { "id": 9, "type": "Output", "name": "dealt", "pos": [0, 0] },
+        \\    { "id": 7, "type": "Subflow", "flow": "combat_subgraph", "bindings": { "damage": 25.0 }, "pos": [240, 60] }
+        \\  ],
+        \\  "edges": []
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), doc.params.len);
+    try std.testing.expectEqualStrings("damage", doc.params[0].name);
+    try std.testing.expectEqualStrings("f32", doc.params[0].type_name);
+    try std.testing.expect(doc.params[0].default_text != null);
+
+    try std.testing.expectEqual(NodeKind.param, doc.nodes[0].kind);
+    try std.testing.expectEqualStrings("damage", doc.nodes[0].param_ref);
+
+    try std.testing.expectEqual(NodeKind.output, doc.nodes[1].kind);
+    try std.testing.expectEqualStrings("dealt", doc.nodes[1].output_name);
+
+    try std.testing.expectEqual(NodeKind.subflow, doc.nodes[2].kind);
+    try std.testing.expectEqualStrings("combat_subgraph", doc.nodes[2].flow_ref);
+    try std.testing.expectEqual(@as(usize, 1), doc.nodes[2].bindings.len);
+    try std.testing.expectEqualStrings("damage", doc.nodes[2].bindings[0].name);
+}
+
+test "render is deterministic and idempotent" {
+    const src =
+        \\{
+        \\  "name": "x",
+        \\  "event": { "type": "OnCreate", "arg_entity": "entity" },
+        \\  "params": [ { "name": "p", "type": "i32", "default": 3 } ],
+        \\  "nodes": [
+        \\    { "id": 1, "type": "Param", "param": "p", "pos": [0, 0] },
+        \\    { "id": 2, "type": "BinOp", "op": "add", "pos": [5, 7] }
+        \\  ],
+        \\  "edges": [
+        \\    { "from": { "node": 1, "pin": "value" }, "to": { "node": 2, "pin": "a" } }
+        \\  ]
+        \\}
+    ;
+    var doc1 = try parse(std.testing.allocator, src);
+    defer doc1.deinit();
+    const text1 = try render(std.testing.allocator, doc1);
+    defer std.testing.allocator.free(text1);
+
+    // Re-parse the rendered text and re-render — must be byte-identical.
+    var doc2 = try parse(std.testing.allocator, text1);
+    defer doc2.deinit();
+    const text2 = try render(std.testing.allocator, doc2);
+    defer std.testing.allocator.free(text2);
+
+    try std.testing.expectEqualStrings(text1, text2);
+}
+
+test "empty graph round-trips" {
+    const src =
+        \\{ "event": { "type": "OnCall" }, "nodes": [], "edges": [] }
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+
+    var doc2 = try parse(std.testing.allocator, text);
+    defer doc2.deinit();
+    const text2 = try render(std.testing.allocator, doc2);
+    defer std.testing.allocator.free(text2);
+    try std.testing.expectEqualStrings(text, text2);
+}
+
+test "displayNameFromPath strips extension" {
+    try std.testing.expectEqualStrings("enemy_tick", displayNameFromPath("a/b/enemy_tick.flow.jsonc"));
+    try std.testing.expectEqualStrings("other.zig", displayNameFromPath("x/other.zig"));
+}

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -165,26 +165,45 @@ fn renderCanvas(s: *FlowDocState) void {
     // Edges. Pin ids are recomputed from the endpoint's node + pin
     // name; a pin that doesn't exist on the node still gets a stable
     // synthetic id so the link draws.
-    for (s.doc.edges, 0..) |e, i| {
+    for (s.doc.edges) |e| {
         const from_pin = pinId(e.from_node, e.from_pin, .output);
         const to_pin = pinId(e.to_node, e.to_pin, .input);
-        const link_id: u64 = 0x1_0000_0000 + @as(u64, @intCast(i));
-        _ = ne.link(link_id, from_pin, to_pin, .{ 0.4, 0.8, 1.0, 1.0 }, 1.5);
+        _ = ne.link(linkId(e), from_pin, to_pin, .{ 0.4, 0.8, 1.0, 1.0 }, 1.5);
     }
+}
+
+/// Deterministic global link id for an edge.
+///
+/// Derived from a hash of the edge's four endpoint components, with bit
+/// 63 forced set so the id can never collide with a node id (small
+/// integers) or a pin id (`pinId` only ever sets bits up to 62). Hashing
+/// the endpoints — rather than using the edge's array index — keeps the
+/// id stable when edges are added or removed, so the node editor's
+/// per-link selection state doesn't jump to a different edge after an
+/// edit.
+fn linkId(e: flow_io.Edge) u64 {
+    var h = std.hash.Wyhash.init(0x11f0);
+    h.update(std.mem.asBytes(&e.from_node));
+    h.update(e.from_pin);
+    h.update(&[_]u8{0}); // delimiter so (pin "ab"|node) ≠ (pin "a"|"b"node)
+    h.update(std.mem.asBytes(&e.to_node));
+    h.update(e.to_pin);
+    return (h.final() & 0x7FFF_FFFF_FFFF_FFFF) | (@as(u64, 1) << 63);
 }
 
 const PinDir = enum { input, output };
 
 /// Deterministic global pin id from a node id, pin name, and
-/// direction. The node id occupies the low 20 bits, a name hash the
-/// next bits, and the direction the top bit — collisions across the
-/// graphs we author are astronomically unlikely and a collision only
-/// costs a mis-drawn link, never data loss.
+/// direction. Layout: bits 0–29 a name hash, bits 30–61 the node id,
+/// bit 62 the direction (set for outputs). Bit 63 is left clear so the
+/// whole pin-id space stays disjoint from link ids (`linkId` always
+/// sets bit 63). Collisions within the name-hash bits are astronomically
+/// unlikely and only cost a mis-drawn link, never data loss.
 fn pinId(node: u32, name: []const u8, dir: PinDir) u64 {
     var h = std.hash.Wyhash.init(node);
     h.update(name);
     const base = (h.final() & 0x3FFF_FFFF) | (@as(u64, node) << 30);
-    return if (dir == .output) base | (1 << 62) else base;
+    return if (dir == .output) base | (@as(u64, 1) << 62) else base;
 }
 
 fn renderNodeBody(s: *FlowDocState, n: flow_io.Node) void {
@@ -290,7 +309,14 @@ fn renderParamsEditor(s: *FlowDocState) void {
         const def_id = std.fmt.bufPrintZ(&id_buf, "##pdef{d}", .{i}) catch "##pd";
         if (zgui.inputText(def_id, .{ .buf = &def_buf })) {
             const txt = std.mem.sliceTo(&def_buf, 0);
-            p.default_text = if (txt.len == 0) null else (dupZ(a, &def_buf) catch p.default_text);
+            // The raw text is normalised to canonical JSON value text so
+            // a save can never emit invalid `.flow.jsonc` — a bare word
+            // becomes a quoted string, `25` stays `25`. Blank → no
+            // default (the param must then be wired or bound).
+            p.default_text = if (txt.len == 0)
+                null
+            else
+                (flow_io.normalizeValueText(a, txt) catch p.default_text);
             s.is_dirty = true;
         }
         zgui.sameLine(.{});
@@ -432,7 +458,10 @@ fn renderBindingsEditor(s: *FlowDocState, n: *flow_io.Node) void {
         seedBuf(&val_buf, b.value_text);
         const val_id = std.fmt.bufPrintZ(&id_buf, "##bv{d}", .{i}) catch "##bv";
         if (zgui.inputText(val_id, .{ .buf = &val_buf })) {
-            b.value_text = dupZ(a, &val_buf) catch b.value_text;
+            // Normalise so the bound literal is always valid JSON text;
+            // see `renderParamsEditor` for the rationale.
+            const txt = std.mem.sliceTo(&val_buf, 0);
+            b.value_text = flow_io.normalizeValueText(a, txt) catch b.value_text;
             s.is_dirty = true;
         }
         zgui.sameLine(.{});
@@ -442,15 +471,25 @@ fn renderBindingsEditor(s: *FlowDocState, n: *flow_io.Node) void {
     zgui.textDisabled("(param name / JSON literal — e.g. 25 or \"txt\")", .{});
 
     if (zgui.button("+ Add binding", .{})) {
-        n.bindings = growBindings(a, n.bindings, .{
+        // Only mark dirty if the grow actually succeeded — a failed
+        // allocation leaves `n.bindings` unchanged.
+        if (growBindings(a, n.bindings, .{
             .name = "param",
             .value_text = "0",
-        }) catch n.bindings;
-        s.is_dirty = true;
+        })) |grown| {
+            n.bindings = grown;
+            s.is_dirty = true;
+        } else |err| {
+            std.log.err("flow: add binding failed: {s}", .{@errorName(err)});
+        }
     }
     if (remove_idx) |idx| {
-        n.bindings = removeAt(flow_io.Binding, a, n.bindings, idx) catch n.bindings;
-        s.is_dirty = true;
+        if (removeAt(flow_io.Binding, a, n.bindings, idx)) |shrunk| {
+            n.bindings = shrunk;
+            s.is_dirty = true;
+        } else |err| {
+            std.log.err("flow: remove binding failed: {s}", .{@errorName(err)});
+        }
     }
 }
 

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -1,0 +1,587 @@
+//! `.flow.jsonc` flow-graph editor — per-tab state and rendering
+//! (RFC: Flows as `.flow.jsonc`, issue #153).
+//!
+//! This is the *authoring* counterpart to `modules/flow.zig`. Where
+//! `flow.zig` is a read-only viewer derived from a `.zig` script,
+//! this editor loads, edits, and writes the `.flow.jsonc` content
+//! format described by the RFC: a flat `nodes` + `edges` graph with a
+//! top-level `event`, an optional subgraph `params` interface, and the
+//! `Subflow` / `Param` / `Output` composition node types.
+//!
+//! Layout — two columns:
+//!   - Left: an imgui-node-editor canvas. Each node is one editor
+//!     node; positions persist into `flow_io.Node.pos` so a save keeps
+//!     the layout. Edges are drawn from `flow_io.Edge`.
+//!   - Right: an inspector. Top section is the subgraph `params`
+//!     editor (declare name/type/default, RFC §3). Below it is the
+//!     node palette (add `Subflow` / `Param` / `Output` / a custom
+//!     typed node) and the selected node's editable fields.
+//!
+//! Scope (v1): structural editing — add/remove nodes, edit the typed
+//! fields of the three composition node types, edit `params`, edit the
+//! event type, move nodes on the canvas. Edge creation by dragging
+//! pins and a load-time cycle check across `Subflow` references are
+//! deferred — see the PR notes. Unknown node types (`BinOp`, …) and
+//! their fields round-trip verbatim through `flow_io` but aren't
+//! field-editable here.
+
+const std = @import("std");
+const zgui = @import("zgui");
+const ne = zgui.node_editor;
+
+const App = @import("../app.zig").App;
+const flow_io = @import("../flow_io.zig");
+
+const inspector_w: f32 = 340;
+const split_gap: f32 = 8;
+
+/// Edit-buffer size for short identifier fields (param names, type
+/// names, flow refs). Comfortably above any realistic identifier.
+const ident_buf_len: usize = 128;
+const IdentBuf = [ident_buf_len:0]u8;
+
+/// Edit-buffer size for a literal value (a `default` or a `binding`).
+const value_buf_len: usize = 256;
+const ValueBuf = [value_buf_len:0]u8;
+
+/// Per-tab state for an open `.flow.jsonc` file.
+pub const FlowDocState = struct {
+    arena: *std.heap.ArenaAllocator,
+    path: []const u8,
+    display_name: []const u8,
+    /// The parsed + editable document. Owns its own arena.
+    doc: flow_io.FlowDoc,
+    /// imgui-node-editor per-canvas state — node positions, selection,
+    /// view transform.
+    editor: *ne.EditorContext,
+    is_dirty: bool = false,
+    /// True until the first frame applies node positions to the editor
+    /// (the editor's node store starts empty; we seed it from
+    /// `doc.nodes[].pos` once).
+    needs_layout: bool = true,
+
+    pub fn open(allocator: std.mem.Allocator, path: []const u8) !FlowDocState {
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const a = arena.allocator();
+        const path_dup = try a.dupe(u8, path);
+        const display_name = flow_io.displayNameFromPath(path_dup);
+
+        var doc = try flow_io.loadFromFile(allocator, path);
+        errdefer doc.deinit();
+
+        const config: ne.Config = .{};
+        const editor = ne.EditorContext.create(config);
+        errdefer editor.destroy();
+
+        return .{
+            .arena = arena,
+            .path = path_dup,
+            .display_name = display_name,
+            .doc = doc,
+            .editor = editor,
+        };
+    }
+
+    pub fn deinit(self: *FlowDocState, allocator: std.mem.Allocator) void {
+        self.editor.destroy();
+        self.doc.deinit();
+        self.arena.deinit();
+        allocator.destroy(self.arena);
+    }
+};
+
+/// Public entry point — `OpenTab.render` dispatches here.
+pub fn render(s: *FlowDocState, app: *App) void {
+    zgui.text("Flow: {s}", .{s.display_name});
+    if (s.is_dirty) {
+        zgui.sameLine(.{});
+        zgui.textColored(.{ 1.0, 0.5, 0.0, 1.0 }, "(unsaved)", .{});
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("Save", .{})) saveFlowDoc(s, app);
+    zgui.sameLine(.{});
+    zgui.textDisabled("(.flow.jsonc — flat graph editor)", .{});
+    zgui.separator();
+
+    const total_w = zgui.getContentRegionAvail()[0];
+    const canvas_w = @max(160.0, total_w - inspector_w - split_gap);
+
+    if (zgui.beginChild("##flowdoc_canvas", .{ .w = canvas_w, .h = 0 })) {
+        renderCanvas(s);
+    }
+    zgui.endChild();
+    zgui.sameLine(.{});
+    if (zgui.beginChild("##flowdoc_inspector", .{
+        .w = 0,
+        .h = 0,
+        .child_flags = .{ .border = true },
+    })) {
+        renderInspector(s);
+    }
+    zgui.endChild();
+}
+
+// ─── Canvas ─────────────────────────────────────────────────────────────
+
+fn renderCanvas(s: *FlowDocState) void {
+    ne.setCurrentEditor(s.editor);
+    defer ne.setCurrentEditor(null);
+
+    ne.begin("##flowdoc_canvas_ne", .{ 0, 0 });
+    defer ne.end();
+
+    // Seed positions from the document the first frame. After that the
+    // editor owns positions; we read them back on save.
+    if (s.needs_layout) {
+        for (s.doc.nodes) |n| {
+            ne.setNodePosition(@intCast(n.id), n.pos);
+        }
+        s.needs_layout = false;
+    }
+
+    // Pull live positions back into the document so a Save persists
+    // the user's layout. Cheap — one lookup per node per frame.
+    for (s.doc.nodes) |*n| {
+        const p = ne.getNodePosition(@intCast(n.id));
+        if (p[0] != n.pos[0] or p[1] != n.pos[1]) {
+            n.pos = p;
+            s.is_dirty = true;
+        }
+    }
+
+    // Pin ids must be globally unique and stable. We derive them from
+    // (node_id, pin_index, direction) — packed into the high bits so
+    // they never collide with node ids or edge ids.
+    for (s.doc.nodes) |n| {
+        ne.beginNode(@intCast(n.id));
+        renderNodeBody(s, n);
+        ne.endNode();
+    }
+
+    // Edges. Pin ids are recomputed from the endpoint's node + pin
+    // name; a pin that doesn't exist on the node still gets a stable
+    // synthetic id so the link draws.
+    for (s.doc.edges, 0..) |e, i| {
+        const from_pin = pinId(e.from_node, e.from_pin, .output);
+        const to_pin = pinId(e.to_node, e.to_pin, .input);
+        const link_id: u64 = 0x1_0000_0000 + @as(u64, @intCast(i));
+        _ = ne.link(link_id, from_pin, to_pin, .{ 0.4, 0.8, 1.0, 1.0 }, 1.5);
+    }
+}
+
+const PinDir = enum { input, output };
+
+/// Deterministic global pin id from a node id, pin name, and
+/// direction. The node id occupies the low 20 bits, a name hash the
+/// next bits, and the direction the top bit — collisions across the
+/// graphs we author are astronomically unlikely and a collision only
+/// costs a mis-drawn link, never data loss.
+fn pinId(node: u32, name: []const u8, dir: PinDir) u64 {
+    var h = std.hash.Wyhash.init(node);
+    h.update(name);
+    const base = (h.final() & 0x3FFF_FFFF) | (@as(u64, node) << 30);
+    return if (dir == .output) base | (1 << 62) else base;
+}
+
+fn renderNodeBody(s: *FlowDocState, n: flow_io.Node) void {
+    _ = s;
+    zgui.text("[{d}] {s}", .{ n.id, n.type_name });
+    switch (n.kind) {
+        .subflow => {
+            zgui.textDisabled("flow: {s}", .{n.flow_ref});
+            // One input pin per binding; output pins are unknown to the
+            // editor without resolving the referenced flow (deferred).
+            for (n.bindings) |b| {
+                ne.beginPin(pinId(n.id, b.name, .input), .input);
+                zgui.text("> {s}", .{b.name});
+                ne.endPin();
+            }
+        },
+        .param => {
+            zgui.textDisabled("param: {s}", .{n.param_ref});
+            ne.beginPin(pinId(n.id, "value", .output), .output);
+            zgui.text("value >", .{});
+            ne.endPin();
+        },
+        .output => {
+            zgui.textDisabled("output: {s}", .{n.output_name});
+            ne.beginPin(pinId(n.id, "value", .input), .input);
+            zgui.text("> value", .{});
+            ne.endPin();
+        },
+        .other => {
+            // Show extras as a compact hint so the user can tell nodes
+            // apart even though the editor can't field-edit them.
+            for (n.extras) |kv| {
+                zgui.textDisabled("{s}: {s}", .{ kv.key, kv.value_text });
+            }
+        },
+    }
+}
+
+// ─── Inspector ──────────────────────────────────────────────────────────
+
+fn renderInspector(s: *FlowDocState) void {
+    renderEventEditor(s);
+    zgui.spacing();
+    zgui.separator();
+    renderParamsEditor(s);
+    zgui.spacing();
+    zgui.separator();
+    renderNodePalette(s);
+    zgui.spacing();
+    zgui.separator();
+    renderSelectedNode(s);
+}
+
+fn renderEventEditor(s: *FlowDocState) void {
+    zgui.text("Event", .{});
+    const a = s.doc.allocator();
+    // Static event buffer — re-seeded each frame from the doc so an
+    // external reload (none in v1) wouldn't desync, and so the buffer
+    // tracks the current value.
+    var buf: IdentBuf = undefined;
+    seedBuf(&buf, s.doc.event.type_name);
+    if (zgui.inputText("##flow_event_type", .{ .buf = &buf })) {
+        s.doc.event.type_name = dupZ(a, &buf) catch s.doc.event.type_name;
+        s.is_dirty = true;
+    }
+    zgui.sameLine(.{});
+    zgui.textDisabled("type", .{});
+}
+
+fn renderParamsEditor(s: *FlowDocState) void {
+    zgui.text("Parameters", .{});
+    zgui.textDisabled("Subgraph input interface (RFC §3).", .{});
+
+    const a = s.doc.allocator();
+    var remove_idx: ?usize = null;
+    var id_buf: [64]u8 = undefined;
+
+    for (s.doc.params, 0..) |*p, i| {
+        zgui.pushIntId(@intCast(i));
+        defer zgui.popId();
+
+        zgui.setNextItemWidth(110);
+        var name_buf: IdentBuf = undefined;
+        seedBuf(&name_buf, p.name);
+        const name_id = std.fmt.bufPrintZ(&id_buf, "##pname{d}", .{i}) catch "##pn";
+        if (zgui.inputText(name_id, .{ .buf = &name_buf })) {
+            p.name = dupZ(a, &name_buf) catch p.name;
+            s.is_dirty = true;
+        }
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(70);
+        var type_buf: IdentBuf = undefined;
+        seedBuf(&type_buf, p.type_name);
+        const type_id = std.fmt.bufPrintZ(&id_buf, "##ptype{d}", .{i}) catch "##pt";
+        if (zgui.inputText(type_id, .{ .buf = &type_buf })) {
+            p.type_name = dupZ(a, &type_buf) catch p.type_name;
+            s.is_dirty = true;
+        }
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(80);
+        var def_buf: ValueBuf = undefined;
+        seedBuf(&def_buf, p.default_text orelse "");
+        const def_id = std.fmt.bufPrintZ(&id_buf, "##pdef{d}", .{i}) catch "##pd";
+        if (zgui.inputText(def_id, .{ .buf = &def_buf })) {
+            const txt = std.mem.sliceTo(&def_buf, 0);
+            p.default_text = if (txt.len == 0) null else (dupZ(a, &def_buf) catch p.default_text);
+            s.is_dirty = true;
+        }
+        zgui.sameLine(.{});
+        const x_id = std.fmt.bufPrintZ(&id_buf, "x##prm{d}", .{i}) catch "x";
+        if (zgui.smallButton(x_id)) remove_idx = i;
+    }
+    zgui.textDisabled("(name / type / default — default may be blank)", .{});
+
+    if (zgui.button("+ Add parameter", .{})) {
+        appendParam(s) catch |err| {
+            std.log.err("flow: add param failed: {s}", .{@errorName(err)});
+        };
+    }
+    if (remove_idx) |idx| {
+        removeParam(s, idx) catch |err| {
+            std.log.err("flow: remove param failed: {s}", .{@errorName(err)});
+        };
+    }
+}
+
+fn renderNodePalette(s: *FlowDocState) void {
+    zgui.text("Add node", .{});
+    if (zgui.button("+ Subflow", .{})) {
+        addNode(s, .subflow) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ Param", .{})) {
+        addNode(s, .param) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ Output", .{})) {
+        addNode(s, .output) catch |err| nodeAddErr(err);
+    }
+}
+
+fn nodeAddErr(err: anyerror) void {
+    std.log.err("flow: add node failed: {s}", .{@errorName(err)});
+}
+
+fn renderSelectedNode(s: *FlowDocState) void {
+    zgui.text("Selected node", .{});
+
+    ne.setCurrentEditor(s.editor);
+    var ids: [4]u64 = undefined;
+    const count = ne.getSelectedNodes(ids[0..]);
+    ne.setCurrentEditor(null);
+
+    if (count <= 0) {
+        zgui.textDisabled("Click a node on the canvas.", .{});
+        return;
+    }
+    const sel_id: u32 = @intCast(ids[0]);
+    var node: ?*flow_io.Node = null;
+    for (s.doc.nodes) |*n| {
+        if (n.id == sel_id) {
+            node = n;
+            break;
+        }
+    }
+    const n = node orelse {
+        zgui.textDisabled("Selection not found.", .{});
+        return;
+    };
+
+    const a = s.doc.allocator();
+    zgui.textDisabled("id {d} — type {s}", .{ n.id, n.type_name });
+
+    switch (n.kind) {
+        .subflow => {
+            zgui.text("Referenced flow", .{});
+            var fbuf: IdentBuf = undefined;
+            seedBuf(&fbuf, n.flow_ref);
+            if (zgui.inputText("##sf_flow", .{ .buf = &fbuf })) {
+                n.flow_ref = dupZ(a, &fbuf) catch n.flow_ref;
+                s.is_dirty = true;
+            }
+            zgui.spacing();
+            zgui.text("Bindings (literal param values)", .{});
+            renderBindingsEditor(s, n);
+        },
+        .param => {
+            zgui.text("Reads parameter", .{});
+            var pbuf: IdentBuf = undefined;
+            seedBuf(&pbuf, n.param_ref);
+            if (zgui.inputText("##pm_ref", .{ .buf = &pbuf })) {
+                n.param_ref = dupZ(a, &pbuf) catch n.param_ref;
+                s.is_dirty = true;
+            }
+            if (n.param_ref.len > 0 and !paramDeclared(s, n.param_ref)) {
+                zgui.textColored(.{ 1.0, 0.4, 0.4, 1.0 }, "(undeclared parameter)", .{});
+            }
+        },
+        .output => {
+            zgui.text("Result pin name", .{});
+            var obuf: IdentBuf = undefined;
+            seedBuf(&obuf, n.output_name);
+            if (zgui.inputText("##out_name", .{ .buf = &obuf })) {
+                n.output_name = dupZ(a, &obuf) catch n.output_name;
+                s.is_dirty = true;
+            }
+        },
+        .other => {
+            zgui.textDisabled("This node type is not field-editable in v1.", .{});
+            zgui.textDisabled("Its fields round-trip verbatim:", .{});
+            for (n.extras) |kv| {
+                zgui.bulletText("{s}: {s}", .{ kv.key, kv.value_text });
+            }
+        },
+    }
+
+    zgui.spacing();
+    if (zgui.button("Delete node", .{})) {
+        deleteNode(s, n.id) catch |err| {
+            std.log.err("flow: delete node failed: {s}", .{@errorName(err)});
+        };
+    }
+}
+
+fn renderBindingsEditor(s: *FlowDocState, n: *flow_io.Node) void {
+    const a = s.doc.allocator();
+    var remove_idx: ?usize = null;
+    var id_buf: [64]u8 = undefined;
+
+    for (n.bindings, 0..) |*b, i| {
+        zgui.pushIntId(@intCast(i));
+        defer zgui.popId();
+
+        zgui.setNextItemWidth(110);
+        var name_buf: IdentBuf = undefined;
+        seedBuf(&name_buf, b.name);
+        const name_id = std.fmt.bufPrintZ(&id_buf, "##bn{d}", .{i}) catch "##bn";
+        if (zgui.inputText(name_id, .{ .buf = &name_buf })) {
+            b.name = dupZ(a, &name_buf) catch b.name;
+            s.is_dirty = true;
+        }
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(110);
+        var val_buf: ValueBuf = undefined;
+        seedBuf(&val_buf, b.value_text);
+        const val_id = std.fmt.bufPrintZ(&id_buf, "##bv{d}", .{i}) catch "##bv";
+        if (zgui.inputText(val_id, .{ .buf = &val_buf })) {
+            b.value_text = dupZ(a, &val_buf) catch b.value_text;
+            s.is_dirty = true;
+        }
+        zgui.sameLine(.{});
+        const x_id = std.fmt.bufPrintZ(&id_buf, "x##bx{d}", .{i}) catch "x";
+        if (zgui.smallButton(x_id)) remove_idx = i;
+    }
+    zgui.textDisabled("(param name / JSON literal — e.g. 25 or \"txt\")", .{});
+
+    if (zgui.button("+ Add binding", .{})) {
+        n.bindings = growBindings(a, n.bindings, .{
+            .name = "param",
+            .value_text = "0",
+        }) catch n.bindings;
+        s.is_dirty = true;
+    }
+    if (remove_idx) |idx| {
+        n.bindings = removeAt(flow_io.Binding, a, n.bindings, idx) catch n.bindings;
+        s.is_dirty = true;
+    }
+}
+
+// ─── Mutators ───────────────────────────────────────────────────────────
+
+fn appendParam(s: *FlowDocState) !void {
+    const a = s.doc.allocator();
+    s.doc.params = try growParams(a, s.doc.params, .{
+        .name = try a.dupe(u8, "param"),
+        .type_name = try a.dupe(u8, "f32"),
+        .default_text = null,
+    });
+    s.is_dirty = true;
+}
+
+fn removeParam(s: *FlowDocState, idx: usize) !void {
+    const a = s.doc.allocator();
+    s.doc.params = try removeAt(flow_io.Param, a, s.doc.params, idx);
+    s.is_dirty = true;
+}
+
+fn addNode(s: *FlowDocState, kind: flow_io.NodeKind) !void {
+    const a = s.doc.allocator();
+    const id = s.doc.nextNodeId();
+    const type_name = kind.typeName() orelse return error.UnsupportedKind;
+
+    // Place new nodes in a staggered cascade so they don't all stack
+    // on the origin.
+    const offset: f32 = @floatFromInt((s.doc.nodes.len % 8) * 30);
+    var node: flow_io.Node = .{
+        .id = id,
+        .type_name = try a.dupe(u8, type_name),
+        .kind = kind,
+        .pos = .{ 40 + offset, 40 + offset },
+    };
+    switch (kind) {
+        .subflow => node.flow_ref = try a.dupe(u8, ""),
+        .param => node.param_ref = try a.dupe(u8, ""),
+        .output => node.output_name = try a.dupe(u8, "result"),
+        .other => unreachable,
+    }
+    s.doc.nodes = try growNodes(a, s.doc.nodes, node);
+    s.needs_layout = true; // re-seed so the new node's pos is applied
+    s.is_dirty = true;
+}
+
+fn deleteNode(s: *FlowDocState, id: u32) !void {
+    const a = s.doc.allocator();
+    // Find the index.
+    var idx: ?usize = null;
+    for (s.doc.nodes, 0..) |n, i| {
+        if (n.id == id) {
+            idx = i;
+            break;
+        }
+    }
+    const i = idx orelse return;
+    s.doc.nodes = try removeAt(flow_io.Node, a, s.doc.nodes, i);
+    // Drop any edges touching the deleted node.
+    var kept: std.ArrayList(flow_io.Edge) = .empty;
+    for (s.doc.edges) |e| {
+        if (e.from_node == id or e.to_node == id) continue;
+        try kept.append(a, e);
+    }
+    s.doc.edges = try kept.toOwnedSlice(a);
+    s.is_dirty = true;
+}
+
+// ─── Slice helpers ──────────────────────────────────────────────────────
+
+fn growNodes(a: std.mem.Allocator, src: []flow_io.Node, add: flow_io.Node) ![]flow_io.Node {
+    const out = try a.alloc(flow_io.Node, src.len + 1);
+    @memcpy(out[0..src.len], src);
+    out[src.len] = add;
+    return out;
+}
+
+fn growParams(a: std.mem.Allocator, src: []flow_io.Param, add: flow_io.Param) ![]flow_io.Param {
+    const out = try a.alloc(flow_io.Param, src.len + 1);
+    @memcpy(out[0..src.len], src);
+    out[src.len] = add;
+    return out;
+}
+
+fn growBindings(a: std.mem.Allocator, src: []flow_io.Binding, add: flow_io.Binding) ![]flow_io.Binding {
+    const out = try a.alloc(flow_io.Binding, src.len + 1);
+    @memcpy(out[0..src.len], src);
+    out[src.len] = .{
+        .name = try a.dupe(u8, add.name),
+        .value_text = try a.dupe(u8, add.value_text),
+    };
+    return out;
+}
+
+fn removeAt(comptime T: type, a: std.mem.Allocator, src: []T, idx: usize) ![]T {
+    if (idx >= src.len) return src;
+    const out = try a.alloc(T, src.len - 1);
+    @memcpy(out[0..idx], src[0..idx]);
+    @memcpy(out[idx..], src[idx + 1 ..]);
+    return out;
+}
+
+fn paramDeclared(s: *FlowDocState, name: []const u8) bool {
+    for (s.doc.params) |p| {
+        if (std.mem.eql(u8, p.name, name)) return true;
+    }
+    return false;
+}
+
+// ─── Buffer helpers ─────────────────────────────────────────────────────
+
+/// Copy `src` into a fixed-size sentinel buffer, zero-padding the rest.
+fn seedBuf(buf: anytype, src: []const u8) void {
+    @memset(buf, 0);
+    const n = @min(buf.len - 1, src.len);
+    @memcpy(buf[0..n], src[0..n]);
+}
+
+/// Duplicate the live text of a sentinel buffer onto `a`.
+fn dupZ(a: std.mem.Allocator, buf: anytype) ![]const u8 {
+    return a.dupe(u8, std.mem.sliceTo(buf, 0));
+}
+
+// ─── Save ───────────────────────────────────────────────────────────────
+
+pub fn saveFlowDoc(s: *FlowDocState, app: *App) void {
+    flow_io.saveToFile(app.allocator, s.path, s.doc) catch |err| {
+        std.log.err("Flow save failed at {s}: {s}", .{ s.path, @errorName(err) });
+        app.setStatus("Error saving flow!");
+        return;
+    };
+    s.is_dirty = false;
+    app.setStatus("Flow saved!");
+}

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -11,6 +11,7 @@ const App = @import("../app.zig").App;
 const module = @import("../module.zig");
 const config = @import("../config.zig");
 const project = @import("../project.zig");
+const flow_io = @import("../flow_io.zig");
 
 pub fn makeModule(app: *App) module.Module {
     return .{
@@ -39,16 +40,32 @@ pub fn isPrefabPath(proj_dir: ?[]const u8, path: []const u8) bool {
 
 /// Return true when `path` is a `.zig` file under the project's
 /// `scripts/flows/` directory. Drives routing of tree clicks into
-/// the Flow viewer (issues #48 + #49, umbrella #42).
+/// the read-only Flow *viewer* (issues #48 + #49, umbrella #42).
 ///
-/// Schema choice: the visualization layer is *derived* from Zig
-/// scripts. There is no `.flow.*` file format — the source of
-/// truth is the underlying Zig the engine actually compiles. The
-/// gui's projector (`src/flows/projector.zig`) parses the file via
-/// `std.zig.Ast` and renders it as a node graph.
+/// This viewer projects a hand-written Zig script into a node graph
+/// (`src/flows/projector.zig`, via `std.zig.Ast`). The authored
+/// `.flow.jsonc` content format is a separate route — see
+/// `isFlowDocPath` and the Flows-as-`.flow.jsonc` RFC (issue #153).
 pub fn isFlowPath(proj_dir: ?[]const u8, path: []const u8) bool {
     const dir = proj_dir orelse return false;
     if (!std.mem.endsWith(u8, path, ".zig")) return false;
+    var prefix_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const prefix = std.fmt.bufPrint(
+        &prefix_buf,
+        "{s}/{s}/{s}/",
+        .{ dir, project.ProjectFolders.scripts, "flows" },
+    ) catch return false;
+    return std.mem.startsWith(u8, path, prefix);
+}
+
+/// Return true when `path` is a `.flow.jsonc` file under the project's
+/// `scripts/flows/` directory — the *authored* flow-graph content
+/// format (RFC: Flows as `.flow.jsonc`, issue #153). Routes a tree
+/// click into the flow-graph editor (`modules/flow_doc.zig`). Distinct
+/// from `isFlowPath`, which matches the read-only `.zig` viewer.
+pub fn isFlowDocPath(proj_dir: ?[]const u8, path: []const u8) bool {
+    const dir = proj_dir orelse return false;
+    if (!std.mem.endsWith(u8, path, flow_io.extension)) return false;
     var prefix_buf: [std.fs.max_path_bytes]u8 = undefined;
     const prefix = std.fmt.bufPrint(
         &prefix_buf,
@@ -121,6 +138,11 @@ fn render(app: *App) void {
                         app.openPrefab(path) catch |err| {
                             std.log.err("Failed to open prefab {s}: {s}", .{ path, @errorName(err) });
                             app.setStatus("Error opening prefab!");
+                        };
+                    } else if (isFlowDocPath(proj_dir, path)) {
+                        app.openFlowDoc(path) catch |err| {
+                            std.log.err("Failed to open flow {s}: {s}", .{ path, @errorName(err) });
+                            app.setStatus("Error opening flow!");
                         };
                     } else if (isFlowPath(proj_dir, path)) {
                         app.openFlow(path) catch |err| {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -12,6 +12,7 @@ const project_tree = @import("modules/project_tree.zig");
 const viewport = @import("modules/viewport.zig");
 const atlas = @import("atlas.zig");
 const gizmo_io = @import("gizmo_io.zig");
+const flow_io = @import("flow_io.zig");
 const gizmos = @import("gizmos.zig");
 const preview = @import("preview.zig");
 const flow_projector = @import("flows/projector.zig");
@@ -4176,5 +4177,125 @@ pub const SplitterClampTests = struct {
         // so the clamp range stays consistent. Result: the floor.
         const result = splitter.clampInspectorWidth(500, 100, default_gap);
         try expect.equal(result, @as(f32, prefs.min_inspector_width));
+    }
+};
+
+// ─── flow_io: .flow.jsonc reader / writer (RFC issue #153) ──────────────
+
+/// Covers `flow_io.parse` / `flow_io.render` — the `.flow.jsonc` flat
+/// `nodes`+`edges` schema, the `Subflow`/`Param`/`Output` node types,
+/// and the determinism guarantee that a re-save produces stable bytes.
+pub const FlowIoTests = struct {
+    test "parses the flat nodes+edges schema" {
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  // leading comment
+            \\  "name": "enemy_tick",
+            \\  "event": { "type": "OnCreate", "arg_entity": "entity" },
+            \\  "nodes": [
+            \\    { "id": 1, "type": "GetComponent", "pos": [0, 0], "component": "Position" },
+            \\    { "id": 3, "type": "BinOp", "op": "add", "pos": [10, 20] }
+            \\  ],
+            \\  "edges": [
+            \\    { "from": { "node": 1, "pin": "x" }, "to": { "node": 3, "pin": "a" } }
+            \\  ]
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        try expect.toBeTrue(std.mem.eql(u8, doc.name.?, "enemy_tick"));
+        try expect.toBeTrue(std.mem.eql(u8, doc.event.type_name, "OnCreate"));
+        try expect.equal(doc.nodes.len, @as(usize, 2));
+        try expect.equal(doc.edges.len, @as(usize, 1));
+        try expect.equal(doc.max_node_id, @as(u32, 3));
+    }
+
+    test "recognises Subflow / Param / Output node types" {
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "name": "combat_subgraph",
+            \\  "event": { "type": "OnCall" },
+            \\  "params": [ { "name": "damage", "type": "f32", "default": 10.0 } ],
+            \\  "nodes": [
+            \\    { "id": 2, "type": "Param", "param": "damage", "pos": [0, 0] },
+            \\    { "id": 9, "type": "Output", "name": "dealt", "pos": [0, 0] },
+            \\    { "id": 7, "type": "Subflow", "flow": "combat_subgraph", "bindings": { "damage": 25.0 }, "pos": [240, 60] }
+            \\  ],
+            \\  "edges": []
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        try expect.equal(doc.params.len, @as(usize, 1));
+        try expect.toBeTrue(std.mem.eql(u8, doc.params[0].name, "damage"));
+        try expect.toBeTrue(doc.params[0].default_text != null);
+        try expect.toBeTrue(doc.nodes[0].kind == .param);
+        try expect.toBeTrue(std.mem.eql(u8, doc.nodes[0].param_ref, "damage"));
+        try expect.toBeTrue(doc.nodes[1].kind == .output);
+        try expect.toBeTrue(std.mem.eql(u8, doc.nodes[1].output_name, "dealt"));
+        try expect.toBeTrue(doc.nodes[2].kind == .subflow);
+        try expect.toBeTrue(std.mem.eql(u8, doc.nodes[2].flow_ref, "combat_subgraph"));
+        try expect.equal(doc.nodes[2].bindings.len, @as(usize, 1));
+    }
+
+    test "re-save is deterministic and idempotent" {
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "name": "x",
+            \\  "event": { "type": "OnCreate", "arg_entity": "entity" },
+            \\  "params": [ { "name": "p", "type": "i32", "default": 3 } ],
+            \\  "nodes": [
+            \\    { "id": 1, "type": "Param", "param": "p", "pos": [0, 0] },
+            \\    { "id": 2, "type": "BinOp", "op": "add", "pos": [5, 7] }
+            \\  ],
+            \\  "edges": [
+            \\    { "from": { "node": 1, "pin": "value" }, "to": { "node": 2, "pin": "a" } }
+            \\  ]
+            \\}
+        ;
+        var doc1 = try flow_io.parse(a, src);
+        defer doc1.deinit();
+        const text1 = try flow_io.render(a, doc1);
+        defer a.free(text1);
+
+        var doc2 = try flow_io.parse(a, text1);
+        defer doc2.deinit();
+        const text2 = try flow_io.render(a, doc2);
+        defer a.free(text2);
+
+        try expect.toBeTrue(std.mem.eql(u8, text1, text2));
+    }
+
+    test "unknown node fields round-trip verbatim" {
+        const a = std.testing.allocator;
+        const src =
+            \\{ "event": { "type": "OnCall" },
+            \\  "nodes": [ { "id": 1, "type": "Literal", "value": 1.5, "pos": [0, 0] } ],
+            \\  "edges": [] }
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        const text = try flow_io.render(a, doc);
+        defer a.free(text);
+        // The `value` key survived even though the editor doesn't model it.
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"value\"") != null);
+    }
+
+    test "displayNameFromPath strips the .flow.jsonc extension" {
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.displayNameFromPath("a/b/enemy_tick.flow.jsonc"),
+            "enemy_tick",
+        ));
+    }
+
+    test "isFlowDocPath matches only .flow.jsonc under scripts/flows" {
+        const dir = "/proj";
+        try expect.toBeTrue(project_tree.isFlowDocPath(dir, "/proj/scripts/flows/a.flow.jsonc"));
+        try expect.toBeTrue(!project_tree.isFlowDocPath(dir, "/proj/scripts/flows/a.zig"));
+        try expect.toBeTrue(!project_tree.isFlowDocPath(dir, "/proj/scenes/a.jsonc"));
     }
 };


### PR DESCRIPTION
Closes #153.

Implements the labelle-gui side of the Flows-as-`.flow.jsonc` RFC. Flow graphs move from a derived-from-Zig viewer to an **authored** `.flow.jsonc` content format with a flat `nodes`+`edges` schema and the `Subflow`/`Param`/`Output` composition node types.

## What's in this PR

### `src/flow_io.zig` (new) — reader/writer
Typed model + JSONC reader + deterministic writer for the RFC §2/§3 schema:

- Parses `name`, `event`, `params`, `nodes`, `edges` using the engine's JSONC convention — `//` line comments stripped, then `std.json` (same pre-pass `scene_io` runs for scenes/prefabs).
- **Deterministic re-save** (RFC §3 open question): fixed top-level key order (`name`, `event`, `params`, `nodes`, `edges`), fixed per-node order (`id`, `type`, `pos`, kind fields, then sorted `extras`), sorted binding/extra keys, canonical number formatting (integers lose the `.0`). Parsing then rendering is idempotent — verified by test.
- `Subflow` / `Param` / `Output` are modeled structurally (`flow`, `bindings`, `param`, `name`); every other node `type` and any unrecognised key round-trips **verbatim** so a save never drops data flow-codegen needs.

### `src/modules/flow_doc.zig` (new) — editor tab
Two-column `.flow.jsonc` editor:

- **Canvas** — imgui-node-editor; node positions persist back into the document on save.
- **Inspector** — the subgraph **`params` editor** (declare name / type / default, RFC §3), an event-type editor, a node palette to add `Subflow`/`Param`/`Output` nodes, and a per-node field editor (including `Subflow` literal `bindings`, with an undeclared-parameter warning on `Param` nodes).

### Wiring
- `src/app.zig`: new `OpenTab.flow_doc` variant + `openFlowDoc`. The existing read-only `.zig` Flow viewer (`OpenTab.flow`) is left unchanged.
- `src/modules/project_tree.zig`: `isFlowDocPath` routes `*.flow.jsonc` under `scripts/flows/` to the new editor; `.zig` files still route to the viewer.
- `src/tests.zig`: `FlowIoTests` — parse/render round-trip, determinism, Subflow/Param/Output recognition, verbatim pass-through, path router.

## Build / test
`zig build`, `zig build test` (216/216), and `zig build gui-test` (15/15) all pass clean.

## Deferred (scoped out of v1)
- **Edge creation by dragging pins** on the canvas — edges parse, render, and round-trip; the canvas draws them but doesn't yet author new ones interactively.
- **Load-time `Subflow` cycle check** (RFC §4) — needs the cross-file flow registry / shared tree-walker, which is flow-codegen + labelle-assembler work, not editor-local.
- **`.flow.zon` → `.flow.jsonc` converter** — the RFC's hard cut-over; belongs with the flow-codegen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)