### PR TITLE
Field-editable inspector for non-composition node types

### DIFF
--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -279,11 +279,21 @@ pub fn decodeStringValue(a: std.mem.Allocator, value_text: []const u8) ![]const 
 /// When the stored value isn't a JSON string, or the decoded text would
 /// not fit in `buf`, the canonical text is copied verbatim (truncated to
 /// `buf` if necessary) — the same fall-through `decodeStringValue` uses.
+///
+/// `buf` is written as a valid NUL-terminated edit buffer: one byte is
+/// reserved for the `0` sentinel, so the copied text is at most
+/// `buf.len - 1` bytes and a `0` is always written immediately after it.
+/// This lets a widget consume `buf` directly via `inputText` / `sliceTo`
+/// without trailing garbage past the value.
 pub fn decodeStringValueBuf(buf: []u8, value_text: []const u8) []const u8 {
+    std.debug.assert(buf.len > 0);
+    // One byte is reserved for the editor's NUL sentinel.
+    const cap = buf.len - 1;
     const trimmed = std.mem.trim(u8, value_text, " \t\r\n");
     const verbatim = blk: {
-        const n = @min(buf.len, trimmed.len);
+        const n = @min(cap, trimmed.len);
         @memcpy(buf[0..n], trimmed[0..n]);
+        buf[n] = 0;
         break :blk buf[0..n];
     };
     if (trimmed.len < 2 or trimmed[0] != '"') return verbatim;
@@ -303,8 +313,9 @@ pub fn decodeStringValueBuf(buf: []u8, value_text: []const u8) []const u8 {
     defer parsed.deinit();
     if (parsed.value != .string) return verbatim;
     const inner = parsed.value.string;
-    if (inner.len > buf.len) return verbatim;
+    if (inner.len > cap) return verbatim;
     @memcpy(buf[0..inner.len], inner);
+    buf[inner.len] = 0;
     return buf[0..inner.len];
 }
 
@@ -332,6 +343,12 @@ pub const DecodedValue = struct {
 /// `buf` (which always reserves one byte for the input-widget
 /// sentinel). When false the returned `text` is the exact, complete
 /// value and is safe to edit.
+///
+/// The returned text is always written as a valid NUL-terminated edit
+/// buffer: a `0` sentinel is placed immediately after the copied text
+/// (within the byte reserved for it), so a caller may hand `buf`
+/// straight to `inputText` / `sliceTo` without trailing garbage past
+/// the value.
 pub fn decodeStringValueBufChecked(buf: []u8, value_text: []const u8) DecodedValue {
     std.debug.assert(buf.len > 0);
     // One byte is reserved for the editor's NUL sentinel, so a value of
@@ -339,12 +356,21 @@ pub fn decodeStringValueBufChecked(buf: []u8, value_text: []const u8) DecodedVal
     const cap = buf.len - 1;
     const trimmed = std.mem.trim(u8, value_text, " \t\r\n");
 
+    // Copy at most `cap` bytes of `text` into `buf`, write the `0`
+    // sentinel after it, and return the result as a `DecodedValue`.
+    const verbatim = struct {
+        fn fill(b: []u8, c: usize, text: []const u8, lossy: bool) DecodedValue {
+            const n = @min(c, text.len);
+            @memcpy(b[0..n], text[0..n]);
+            b[n] = 0;
+            return .{ .text = b[0..n], .truncated = lossy };
+        }
+    }.fill;
+
     // Non-string canonical values (numbers, bools, null) are edited
     // verbatim; they fit only when shorter than the editable capacity.
     if (trimmed.len < 2 or trimmed[0] != '"') {
-        const n = @min(cap, trimmed.len);
-        @memcpy(buf[0..n], trimmed[0..n]);
-        return .{ .text = buf[0..n], .truncated = trimmed.len > cap };
+        return verbatim(buf, cap, trimmed, trimmed.len > cap);
     }
 
     var scratch: [1024]u8 = undefined;
@@ -356,25 +382,20 @@ pub fn decodeStringValueBufChecked(buf: []u8, value_text: []const u8) DecodedVal
         .{},
     ) catch {
         // Unparseable — fall through to the verbatim canonical text.
-        const n = @min(cap, trimmed.len);
-        @memcpy(buf[0..n], trimmed[0..n]);
-        return .{ .text = buf[0..n], .truncated = trimmed.len > cap };
+        return verbatim(buf, cap, trimmed, trimmed.len > cap);
     };
     defer parsed.deinit();
     if (parsed.value != .string) {
-        const n = @min(cap, trimmed.len);
-        @memcpy(buf[0..n], trimmed[0..n]);
-        return .{ .text = buf[0..n], .truncated = trimmed.len > cap };
+        return verbatim(buf, cap, trimmed, trimmed.len > cap);
     }
     const inner = parsed.value.string;
     if (inner.len > cap) {
         // The decoded text won't fit; surface a truncated verbatim view
         // and mark it lossy so the editor stays read-only.
-        const n = @min(cap, trimmed.len);
-        @memcpy(buf[0..n], trimmed[0..n]);
-        return .{ .text = buf[0..n], .truncated = true };
+        return verbatim(buf, cap, trimmed, true);
     }
     @memcpy(buf[0..inner.len], inner);
+    buf[inner.len] = 0;
     return .{ .text = buf[0..inner.len], .truncated = false };
 }
 

--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -156,6 +156,125 @@ pub const KeyValue = struct {
     value_text: []const u8,
 };
 
+// ─── Typed editing of `.other` node fields ─────────────────────────────
+//
+// `Subflow`/`Param`/`Output` are modeled structurally above. Every other
+// node type is `.other` and carries its type-specific keys verbatim in
+// `extras`. The editor still wants to *field-edit* a handful of common
+// node types — without promoting them to first-class `NodeKind`s, which
+// would mean per-type writer branches. Instead the editor uses the
+// `OtherFieldSpec` table: for a recognised `type_name` it names the one
+// key the inspector exposes as a widget; the value stays in `extras`, so
+// the existing deterministic writer emits it unchanged and genuinely
+// unknown keys keep round-tripping verbatim.
+
+/// How the inspector should render a recognised `.other` field.
+pub const OtherFieldWidget = enum {
+    /// Free-form text edited as a JSON string value.
+    text,
+    /// A fixed choice list (currently only `BinOp.op`).
+    op_combo,
+    /// A JSON literal of any type (`Literal.value`) — normalised on edit.
+    literal,
+};
+
+/// Names the single editable field for a recognised `.other` node type.
+pub const OtherFieldSpec = struct {
+    /// The node `type` string this spec matches (e.g. `"BinOp"`).
+    type_name: []const u8,
+    /// The `extras` key the inspector edits (e.g. `"op"`).
+    key: []const u8,
+    /// Inspector label shown next to the widget.
+    label: []const u8,
+    widget: OtherFieldWidget,
+};
+
+/// The closed list of `BinOp.op` values offered by the combo box.
+pub const bin_ops = [_][]const u8{ "add", "sub", "mul", "div" };
+
+/// Recognised `.other` node types and their one editable field. Keeping
+/// this in `flow_io` (next to the model) makes it unit-testable without
+/// a GUI and keeps the editor a thin consumer.
+pub const other_field_specs = [_]OtherFieldSpec{
+    .{ .type_name = "BinOp", .key = "op", .label = "Operator", .widget = .op_combo },
+    .{ .type_name = "GetComponent", .key = "component", .label = "Component", .widget = .text },
+    .{ .type_name = "SetField", .key = "target", .label = "Target", .widget = .text },
+    .{ .type_name = "Literal", .key = "value", .label = "Value", .widget = .literal },
+    .{ .type_name = "Identifier", .key = "name", .label = "Name", .widget = .text },
+    .{ .type_name = "Call", .key = "callee", .label = "Callee", .widget = .text },
+};
+
+/// Return the editable-field spec for a node `type_name`, or null when
+/// the type is genuinely unknown (the inspector then shows the verbatim
+/// fallback view).
+pub fn otherFieldSpec(type_name: []const u8) ?OtherFieldSpec {
+    for (other_field_specs) |spec| {
+        if (std.mem.eql(u8, spec.type_name, type_name)) return spec;
+    }
+    return null;
+}
+
+/// Look up the verbatim value text of an `extras` key, or null when the
+/// node doesn't carry that key.
+pub fn extraValue(node: Node, key: []const u8) ?[]const u8 {
+    for (node.extras) |kv| {
+        if (std.mem.eql(u8, kv.key, key)) return kv.value_text;
+    }
+    return null;
+}
+
+/// Set (or insert) an `extras` key on `node` to `value_text`, keeping the
+/// slice sorted so the writer stays deterministic. `value_text` must
+/// already be canonical JSON value text — callers pass the output of
+/// `jsonValueToText` or `normalizeValueText`. The new slice and its
+/// strings are allocated on `a`; the previous slice is left for the
+/// arena to reclaim.
+pub fn setExtraValue(
+    a: std.mem.Allocator,
+    node: *Node,
+    key: []const u8,
+    value_text: []const u8,
+) !void {
+    for (node.extras) |*kv| {
+        if (std.mem.eql(u8, kv.key, key)) {
+            kv.value_text = try a.dupe(u8, value_text);
+            return;
+        }
+    }
+    const out = try a.alloc(KeyValue, node.extras.len + 1);
+    @memcpy(out[0..node.extras.len], node.extras);
+    out[node.extras.len] = .{
+        .key = try a.dupe(u8, key),
+        .value_text = try a.dupe(u8, value_text),
+    };
+    sortKeyValues(out);
+    node.extras = out;
+}
+
+/// Decode a JSON-string `extras` value (e.g. `"add"`) back to its raw
+/// inner text for display in a text widget. When the stored value isn't
+/// a JSON string (a `Literal.value` may be a number or bool) the
+/// canonical text is returned unchanged. Result is owned by `a`.
+pub fn decodeStringValue(a: std.mem.Allocator, value_text: []const u8) ![]const u8 {
+    const trimmed = std.mem.trim(u8, value_text, " \t\r\n");
+    if (trimmed.len < 2 or trimmed[0] != '"') return a.dupe(u8, trimmed);
+    var parsed = std.json.parseFromSlice(std.json.Value, a, trimmed, .{}) catch {
+        return a.dupe(u8, trimmed);
+    };
+    defer parsed.deinit();
+    if (parsed.value != .string) return a.dupe(u8, trimmed);
+    return a.dupe(u8, parsed.value.string);
+}
+
+/// Canonical JSON text for a plain string value — the form a `.text`
+/// widget's input must be stored as so the writer emits valid JSON.
+pub fn encodeStringValue(a: std.mem.Allocator, raw: []const u8) ![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(a);
+    try writeJsonString(a, &out, raw);
+    return out.toOwnedSlice(a);
+}
+
 /// One graph edge — same `{node, pin}` shape on both ends as `.flow.zon`
 /// used (RFC §2, `links` → `edges` is a rename only).
 pub const Edge = struct {
@@ -1096,6 +1215,78 @@ test "huge flow file saves and round-trips at scale" {
     const disk_text = try render(a, disk_doc);
     defer a.free(disk_text);
     try std.testing.expectEqualStrings(text1, disk_text);
+}
+
+test "otherFieldSpec recognises the field-editable .other node types" {
+    try std.testing.expectEqual(OtherFieldWidget.op_combo, otherFieldSpec("BinOp").?.widget);
+    try std.testing.expectEqualStrings("op", otherFieldSpec("BinOp").?.key);
+    try std.testing.expectEqualStrings("component", otherFieldSpec("GetComponent").?.key);
+    try std.testing.expectEqualStrings("target", otherFieldSpec("SetField").?.key);
+    try std.testing.expectEqual(OtherFieldWidget.literal, otherFieldSpec("Literal").?.widget);
+    try std.testing.expectEqualStrings("name", otherFieldSpec("Identifier").?.key);
+    try std.testing.expectEqualStrings("callee", otherFieldSpec("Call").?.key);
+    // A genuinely-unknown type has no spec — inspector falls back to the
+    // verbatim view.
+    try std.testing.expect(otherFieldSpec("SomeFutureNode") == null);
+}
+
+test "setExtraValue updates an existing key and keeps extras sorted" {
+    const src =
+        \\{
+        \\  "nodes": [ { "id": 1, "type": "BinOp", "op": "add", "zlast": 1, "pos": [0, 0] } ],
+        \\  "edges": []
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    const a = doc.allocator();
+
+    try std.testing.expectEqualStrings("\"add\"", extraValue(doc.nodes[0], "op").?);
+    try setExtraValue(a, &doc.nodes[0], "op", "\"mul\"");
+    try std.testing.expectEqualStrings("\"mul\"", extraValue(doc.nodes[0], "op").?);
+
+    // The edited graph still renders to deterministic, idempotent text.
+    const text1 = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text1);
+    var doc2 = try parse(std.testing.allocator, text1);
+    defer doc2.deinit();
+    const text2 = try render(std.testing.allocator, doc2);
+    defer std.testing.allocator.free(text2);
+    try std.testing.expectEqualStrings(text1, text2);
+    try std.testing.expect(std.mem.indexOf(u8, text1, "\"op\": \"mul\"") != null);
+}
+
+test "setExtraValue inserts a missing key in sorted order" {
+    const src =
+        \\{ "nodes": [ { "id": 1, "type": "GetComponent", "pos": [0, 0] } ], "edges": [] }
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    const a = doc.allocator();
+
+    try std.testing.expect(extraValue(doc.nodes[0], "component") == null);
+    try setExtraValue(a, &doc.nodes[0], "component", "\"Position\"");
+    try std.testing.expectEqualStrings("\"Position\"", extraValue(doc.nodes[0], "component").?);
+
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "\"component\": \"Position\"") != null);
+}
+
+test "decodeStringValue / encodeStringValue round-trip" {
+    const a = std.testing.allocator;
+    const decoded = try decodeStringValue(a, "\"Position\"");
+    defer a.free(decoded);
+    try std.testing.expectEqualStrings("Position", decoded);
+
+    const encoded = try encodeStringValue(a, "Position");
+    defer a.free(encoded);
+    try std.testing.expectEqualStrings("\"Position\"", encoded);
+
+    // A non-string literal value is returned as-is by decode.
+    const num = try decodeStringValue(a, "1.5");
+    defer a.free(num);
+    try std.testing.expectEqualStrings("1.5", num);
 }
 
 test "binding order is deterministic after an edit reorders the slice" {

--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -308,6 +308,76 @@ pub fn decodeStringValueBuf(buf: []u8, value_text: []const u8) []const u8 {
     return buf[0..inner.len];
 }
 
+/// Result of `decodeStringValueBufChecked` — the decoded slice plus a
+/// flag telling the caller the value did not fit the buffer verbatim.
+pub const DecodedValue = struct {
+    /// The decoded (or, on fall-through, verbatim) text — a slice into
+    /// the caller's buffer, possibly truncated.
+    text: []const u8,
+    /// True when the canonical/decoded text was longer than the buffer
+    /// and `text` is therefore a truncated, lossy view. A caller that
+    /// would write `text` back must instead treat the field as
+    /// read-only so the original value round-trips untouched.
+    truncated: bool,
+};
+
+/// Like `decodeStringValueBuf`, but also reports whether the value was
+/// too long to represent in `buf` without loss. An inline editor must
+/// check `truncated` and refuse to write the field when it is set —
+/// editing a truncated view and saving it would corrupt the stored
+/// value (silent data loss).
+///
+/// `truncated` is true when either the decoded inner string, or the
+/// verbatim canonical text used on fall-through, would not fit in
+/// `buf` (which always reserves one byte for the input-widget
+/// sentinel). When false the returned `text` is the exact, complete
+/// value and is safe to edit.
+pub fn decodeStringValueBufChecked(buf: []u8, value_text: []const u8) DecodedValue {
+    std.debug.assert(buf.len > 0);
+    // One byte is reserved for the editor's NUL sentinel, so a value of
+    // exactly `buf.len` would still be truncated by the widget.
+    const cap = buf.len - 1;
+    const trimmed = std.mem.trim(u8, value_text, " \t\r\n");
+
+    // Non-string canonical values (numbers, bools, null) are edited
+    // verbatim; they fit only when shorter than the editable capacity.
+    if (trimmed.len < 2 or trimmed[0] != '"') {
+        const n = @min(cap, trimmed.len);
+        @memcpy(buf[0..n], trimmed[0..n]);
+        return .{ .text = buf[0..n], .truncated = trimmed.len > cap };
+    }
+
+    var scratch: [1024]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&scratch);
+    var parsed = std.json.parseFromSlice(
+        std.json.Value,
+        fba.allocator(),
+        trimmed,
+        .{},
+    ) catch {
+        // Unparseable — fall through to the verbatim canonical text.
+        const n = @min(cap, trimmed.len);
+        @memcpy(buf[0..n], trimmed[0..n]);
+        return .{ .text = buf[0..n], .truncated = trimmed.len > cap };
+    };
+    defer parsed.deinit();
+    if (parsed.value != .string) {
+        const n = @min(cap, trimmed.len);
+        @memcpy(buf[0..n], trimmed[0..n]);
+        return .{ .text = buf[0..n], .truncated = trimmed.len > cap };
+    }
+    const inner = parsed.value.string;
+    if (inner.len > cap) {
+        // The decoded text won't fit; surface a truncated verbatim view
+        // and mark it lossy so the editor stays read-only.
+        const n = @min(cap, trimmed.len);
+        @memcpy(buf[0..n], trimmed[0..n]);
+        return .{ .text = buf[0..n], .truncated = true };
+    }
+    @memcpy(buf[0..inner.len], inner);
+    return .{ .text = buf[0..inner.len], .truncated = false };
+}
+
 /// Canonical JSON text for a plain string value — the form a `.text`
 /// widget's input must be stored as so the writer emits valid JSON.
 pub fn encodeStringValue(a: std.mem.Allocator, raw: []const u8) ![]const u8 {

--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -266,6 +266,48 @@ pub fn decodeStringValue(a: std.mem.Allocator, value_text: []const u8) ![]const 
     return a.dupe(u8, parsed.value.string);
 }
 
+/// Buffer-backed variant of `decodeStringValue` — decodes a JSON-string
+/// `extras` value into the caller-provided `buf` and returns a slice
+/// into it, allocating nothing on any persistent allocator. Used by
+/// per-frame inspector widgets so they don't leak onto the document
+/// arena (one decode per frame for as long as a node stays selected).
+///
+/// The transient JSON parse runs against an internal stack-backed
+/// `FixedBufferAllocator` whose scratch space is reclaimed on return —
+/// nothing it allocates escapes.
+///
+/// When the stored value isn't a JSON string, or the decoded text would
+/// not fit in `buf`, the canonical text is copied verbatim (truncated to
+/// `buf` if necessary) — the same fall-through `decodeStringValue` uses.
+pub fn decodeStringValueBuf(buf: []u8, value_text: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, value_text, " \t\r\n");
+    const verbatim = blk: {
+        const n = @min(buf.len, trimmed.len);
+        @memcpy(buf[0..n], trimmed[0..n]);
+        break :blk buf[0..n];
+    };
+    if (trimmed.len < 2 or trimmed[0] != '"') return verbatim;
+
+    // Scratch space for the transient parse. A JSON-string `extras`
+    // value is small (an operator word, a component/identifier name);
+    // 1 KiB comfortably covers any realistic field plus parser slack,
+    // and the fall-through handles anything larger gracefully.
+    var scratch: [1024]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&scratch);
+    var parsed = std.json.parseFromSlice(
+        std.json.Value,
+        fba.allocator(),
+        trimmed,
+        .{},
+    ) catch return verbatim;
+    defer parsed.deinit();
+    if (parsed.value != .string) return verbatim;
+    const inner = parsed.value.string;
+    if (inner.len > buf.len) return verbatim;
+    @memcpy(buf[0..inner.len], inner);
+    return buf[0..inner.len];
+}
+
 /// Canonical JSON text for a plain string value — the form a `.text`
 /// widget's input must be stored as so the writer emits valid JSON.
 pub fn encodeStringValue(a: std.mem.Allocator, raw: []const u8) ![]const u8 {

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -852,11 +852,16 @@ fn renderOtherField(s: *FlowDocState, n: *flow_io.Node, spec: flow_io.OtherField
             // widget edits the bare inner text. Decode into a stack
             // buffer — see `.op_combo` above: a per-frame doc-arena
             // allocation here would leak while the node stays selected.
-            var decode_buf: IdentBuf = undefined;
-            const decoded = flow_io.decodeStringValueBuf(&decode_buf, current);
             var buf: IdentBuf = undefined;
-            seedBuf(&buf, decoded);
-            if (zgui.inputText("##other_text", .{ .buf = &buf })) {
+            const decoded = flow_io.decodeStringValueBufChecked(&buf, current);
+            if (decoded.truncated) {
+                // The value is longer than the inline editor can hold.
+                // Editing the truncated view and saving would overwrite
+                // the real stored value with a partial copy — silent
+                // data loss. Show a read-only, disabled widget instead
+                // so the original `extras` value round-trips untouched.
+                renderTooLongField(current);
+            } else if (zgui.inputText("##other_text", .{ .buf = &buf })) {
                 const raw = std.mem.sliceTo(&buf, 0);
                 const encoded = flow_io.encodeStringValue(a, raw) catch return;
                 flow_io.setExtraValue(a, n, spec.key, encoded) catch return;
@@ -867,14 +872,23 @@ fn renderOtherField(s: *FlowDocState, n: *flow_io.Node, spec: flow_io.OtherField
             // `Literal.value` is any JSON type — edit the canonical text
             // directly and normalise so a save can't emit invalid JSON.
             var buf: ValueBuf = undefined;
-            seedBuf(&buf, current);
-            if (zgui.inputText("##other_literal", .{ .buf = &buf })) {
-                const raw = std.mem.sliceTo(&buf, 0);
-                const norm = flow_io.normalizeValueText(a, raw) catch return;
-                flow_io.setExtraValue(a, n, spec.key, norm) catch return;
-                s.is_dirty = true;
+            // `ValueBuf` reserves one byte for the widget's NUL
+            // sentinel; a `value` of `buf.len` chars or more can't be
+            // seeded losslessly, so seeding it and committing on the
+            // first `inputText` keystroke would write back a truncated
+            // literal. Detect that and fall back to a read-only view.
+            if (current.len > buf.len - 1) {
+                renderTooLongField(current);
+            } else {
+                seedBuf(&buf, current);
+                if (zgui.inputText("##other_literal", .{ .buf = &buf })) {
+                    const raw = std.mem.sliceTo(&buf, 0);
+                    const norm = flow_io.normalizeValueText(a, raw) catch return;
+                    flow_io.setExtraValue(a, n, spec.key, norm) catch return;
+                    s.is_dirty = true;
+                }
+                zgui.textDisabled("(JSON literal — e.g. 25, 1.5, \"txt\", true)", .{});
             }
-            zgui.textDisabled("(JSON literal — e.g. 25, 1.5, \"txt\", true)", .{});
         },
     }
 
@@ -893,6 +907,26 @@ fn renderOtherField(s: *FlowDocState, n: *flow_io.Node, spec: flow_io.OtherField
             zgui.bulletText("{s}: {s}", .{ kv.key, kv.value_text });
         }
     }
+}
+
+/// Render a recognised field whose stored value is too long for the
+/// inline editor. The value is shown in a disabled (read-only) input so
+/// the user can see it in full-ish, with a hint explaining why it can't
+/// be edited here. Crucially, nothing is written back: the original
+/// `extras` value is left untouched so a save round-trips it verbatim.
+fn renderTooLongField(value: []const u8) void {
+    zgui.beginDisabled(.{ .disabled = true });
+    // A stack buffer just for display — wider than the edit buffers so
+    // the user sees as much as practical. The widget is disabled, so
+    // even a truncated preview here can never be committed.
+    var view: [1024:0]u8 = undefined;
+    seedBuf(&view, value);
+    _ = zgui.inputText("##other_too_long", .{ .buf = &view });
+    zgui.endDisabled();
+    zgui.textDisabled(
+        "(value too long to edit inline — edit the .flow.jsonc file directly)",
+        .{},
+    );
 }
 
 // ─── Mutators ───────────────────────────────────────────────────────────

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -817,34 +817,45 @@ fn renderOtherField(s: *FlowDocState, n: *flow_io.Node, spec: flow_io.OtherField
             // doc arena here would leak for as long as the node stays
             // selected.
             var decode_buf: IdentBuf = undefined;
-            const decoded = flow_io.decodeStringValueBuf(&decode_buf, current);
-            // A missing or invalid stored `op` is treated as *no
-            // selection* (blank preview) rather than silently previewing
-            // the first choice. Otherwise picking the displayed default
-            // (`add`) wouldn't register as a change and could never be
-            // committed — the combo would show `add` without it ever
-            // being written to the node.
-            var sel: ?usize = null;
-            for (flow_io.bin_ops, 0..) |op, i| {
-                if (std.mem.eql(u8, op, decoded)) sel = i;
-            }
-            var preview_z: IdentBuf = undefined;
-            seedBuf(&preview_z, if (sel) |i| flow_io.bin_ops[i] else "");
-            if (zgui.beginCombo("##other_op", .{ .preview_value = &preview_z })) {
+            const decoded = flow_io.decodeStringValueBufChecked(&decode_buf, current);
+            if (decoded.truncated) {
+                // A stored `op` longer than the identifier buffer can't
+                // be matched against the choice list without loss — the
+                // combo would show a blank selection, and picking any
+                // operator would silently overwrite the full stored
+                // value on save. Treat it like the `.text` too-long case:
+                // show a read-only view and write nothing, so the
+                // original `op` round-trips verbatim.
+                renderTooLongField(current);
+            } else {
+                // A missing or invalid stored `op` is treated as *no
+                // selection* (blank preview) rather than silently
+                // previewing the first choice. Otherwise picking the
+                // displayed default (`add`) wouldn't register as a change
+                // and could never be committed — the combo would show
+                // `add` without it ever being written to the node.
+                var sel: ?usize = null;
                 for (flow_io.bin_ops, 0..) |op, i| {
-                    var op_z: IdentBuf = undefined;
-                    seedBuf(&op_z, op);
-                    if (zgui.selectable(&op_z, .{ .selected = sel == i })) {
-                        // `selectable` fires on every click — commit even
-                        // when the picked op equals the previewed one, so
-                        // selecting `add` on a node with no valid `op`
-                        // still writes and marks the doc dirty.
-                        const encoded = flow_io.encodeStringValue(a, op) catch return;
-                        flow_io.setExtraValue(a, n, spec.key, encoded) catch return;
-                        s.is_dirty = true;
-                    }
+                    if (std.mem.eql(u8, op, decoded.text)) sel = i;
                 }
-                zgui.endCombo();
+                var preview_z: IdentBuf = undefined;
+                seedBuf(&preview_z, if (sel) |i| flow_io.bin_ops[i] else "");
+                if (zgui.beginCombo("##other_op", .{ .preview_value = &preview_z })) {
+                    for (flow_io.bin_ops, 0..) |op, i| {
+                        var op_z: IdentBuf = undefined;
+                        seedBuf(&op_z, op);
+                        if (zgui.selectable(&op_z, .{ .selected = sel == i })) {
+                            // `selectable` fires on every click — commit
+                            // even when the picked op equals the previewed
+                            // one, so selecting `add` on a node with no
+                            // valid `op` still writes and marks dirty.
+                            const encoded = flow_io.encodeStringValue(a, op) catch return;
+                            flow_io.setExtraValue(a, n, spec.key, encoded) catch return;
+                            s.is_dirty = true;
+                        }
+                    }
+                    zgui.endCombo();
+                }
             }
         },
         .text => {

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -812,19 +812,33 @@ fn renderOtherField(s: *FlowDocState, n: *flow_io.Node, spec: flow_io.OtherField
     switch (spec.widget) {
         .op_combo => {
             // `op` is stored as a JSON string (`"add"`); decode to the
-            // bare word to match against the choice list.
-            const decoded = flow_io.decodeStringValue(a, current) catch current;
-            var sel: usize = 0;
+            // bare word to match against the choice list. Decode into a
+            // stack buffer — this runs every frame, so allocating on the
+            // doc arena here would leak for as long as the node stays
+            // selected.
+            var decode_buf: IdentBuf = undefined;
+            const decoded = flow_io.decodeStringValueBuf(&decode_buf, current);
+            // A missing or invalid stored `op` is treated as *no
+            // selection* (blank preview) rather than silently previewing
+            // the first choice. Otherwise picking the displayed default
+            // (`add`) wouldn't register as a change and could never be
+            // committed — the combo would show `add` without it ever
+            // being written to the node.
+            var sel: ?usize = null;
             for (flow_io.bin_ops, 0..) |op, i| {
                 if (std.mem.eql(u8, op, decoded)) sel = i;
             }
             var preview_z: IdentBuf = undefined;
-            seedBuf(&preview_z, flow_io.bin_ops[sel]);
+            seedBuf(&preview_z, if (sel) |i| flow_io.bin_ops[i] else "");
             if (zgui.beginCombo("##other_op", .{ .preview_value = &preview_z })) {
                 for (flow_io.bin_ops, 0..) |op, i| {
                     var op_z: IdentBuf = undefined;
                     seedBuf(&op_z, op);
-                    if (zgui.selectable(&op_z, .{ .selected = i == sel })) {
+                    if (zgui.selectable(&op_z, .{ .selected = sel == i })) {
+                        // `selectable` fires on every click — commit even
+                        // when the picked op equals the previewed one, so
+                        // selecting `add` on a node with no valid `op`
+                        // still writes and marks the doc dirty.
                         const encoded = flow_io.encodeStringValue(a, op) catch return;
                         flow_io.setExtraValue(a, n, spec.key, encoded) catch return;
                         s.is_dirty = true;
@@ -835,8 +849,11 @@ fn renderOtherField(s: *FlowDocState, n: *flow_io.Node, spec: flow_io.OtherField
         },
         .text => {
             // Identifier-like fields are stored as JSON strings; the
-            // widget edits the bare inner text.
-            const decoded = flow_io.decodeStringValue(a, current) catch current;
+            // widget edits the bare inner text. Decode into a stack
+            // buffer — see `.op_combo` above: a per-frame doc-arena
+            // allocation here would leak while the node stays selected.
+            var decode_buf: IdentBuf = undefined;
+            const decoded = flow_io.decodeStringValueBuf(&decode_buf, current);
             var buf: IdentBuf = undefined;
             seedBuf(&buf, decoded);
             if (zgui.inputText("##other_text", .{ .buf = &buf })) {

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -17,13 +17,16 @@
 //!     node palette (add `Subflow` / `Param` / `Output` / a custom
 //!     typed node) and the selected node's editable fields.
 //!
-//! Scope (v1): structural editing — add/remove nodes, edit the typed
-//! fields of the three composition node types, edit `params`, edit the
-//! event type, move nodes on the canvas. Edge creation by dragging
-//! pins and a load-time cycle check across `Subflow` references are
-//! deferred — see the PR notes. Unknown node types (`BinOp`, …) and
-//! their fields round-trip verbatim through `flow_io` but aren't
-//! field-editable here.
+//! Scope: structural editing — add/remove nodes, edit the typed fields
+//! of the three composition node types, edit `params`, edit the event
+//! type, move nodes on the canvas. The inspector also field-edits a set
+//! of recognised non-composition node types (`BinOp`, `GetComponent`,
+//! `SetField`, `Literal`, `Identifier`, `Call`) via the
+//! `flow_io.other_field_specs` table — each exposes one widget over its
+//! `extras` value, so the deterministic writer emits it unchanged.
+//! Genuinely-unknown node types still fall back to the verbatim view.
+//! Edge creation by dragging pins and a load-time cycle check across
+//! `Subflow` references are deferred — see the PR notes.
 
 const std = @import("std");
 const zgui = @import("zgui");
@@ -715,10 +718,16 @@ fn renderSelectedNode(s: *FlowDocState) void {
             }
         },
         .other => {
-            zgui.textDisabled("This node type is not field-editable in v1.", .{});
-            zgui.textDisabled("Its fields round-trip verbatim:", .{});
-            for (n.extras) |kv| {
-                zgui.bulletText("{s}: {s}", .{ kv.key, kv.value_text });
+            if (flow_io.otherFieldSpec(n.type_name)) |spec| {
+                renderOtherField(s, n, spec);
+            } else {
+                // A genuinely-unknown node type: no widget, just the
+                // verbatim round-tripped fields.
+                zgui.textDisabled("This node type is not field-editable.", .{});
+                zgui.textDisabled("Its fields round-trip verbatim:", .{});
+                for (n.extras) |kv| {
+                    zgui.bulletText("{s}: {s}", .{ kv.key, kv.value_text });
+                }
             }
         },
     }
@@ -785,6 +794,86 @@ fn renderBindingsEditor(s: *FlowDocState, n: *flow_io.Node) void {
             s.is_dirty = true;
         } else |err| {
             std.log.err("flow: remove binding failed: {s}", .{@errorName(err)});
+        }
+    }
+}
+
+/// Inspector editing for a recognised `.other` node type (`BinOp`,
+/// `GetComponent`, `SetField`, `Literal`, `Identifier`, `Call`). The
+/// value lives in `n.extras` under `spec.key`; the widget writes the
+/// canonical JSON text back there via `flow_io.setExtraValue`, so the
+/// deterministic writer emits it unchanged and any other (genuinely
+/// unknown) key on the node still round-trips verbatim.
+fn renderOtherField(s: *FlowDocState, n: *flow_io.Node, spec: flow_io.OtherFieldSpec) void {
+    const a = s.doc.allocator();
+    const current = flow_io.extraValue(n.*, spec.key) orelse "";
+
+    zgui.text("{s}", .{spec.label});
+    switch (spec.widget) {
+        .op_combo => {
+            // `op` is stored as a JSON string (`"add"`); decode to the
+            // bare word to match against the choice list.
+            const decoded = flow_io.decodeStringValue(a, current) catch current;
+            var sel: usize = 0;
+            for (flow_io.bin_ops, 0..) |op, i| {
+                if (std.mem.eql(u8, op, decoded)) sel = i;
+            }
+            var preview_z: IdentBuf = undefined;
+            seedBuf(&preview_z, flow_io.bin_ops[sel]);
+            if (zgui.beginCombo("##other_op", .{ .preview_value = &preview_z })) {
+                for (flow_io.bin_ops, 0..) |op, i| {
+                    var op_z: IdentBuf = undefined;
+                    seedBuf(&op_z, op);
+                    if (zgui.selectable(&op_z, .{ .selected = i == sel })) {
+                        const encoded = flow_io.encodeStringValue(a, op) catch return;
+                        flow_io.setExtraValue(a, n, spec.key, encoded) catch return;
+                        s.is_dirty = true;
+                    }
+                }
+                zgui.endCombo();
+            }
+        },
+        .text => {
+            // Identifier-like fields are stored as JSON strings; the
+            // widget edits the bare inner text.
+            const decoded = flow_io.decodeStringValue(a, current) catch current;
+            var buf: IdentBuf = undefined;
+            seedBuf(&buf, decoded);
+            if (zgui.inputText("##other_text", .{ .buf = &buf })) {
+                const raw = std.mem.sliceTo(&buf, 0);
+                const encoded = flow_io.encodeStringValue(a, raw) catch return;
+                flow_io.setExtraValue(a, n, spec.key, encoded) catch return;
+                s.is_dirty = true;
+            }
+        },
+        .literal => {
+            // `Literal.value` is any JSON type — edit the canonical text
+            // directly and normalise so a save can't emit invalid JSON.
+            var buf: ValueBuf = undefined;
+            seedBuf(&buf, current);
+            if (zgui.inputText("##other_literal", .{ .buf = &buf })) {
+                const raw = std.mem.sliceTo(&buf, 0);
+                const norm = flow_io.normalizeValueText(a, raw) catch return;
+                flow_io.setExtraValue(a, n, spec.key, norm) catch return;
+                s.is_dirty = true;
+            }
+            zgui.textDisabled("(JSON literal — e.g. 25, 1.5, \"txt\", true)", .{});
+        },
+    }
+
+    // Any other keys on the node (beyond the one editable field) still
+    // round-trip; surface them so the user sees nothing is hidden.
+    var has_other = false;
+    for (n.extras) |kv| {
+        if (std.mem.eql(u8, kv.key, spec.key)) continue;
+        has_other = true;
+    }
+    if (has_other) {
+        zgui.spacing();
+        zgui.textDisabled("Other fields (round-trip verbatim):", .{});
+        for (n.extras) |kv| {
+            if (std.mem.eql(u8, kv.key, spec.key)) continue;
+            zgui.bulletText("{s}: {s}", .{ kv.key, kv.value_text });
         }
     }
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4829,6 +4829,31 @@ pub const FlowIoTests = struct {
         try expect.toBeTrue(flow_io.decodeStringValueBuf(&buf, "").len == 0);
     }
 
+    test "decodeStringValueBuf NUL-terminates the result for edit reuse" {
+        // The result must be a valid NUL-terminated edit buffer: a `0`
+        // sentinel sits immediately after the copied text so a widget can
+        // consume `buf` directly without trailing garbage past the value.
+        var buf: [128]u8 = undefined;
+        @memset(&buf, 0xAA); // poison so a missing sentinel would show
+
+        const decoded = flow_io.decodeStringValueBuf(&buf, "\"Position\"");
+        try expect.toBeTrue(buf[decoded.len] == 0);
+        try expect.toBeTrue(std.mem.eql(u8, std.mem.sliceTo(&buf, 0), "Position"));
+
+        @memset(&buf, 0xAA);
+        const num = flow_io.decodeStringValueBuf(&buf, "42");
+        try expect.toBeTrue(buf[num.len] == 0);
+        try expect.toBeTrue(std.mem.eql(u8, std.mem.sliceTo(&buf, 0), "42"));
+
+        // Even the verbatim overflow fall-through terminates within the
+        // reserved sentinel byte.
+        var small: [4]u8 = undefined;
+        @memset(&small, 0xAA);
+        const over = flow_io.decodeStringValueBuf(&small, "\"abcdefghij\"");
+        try expect.toBeTrue(over.len < small.len);
+        try expect.toBeTrue(small[over.len] == 0);
+    }
+
     test "decodeStringValueBuf falls through when the decoded text overflows buf" {
         // A decoded string longer than the buffer can't be copied in;
         // the canonical (quoted) text is returned verbatim, truncated to
@@ -4868,6 +4893,35 @@ pub const FlowIoTests = struct {
         const num = flow_io.decodeStringValueBufChecked(&buf, "42");
         try expect.toBeTrue(!num.truncated);
         try expect.toBeTrue(std.mem.eql(u8, num.text, "42"));
+    }
+
+    test "decodeStringValueBufChecked NUL-terminates the result for edit reuse" {
+        // The `.text` inspector hands this buffer straight to `inputText`
+        // / `sliceTo`; a `0` sentinel must sit immediately after the
+        // decoded text so the widget shows no trailing garbage and a save
+        // can't persist a corrupted `extras` string.
+        var buf: [128]u8 = undefined;
+        @memset(&buf, 0xAA); // poison so a missing sentinel would show
+
+        const got = flow_io.decodeStringValueBufChecked(&buf, "\"Position\"");
+        try expect.toBeTrue(!got.truncated);
+        try expect.toBeTrue(buf[got.text.len] == 0);
+        try expect.toBeTrue(std.mem.eql(u8, std.mem.sliceTo(&buf, 0), "Position"));
+
+        // Non-string verbatim path also terminates.
+        @memset(&buf, 0xAA);
+        const num = flow_io.decodeStringValueBufChecked(&buf, "1.5");
+        try expect.toBeTrue(buf[num.text.len] == 0);
+        try expect.toBeTrue(std.mem.eql(u8, std.mem.sliceTo(&buf, 0), "1.5"));
+
+        // A truncated (too-long) decoded view still terminates within the
+        // reserved sentinel byte — the view never overruns the buffer.
+        var small: [4]u8 = undefined;
+        @memset(&small, 0xAA);
+        const over = flow_io.decodeStringValueBufChecked(&small, "\"abcdefghij\"");
+        try expect.toBeTrue(over.truncated);
+        try expect.toBeTrue(over.text.len < small.len);
+        try expect.toBeTrue(small[over.text.len] == 0);
     }
 
     test "decodeStringValueBufChecked flags a too-long decoded string" {
@@ -4959,6 +5013,46 @@ pub const FlowIoTests = struct {
         defer a.free(text);
         try expect.toBeTrue(std.mem.indexOf(u8, text, "y" ** 400) != null);
 
+        var doc2 = try flow_io.parse(a, text);
+        defer doc2.deinit();
+        const text2 = try flow_io.render(a, doc2);
+        defer a.free(text2);
+        try expect.toBeTrue(std.mem.eql(u8, text, text2));
+    }
+
+    test "a too-long BinOp op survives a load -> save round-trip" {
+        const a = std.testing.allocator;
+        // A `BinOp.op` JSON string whose decoded text is far longer than
+        // the inspector's 128-byte identifier edit buffer. The `.op_combo`
+        // path must detect the truncation (via `decodeStringValueBufChecked`)
+        // and refuse to write — picking an operator would otherwise
+        // silently clobber the full stored value on save.
+        const long_op = "z" ** 300;
+        const src = std.fmt.allocPrint(a,
+            \\{{ "event": {{ "type": "OnCreate" }},
+            \\  "nodes": [ {{ "id": 1, "type": "BinOp", "op": "{s}", "pos": [0, 0] }} ],
+            \\  "edges": [] }}
+        , .{long_op}) catch unreachable;
+        defer a.free(src);
+
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        // The inspector's `.op_combo` path decodes into an `IdentBuf`
+        // (128 bytes); a 300-char value must come back flagged truncated
+        // so the combo goes read-only instead of allowing a write.
+        const stored = flow_io.extraValue(doc.nodes[0], "op").?;
+        var ident_buf: [128]u8 = undefined;
+        const decoded = flow_io.decodeStringValueBufChecked(&ident_buf, stored);
+        try expect.toBeTrue(decoded.truncated);
+
+        // An untouched too-long `op` must round-trip verbatim — the
+        // editor skips the write, so `extras` is unchanged.
+        const text = try flow_io.render(a, doc);
+        defer a.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, long_op) != null);
+
+        // And the re-save stays deterministic.
         var doc2 = try flow_io.parse(a, text);
         defer doc2.deinit();
         const text2 = try flow_io.render(a, doc2);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4723,6 +4723,82 @@ pub const FlowIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"value\"") != null);
     }
 
+    test "otherFieldSpec maps field-editable node types to one extras key" {
+        try expect.toBeTrue(flow_io.otherFieldSpec("BinOp").?.widget == .op_combo);
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.otherFieldSpec("BinOp").?.key, "op"));
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.otherFieldSpec("GetComponent").?.key, "component"));
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.otherFieldSpec("SetField").?.key, "target"));
+        try expect.toBeTrue(flow_io.otherFieldSpec("Literal").?.widget == .literal);
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.otherFieldSpec("Identifier").?.key, "name"));
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.otherFieldSpec("Call").?.key, "callee"));
+        // A genuinely-unknown node type has no spec → verbatim fallback.
+        try expect.toBeTrue(flow_io.otherFieldSpec("MysteryNode") == null);
+    }
+
+    test "editing an .other field via setExtraValue stays deterministic" {
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "event": { "type": "OnCreate" },
+            \\  "nodes": [
+            \\    { "id": 1, "type": "BinOp", "op": "add", "pos": [0, 0] },
+            \\    { "id": 2, "type": "GetComponent", "pos": [10, 0] }
+            \\  ],
+            \\  "edges": []
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        const da = doc.allocator();
+
+        // Edit BinOp.op (existing key) and GetComponent.component (new key).
+        try flow_io.setExtraValue(da, &doc.nodes[0], "op", "\"mul\"");
+        try flow_io.setExtraValue(da, &doc.nodes[1], "component", "\"Position\"");
+
+        const text1 = try flow_io.render(a, doc);
+        defer a.free(text1);
+        var doc2 = try flow_io.parse(a, text1);
+        defer doc2.deinit();
+        const text2 = try flow_io.render(a, doc2);
+        defer a.free(text2);
+
+        // Re-save is byte-identical and the edits are present.
+        try expect.toBeTrue(std.mem.eql(u8, text1, text2));
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"op\": \"mul\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"component\": \"Position\"") != null);
+    }
+
+    test "editing an .other field keeps unrelated extras keys verbatim" {
+        const a = std.testing.allocator;
+        const src =
+            \\{ "event": { "type": "OnCall" },
+            \\  "nodes": [ { "id": 1, "type": "Literal", "value": 1, "note": "keep me", "pos": [0, 0] } ],
+            \\  "edges": [] }
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        const da = doc.allocator();
+
+        try flow_io.setExtraValue(da, &doc.nodes[0], "value", "2.5");
+        const text = try flow_io.render(a, doc);
+        defer a.free(text);
+
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"value\": 2.5") != null);
+        // The unknown `note` key is untouched.
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"note\": \"keep me\"") != null);
+    }
+
+    test "string value text decodes and re-encodes round-trip" {
+        const a = std.testing.allocator;
+        const decoded = try flow_io.decodeStringValue(a, "\"Position\"");
+        defer a.free(decoded);
+        try expect.toBeTrue(std.mem.eql(u8, decoded, "Position"));
+
+        const encoded = try flow_io.encodeStringValue(a, "Velocity");
+        defer a.free(encoded);
+        try expect.toBeTrue(std.mem.eql(u8, encoded, "\"Velocity\""));
+    }
+
     test "displayNameFromPath strips the .flow.jsonc extension" {
         try expect.toBeTrue(std.mem.eql(
             u8,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4857,6 +4857,115 @@ pub const FlowIoTests = struct {
         }
     }
 
+    test "decodeStringValueBufChecked reports a clean fit as not truncated" {
+        var buf: [128]u8 = undefined;
+        // A short JSON string decodes and fits — safe to edit.
+        const got = flow_io.decodeStringValueBufChecked(&buf, "\"Position\"");
+        try expect.toBeTrue(!got.truncated);
+        try expect.toBeTrue(std.mem.eql(u8, got.text, "Position"));
+
+        // A short non-string canonical value fits verbatim.
+        const num = flow_io.decodeStringValueBufChecked(&buf, "42");
+        try expect.toBeTrue(!num.truncated);
+        try expect.toBeTrue(std.mem.eql(u8, num.text, "42"));
+    }
+
+    test "decodeStringValueBufChecked flags a too-long decoded string" {
+        // The decoded inner text (`abcdefghij`, 10 chars) exceeds the
+        // editable capacity of a 4-byte buffer (3 usable chars).
+        var small: [4]u8 = undefined;
+        const got = flow_io.decodeStringValueBufChecked(&small, "\"abcdefghij\"");
+        try expect.toBeTrue(got.truncated);
+        // The view never overruns the buffer.
+        try expect.toBeTrue(got.text.len <= small.len);
+    }
+
+    test "decodeStringValueBufChecked flags a too-long non-string literal" {
+        // A bare number longer than the editable capacity is truncated
+        // — editing it would corrupt the literal, so it's flagged.
+        var small: [4]u8 = undefined;
+        const got = flow_io.decodeStringValueBufChecked(&small, "123456789");
+        try expect.toBeTrue(got.truncated);
+
+        // A value of exactly `buf.len` chars still doesn't fit: one byte
+        // is reserved for the editor's NUL sentinel.
+        var four: [4]u8 = undefined;
+        const exact = flow_io.decodeStringValueBufChecked(&four, "1234");
+        try expect.toBeTrue(exact.truncated);
+    }
+
+    test "a too-long .text field value survives a load -> save round-trip" {
+        const a = std.testing.allocator;
+        // A `GetComponent.component` whose decoded string is far longer
+        // than the inspector's 128-byte identifier edit buffer. The
+        // inspector must refuse to edit it; the writer must still emit
+        // it unchanged.
+        const long_name = "X" ** 300;
+        const src = std.fmt.allocPrint(a,
+            \\{{ "event": {{ "type": "OnCreate" }},
+            \\  "nodes": [ {{ "id": 1, "type": "GetComponent", "component": "{s}", "pos": [0, 0] }} ],
+            \\  "edges": [] }}
+        , .{long_name}) catch unreachable;
+        defer a.free(src);
+
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        // The inspector's `.text` path would decode into an `IdentBuf`
+        // (128 bytes); a 300-char value must come back flagged.
+        const stored = flow_io.extraValue(doc.nodes[0], "component").?;
+        var ident_buf: [128]u8 = undefined;
+        const decoded = flow_io.decodeStringValueBufChecked(&ident_buf, stored);
+        try expect.toBeTrue(decoded.truncated);
+
+        // An untouched too-long value must round-trip verbatim — the
+        // editor skips the write, so `extras` is unchanged.
+        const text = try flow_io.render(a, doc);
+        defer a.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, long_name) != null);
+
+        // And the re-save stays deterministic.
+        var doc2 = try flow_io.parse(a, text);
+        defer doc2.deinit();
+        const text2 = try flow_io.render(a, doc2);
+        defer a.free(text2);
+        try expect.toBeTrue(std.mem.eql(u8, text, text2));
+    }
+
+    test "a too-long Literal value survives a load -> save round-trip" {
+        const a = std.testing.allocator;
+        // A `Literal.value` JSON string longer than the inspector's
+        // 256-byte `ValueBuf`. Seeding it would truncate; the inspector
+        // must keep the field read-only and leave `extras` untouched.
+        const long_lit = "\"" ++ ("y" ** 400) ++ "\"";
+        const src = std.fmt.allocPrint(a,
+            \\{{ "event": {{ "type": "OnCall" }},
+            \\  "nodes": [ {{ "id": 1, "type": "Literal", "value": {s}, "pos": [0, 0] }} ],
+            \\  "edges": [] }}
+        , .{long_lit}) catch unreachable;
+        defer a.free(src);
+
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        // The stored canonical text is longer than the 256-byte buffer
+        // (255 usable) — the inspector's literal path treats it as
+        // read-only.
+        const stored = flow_io.extraValue(doc.nodes[0], "value").?;
+        try expect.toBeTrue(stored.len > 255);
+
+        // The untouched literal round-trips verbatim and deterministically.
+        const text = try flow_io.render(a, doc);
+        defer a.free(text);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "y" ** 400) != null);
+
+        var doc2 = try flow_io.parse(a, text);
+        defer doc2.deinit();
+        const text2 = try flow_io.render(a, doc2);
+        defer a.free(text2);
+        try expect.toBeTrue(std.mem.eql(u8, text, text2));
+    }
+
     test "displayNameFromPath strips the .flow.jsonc extension" {
         try expect.toBeTrue(std.mem.eql(
             u8,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4799,6 +4799,64 @@ pub const FlowIoTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, encoded, "\"Velocity\""));
     }
 
+    test "decodeStringValueBuf decodes into a stack buffer without allocating" {
+        var buf: [128]u8 = undefined;
+
+        // A JSON string decodes to its bare inner text.
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.decodeStringValueBuf(&buf, "\"Position\""),
+            "Position",
+        ));
+        // Whitespace around the value is trimmed before decoding.
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.decodeStringValueBuf(&buf, "  \"add\" "),
+            "add",
+        ));
+        // A non-string canonical value (number/bool) comes back verbatim.
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.decodeStringValueBuf(&buf, "42"),
+            "42",
+        ));
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            flow_io.decodeStringValueBuf(&buf, "true"),
+            "true",
+        ));
+        // An empty value yields an empty slice (no out-of-bounds).
+        try expect.toBeTrue(flow_io.decodeStringValueBuf(&buf, "").len == 0);
+    }
+
+    test "decodeStringValueBuf falls through when the decoded text overflows buf" {
+        // A decoded string longer than the buffer can't be copied in;
+        // the canonical (quoted) text is returned verbatim, truncated to
+        // the buffer rather than overrunning it.
+        var small: [4]u8 = undefined;
+        const out = flow_io.decodeStringValueBuf(&small, "\"abcdefghij\"");
+        try expect.toBeTrue(out.len <= small.len);
+        // Verbatim fall-through keeps the leading quote of the raw text.
+        try expect.toBeTrue(out[0] == '"');
+    }
+
+    test "decodeStringValueBuf agrees with decodeStringValue" {
+        const a = std.testing.allocator;
+        const cases = [_][]const u8{
+            "\"Position\"", "\"add\"", "123", "false", "\"\"",
+        };
+        for (cases) |c| {
+            var buf: [128]u8 = undefined;
+            const allocd = try flow_io.decodeStringValue(a, c);
+            defer a.free(allocd);
+            try expect.toBeTrue(std.mem.eql(
+                u8,
+                flow_io.decodeStringValueBuf(&buf, c),
+                allocd,
+            ));
+        }
+    }
+
     test "displayNameFromPath strips the .flow.jsonc extension" {
         try expect.toBeTrue(std.mem.eql(
             u8,


### PR DESCRIPTION
## Summary

The `.flow.jsonc` flow editor's inspector previously only field-edited the three composition node types (`Subflow` / `Param` / `Output`). Every other node type fell into the `.other` arm, which showed "This node type is not field-editable in v1" and only listed verbatim round-tripped `extras`.

This PR makes six common non-composition node types field-editable:

| Type | Field | Widget |
|------|-------|--------|
| `BinOp` | `op` | combo box (add/sub/mul/div) |
| `GetComponent` | `component` | text input |
| `SetField` | `target` | text input |
| `Literal` | `value` | JSON-literal text input (normalised) |
| `Identifier` | `name` | text input |
| `Call` | `callee` | text input |

## Approach

Approach (b) — typed inspector editing over the existing `extras` representation. These node types stay `NodeKind.other`; no new structural kinds and no per-type writer branches were added, so the existing deterministic writer and verbatim round-trip behaviour are untouched.

- `flow_io` gains an `other_field_specs` table mapping each recognised `type` string to the single `extras` key the inspector exposes and a widget hint. Living next to the model makes it unit-testable without a GUI.
- `extraValue` / `setExtraValue` read and write an `extras` entry; insert keeps the slice sorted so the writer stays deterministic.
- `decodeStringValue` / `encodeStringValue` convert between a JSON-string `extras` value and the bare text the widgets edit.
- `flow_doc.renderOtherField` renders the per-type widget; each edit sets `is_dirty`. Any other keys on a node beyond the one editable field still round-trip and are surfaced read-only so nothing is hidden.
- Genuinely-unknown node types (no spec) keep the existing verbatim fallback view.

A save still produces the same valid, deterministic `.flow.jsonc` and never drops data.

## Verification

- `zig build` — passes.
- `zig build test` — 248/248 pass, including new `FlowIoTests` cases (spec table, `setExtraValue` insert/update determinism, verbatim preservation of unrelated keys, string encode/decode) plus new unit tests in `flow_io.zig`.
- `zig build gui-test` — 16/16 pass.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)