### PR TITLE
Add load-time Subflow reference-cycle check to the flow editor

### DIFF
--- a/src/flow_cycle.zig
+++ b/src/flow_cycle.zig
@@ -1,0 +1,416 @@
+//! Load-time `Subflow` reference-cycle check for the `.flow.jsonc`
+//! editor (issue #159).
+//!
+//! A `.flow.jsonc` flow can reference other flows through `Subflow`
+//! nodes (`flow_io.Node.flow_ref`). flow-codegen rejects a cyclic
+//! reference graph, but only at build time — by then the editor has
+//! long since accepted the file. This module resolves the transitive
+//! set of referenced flows and flags two problems the editor should
+//! surface immediately:
+//!
+//!   - **A reference cycle** — `a → b → … → a`. flow-codegen raises
+//!     `FlowReferenceCycle` for this; codegen can't generate a finite
+//!     program from an infinitely-nested flow.
+//!   - **An unresolved reference** — a `Subflow` names a flow whose
+//!     `scripts/flows/<name>.flow.jsonc` file doesn't exist or won't
+//!     parse. flow-codegen raises `UnknownFlowRef`.
+//!
+//! The pure walk (`detectCycle`) is decoupled from the filesystem via
+//! a `Resolver` callback so it can be unit-tested with an in-memory
+//! reference graph. `analyzeProject` wires the callback to read flow
+//! files from a project's `scripts/flows/` directory.
+//!
+//! Reusing flow-codegen's own registry was considered (the ticket
+//! suggested it) but its published `v0.1.0` package predates the
+//! `.flow.jsonc` schema — it still parses the older `.flow.zon`
+//! format and exposes no registry / cycle-detection surface. An
+//! equivalent depth-first walk is implemented here instead.
+
+const std = @import("std");
+const io_global = @import("io_global.zig");
+const flow_io = @import("flow_io.zig");
+
+/// Outcome of a cycle check.
+pub const Status = union(enum) {
+    /// No cycle, every transitively-referenced flow resolved.
+    clean,
+    /// A reference cycle was found. `chain` is the offending path of
+    /// flow names, starting and ending with the same name
+    /// (e.g. `a → b → a`).
+    cycle: Chain,
+    /// A `Subflow` referenced a flow that couldn't be resolved.
+    /// `chain` is the path of flow names from the entry flow down to
+    /// (and including) the unresolved name.
+    unresolved: Chain,
+};
+
+/// An ordered list of flow names describing an offending reference
+/// path. Owned by the allocator passed to the analysis call.
+pub const Chain = struct {
+    names: [][]const u8,
+
+    /// Render the chain as `a → b → c` into `out`.
+    pub fn format(self: Chain, out: *std.ArrayList(u8), a: std.mem.Allocator) !void {
+        for (self.names, 0..) |name, i| {
+            if (i > 0) try out.appendSlice(a, " \u{2192} ");
+            try out.appendSlice(a, name);
+        }
+    }
+};
+
+/// A full analysis result plus the arena that owns every name string
+/// and the chain slice. Caller frees via `deinit`.
+pub const Report = struct {
+    arena: *std.heap.ArenaAllocator,
+    status: Status,
+
+    pub fn deinit(self: *Report) void {
+        const child = self.arena.child_allocator;
+        self.arena.deinit();
+        child.destroy(self.arena);
+    }
+
+    pub fn allocator(self: *Report) std.mem.Allocator {
+        return self.arena.allocator();
+    }
+};
+
+/// Abstract source of a flow's outgoing `Subflow` references. The pure
+/// `detectCycle` walk only needs this — it never touches the
+/// filesystem. `refs` returns:
+///   - the (possibly empty) list of flow names this flow references,
+///   - or `null` when the named flow cannot be resolved at all.
+/// The returned slice and its strings must outlive the `detectCycle`
+/// call (the project resolver allocates them on the report arena).
+pub const Resolver = struct {
+    ctx: *anyopaque,
+    refsFn: *const fn (ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8,
+
+    fn refs(self: Resolver, name: []const u8) anyerror!?[]const []const u8 {
+        return self.refsFn(self.ctx, name);
+    }
+};
+
+/// Walk the `Subflow` reference graph reachable from `entry` and
+/// classify it. Pure over `resolver` — no filesystem access here.
+///
+/// `arena` owns the chain in any non-`clean` result; the caller is
+/// expected to wrap the whole thing in a `Report`.
+pub fn detectCycle(
+    arena: std.mem.Allocator,
+    entry: []const u8,
+    resolver: Resolver,
+) !Status {
+    var visited: std.StringHashMapUnmanaged(void) = .empty;
+    defer visited.deinit(arena);
+    // The current DFS path — also the on-stack set for cycle detection.
+    var path: std.ArrayList([]const u8) = .empty;
+    defer path.deinit(arena);
+
+    return walk(arena, entry, resolver, &visited, &path);
+}
+
+/// Recursive DFS body. `path` holds the names on the current branch
+/// (entry-to-current); a name reappearing in `path` is a cycle.
+/// `visited` is the global "fully explored, no cycle below" set so a
+/// diamond-shaped reference graph isn't re-walked exponentially.
+fn walk(
+    arena: std.mem.Allocator,
+    name: []const u8,
+    resolver: Resolver,
+    visited: *std.StringHashMapUnmanaged(void),
+    path: *std.ArrayList([]const u8),
+) !Status {
+    // Cycle: `name` is already on the current branch. The offending
+    // chain is the path from that earlier occurrence to here, plus
+    // `name` again to close the loop.
+    for (path.items, 0..) |on_path, i| {
+        if (std.mem.eql(u8, on_path, name)) {
+            var chain: std.ArrayList([]const u8) = .empty;
+            for (path.items[i..]) |n| {
+                try chain.append(arena, try arena.dupe(u8, n));
+            }
+            try chain.append(arena, try arena.dupe(u8, name));
+            return .{ .cycle = .{ .names = try chain.toOwnedSlice(arena) } };
+        }
+    }
+
+    // Already proven clean on an earlier branch — skip.
+    if (visited.contains(name)) return .clean;
+
+    const child_refs = (try resolver.refs(name)) orelse {
+        // `name` itself couldn't be resolved. Report the path that led
+        // here, including `name`.
+        var chain: std.ArrayList([]const u8) = .empty;
+        for (path.items) |n| {
+            try chain.append(arena, try arena.dupe(u8, n));
+        }
+        try chain.append(arena, try arena.dupe(u8, name));
+        return .{ .unresolved = .{ .names = try chain.toOwnedSlice(arena) } };
+    };
+
+    try path.append(arena, name);
+    defer _ = path.pop();
+
+    for (child_refs) |ref| {
+        const sub = try walk(arena, ref, resolver, visited, path);
+        if (sub != .clean) return sub;
+    }
+
+    // Mark explored only after the whole subtree proved clean. Use an
+    // arena-owned copy so the key outlives any borrowed slice.
+    try visited.put(arena, try arena.dupe(u8, name), {});
+    return .clean;
+}
+
+// ─── Project-backed resolver ────────────────────────────────────────────
+
+/// Resolver context that reads `<flows_dir>/<name>.flow.jsonc` from
+/// disk. Parses each file once and caches its `Subflow` references on
+/// the report arena, so a diamond reference graph reads each file at
+/// most once.
+const ProjectResolver = struct {
+    arena: std.mem.Allocator,
+    /// Absolute path of the project's `scripts/flows/` directory.
+    flows_dir: []const u8,
+    /// flow name → its outgoing Subflow refs (`null` cached for a name
+    /// whose file is missing or unparseable).
+    cache: std.StringHashMapUnmanaged(?[]const []const u8) = .empty,
+
+    fn refs(ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8 {
+        const self: *ProjectResolver = @ptrCast(@alignCast(ctx));
+        if (self.cache.get(name)) |cached| return cached;
+
+        const result = self.loadRefs(name) catch null;
+        try self.cache.put(self.arena, try self.arena.dupe(u8, name), result);
+        return result;
+    }
+
+    /// Read and parse `<flows_dir>/<name>.flow.jsonc`, returning the
+    /// distinct non-empty `Subflow` `flow_ref` values it contains.
+    fn loadRefs(self: *ProjectResolver, name: []const u8) !?[]const []const u8 {
+        const path = try std.fs.path.join(
+            self.arena,
+            &.{ self.flows_dir, name },
+        );
+        // `name` is a bare flow name; the on-disk file adds the
+        // extension. Build `<flows_dir>/<name>.flow.jsonc`.
+        const full = try std.fmt.allocPrint(
+            self.arena,
+            "{s}{s}",
+            .{ path, flow_io.extension },
+        );
+
+        var doc = flow_io.loadFromFile(self.arena, full) catch return null;
+        defer doc.deinit();
+
+        var out: std.ArrayList([]const u8) = .empty;
+        var seen: std.StringHashMapUnmanaged(void) = .empty;
+        defer seen.deinit(self.arena);
+        for (doc.nodes) |node| {
+            if (node.kind != .subflow) continue;
+            if (node.flow_ref.len == 0) continue;
+            if (seen.contains(node.flow_ref)) continue;
+            const ref = try self.arena.dupe(u8, node.flow_ref);
+            try seen.put(self.arena, ref, {});
+            try out.append(self.arena, ref);
+        }
+        return try out.toOwnedSlice(self.arena);
+    }
+};
+
+/// Analyze a single open flow document against the other flows in the
+/// project. `entry_refs` is the *live* set of `Subflow` references on
+/// the document being edited (read straight from `FlowDoc`, so an
+/// in-editor edit is reflected without saving first). `flows_dir` is
+/// the project's `scripts/flows/` directory; the referenced flows are
+/// read from there.
+///
+/// The entry flow's references come from `entry_refs`; every
+/// transitively-referenced flow is read from disk. This means an
+/// unsaved edit to the open document is checked immediately, while
+/// referenced flows reflect their on-disk state.
+pub fn analyze(
+    child_allocator: std.mem.Allocator,
+    entry_name: []const u8,
+    entry_refs: []const []const u8,
+    flows_dir: []const u8,
+) !Report {
+    const arena = try child_allocator.create(std.heap.ArenaAllocator);
+    errdefer child_allocator.destroy(arena);
+    arena.* = std.heap.ArenaAllocator.init(child_allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    var resolver_ctx = try a.create(ProjectResolver);
+    resolver_ctx.* = .{
+        .arena = a,
+        .flows_dir = try a.dupe(u8, flows_dir),
+    };
+
+    // Pre-seed the cache with the live (possibly unsaved) entry flow so
+    // its references aren't re-read from a stale on-disk copy.
+    {
+        var refs_copy: std.ArrayList([]const u8) = .empty;
+        var seen: std.StringHashMapUnmanaged(void) = .empty;
+        defer seen.deinit(a);
+        for (entry_refs) |r| {
+            if (r.len == 0) continue;
+            if (seen.contains(r)) continue;
+            const dup = try a.dupe(u8, r);
+            try seen.put(a, dup, {});
+            try refs_copy.append(a, dup);
+        }
+        try resolver_ctx.cache.put(
+            a,
+            try a.dupe(u8, entry_name),
+            try refs_copy.toOwnedSlice(a),
+        );
+    }
+
+    const resolver: Resolver = .{
+        .ctx = resolver_ctx,
+        .refsFn = ProjectResolver.refs,
+    };
+
+    const status = try detectCycle(a, entry_name, resolver);
+    return .{ .arena = arena, .status = status };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+/// In-memory resolver for tests — a flow name → refs map. A name absent
+/// from the map resolves to `null` (unresolved).
+const MapResolver = struct {
+    map: std.StringHashMapUnmanaged([]const []const u8),
+
+    fn refs(ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8 {
+        const self: *MapResolver = @ptrCast(@alignCast(ctx));
+        return self.map.get(name);
+    }
+
+    fn resolver(self: *MapResolver) Resolver {
+        return .{ .ctx = self, .refsFn = MapResolver.refs };
+    }
+};
+
+test "detectCycle: clean linear chain" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "a", &.{"b"});
+    try m.map.put(a, "b", &.{"c"});
+    try m.map.put(a, "c", &.{});
+
+    const status = try detectCycle(a, "a", m.resolver());
+    try std.testing.expect(status == .clean);
+}
+
+test "detectCycle: direct self-reference is a cycle" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "a", &.{"a"});
+
+    const status = try detectCycle(a, "a", m.resolver());
+    try std.testing.expect(status == .cycle);
+    try std.testing.expectEqual(@as(usize, 2), status.cycle.names.len);
+    try std.testing.expectEqualStrings("a", status.cycle.names[0]);
+    try std.testing.expectEqualStrings("a", status.cycle.names[1]);
+}
+
+test "detectCycle: indirect cycle reports the offending chain" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "a", &.{"b"});
+    try m.map.put(a, "b", &.{"c"});
+    try m.map.put(a, "c", &.{"a"});
+
+    const status = try detectCycle(a, "a", m.resolver());
+    try std.testing.expect(status == .cycle);
+    // Chain is a → b → c → a.
+    try std.testing.expectEqual(@as(usize, 4), status.cycle.names.len);
+    try std.testing.expectEqualStrings("a", status.cycle.names[0]);
+    try std.testing.expectEqualStrings("b", status.cycle.names[1]);
+    try std.testing.expectEqualStrings("c", status.cycle.names[2]);
+    try std.testing.expectEqualStrings("a", status.cycle.names[3]);
+}
+
+test "detectCycle: cycle not involving the entry flow is still found" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    // entry → b → c → b  (the cycle is b↔c, entry is clean itself)
+    try m.map.put(a, "entry", &.{"b"});
+    try m.map.put(a, "b", &.{"c"});
+    try m.map.put(a, "c", &.{"b"});
+
+    const status = try detectCycle(a, "entry", m.resolver());
+    try std.testing.expect(status == .cycle);
+    try std.testing.expectEqualStrings("b", status.cycle.names[0]);
+    try std.testing.expectEqualStrings("b", status.cycle.names[status.cycle.names.len - 1]);
+}
+
+test "detectCycle: unresolved reference is reported" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "a", &.{"b"});
+    try m.map.put(a, "b", &.{"missing"});
+    // "missing" deliberately absent from the map.
+
+    const status = try detectCycle(a, "a", m.resolver());
+    try std.testing.expect(status == .unresolved);
+    try std.testing.expectEqual(@as(usize, 3), status.unresolved.names.len);
+    try std.testing.expectEqualStrings("missing", status.unresolved.names[2]);
+}
+
+test "detectCycle: diamond reference graph is clean and walked once" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    // a → b → d, a → c → d. `d` is reachable two ways but no cycle.
+    try m.map.put(a, "a", &.{ "b", "c" });
+    try m.map.put(a, "b", &.{"d"});
+    try m.map.put(a, "c", &.{"d"});
+    try m.map.put(a, "d", &.{});
+
+    const status = try detectCycle(a, "a", m.resolver());
+    try std.testing.expect(status == .clean);
+}
+
+test "detectCycle: empty entry with no refs is clean" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "solo", &.{});
+
+    const status = try detectCycle(a, "solo", m.resolver());
+    try std.testing.expect(status == .clean);
+}
+
+test "Chain.format renders names joined by an arrow" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    const chain: Chain = .{ .names = @constCast(&[_][]const u8{ "a", "b", "a" }) };
+    var out: std.ArrayList(u8) = .empty;
+    try chain.format(&out, a);
+    try std.testing.expectEqualStrings("a \u{2192} b \u{2192} a", out.items);
+}

--- a/src/flow_cycle.zig
+++ b/src/flow_cycle.zig
@@ -15,6 +15,11 @@
 //!     effective registry name (RFC §5: the flow's top-level `name`,
 //!     else its filename basename) matches no `.flow.jsonc` file under
 //!     `scripts/flows/`. flow-codegen raises `UnknownFlowRef`.
+//!   - **A broken referenced file** — a `Subflow` resolves to a file
+//!     that exists on disk but fails to load/parse (a JSON or schema
+//!     error). flow-codegen can't read it either; the editor surfaces
+//!     this distinctly from a plain missing file so the author knows to
+//!     fix the file rather than create one.
 //!
 //! The pure walk (`detectCycle`) is decoupled from the filesystem via
 //! a `Resolver` callback so it can be unit-tested with an in-memory
@@ -39,10 +44,33 @@ pub const Status = union(enum) {
     /// flow names, starting and ending with the same name
     /// (e.g. `a → b → a`).
     cycle: Chain,
-    /// A `Subflow` referenced a flow that couldn't be resolved.
-    /// `chain` is the path of flow names from the entry flow down to
-    /// (and including) the unresolved name.
+    /// A `Subflow` referenced a flow whose effective registry name
+    /// matches no `.flow.jsonc` file on disk. `chain` is the path of
+    /// flow names from the entry flow down to (and including) the
+    /// missing name.
     unresolved: Chain,
+    /// A `Subflow` referenced a flow whose file exists on disk but
+    /// failed to load or parse (a JSON / schema error). `chain` is the
+    /// path of flow names from the entry flow down to (and including)
+    /// the broken flow's name. Distinct from `unresolved` so the editor
+    /// can tell "fix this file" apart from "create this file".
+    parse_failed: Chain,
+};
+
+/// A snapshot of one `.flow.jsonc` file the analysis read while
+/// resolving references — its path plus the `mtime`/`size` observed at
+/// read time. `refreshCycleCheck` keeps this set so it can cheaply tell
+/// whether any referenced file changed on disk since the last check
+/// (which can create or break a *transitive* cycle the open flow's own
+/// reference set never reveals).
+pub const FileStamp = struct {
+    /// Absolute path of the file, owned by the report arena.
+    path: []const u8,
+    /// Last-modification time in nanoseconds (`Io.Timestamp`), or
+    /// `null` when the file could not be stat'd (e.g. it is missing).
+    mtime_ns: ?i96,
+    /// File size in bytes, or `null` when the file could not be stat'd.
+    size: ?u64,
 };
 
 /// An ordered list of flow names describing an offending reference
@@ -69,6 +97,13 @@ pub const Report = struct {
     /// re-runs). Empty for a `clean` status. Owned by `arena`, so the
     /// UI can display it every frame without re-allocating.
     chain_text: []const u8 = "",
+    /// Every `.flow.jsonc` file the analysis stat'd while resolving
+    /// referenced flows, with the `mtime`/`size` observed at read time.
+    /// `refreshCycleCheck` keeps this so it can detect an on-disk edit
+    /// to a *referenced* flow — which can create or break a transitive
+    /// cycle the open flow's own reference set never reveals. Owned by
+    /// `arena`.
+    read_files: []const FileStamp = &.{},
 
     pub fn deinit(self: *Report) void {
         const child = self.arena.child_allocator;
@@ -81,18 +116,32 @@ pub const Report = struct {
     }
 };
 
+/// Result of resolving one flow name to its outgoing `Subflow`
+/// references — the value the `Resolver` callback returns.
+pub const RefResult = union(enum) {
+    /// The flow resolved; `.refs` is its (possibly empty) list of
+    /// referenced flow names. The slice and its strings must outlive
+    /// the `detectCycle` call.
+    ok: []const []const u8,
+    /// No flow with this effective name exists on disk.
+    missing,
+    /// A flow file with this name exists but failed to load or parse
+    /// (a JSON / schema error). Distinct from `missing` so the editor
+    /// can surface "fix this file" rather than "create this file".
+    parse_failed,
+};
+
 /// Abstract source of a flow's outgoing `Subflow` references. The pure
 /// `detectCycle` walk only needs this — it never touches the
-/// filesystem. `refs` returns:
-///   - the (possibly empty) list of flow names this flow references,
-///   - or `null` when the named flow cannot be resolved at all.
+/// filesystem. `refs` returns a `RefResult` classifying the named flow
+/// as resolved (with its references), missing, or present-but-broken.
 /// The returned slice and its strings must outlive the `detectCycle`
 /// call (the project resolver allocates them on the report arena).
 pub const Resolver = struct {
     ctx: *anyopaque,
-    refsFn: *const fn (ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8,
+    refsFn: *const fn (ctx: *anyopaque, name: []const u8) anyerror!RefResult,
 
-    fn refs(self: Resolver, name: []const u8) anyerror!?[]const []const u8 {
+    fn refs(self: Resolver, name: []const u8) anyerror!RefResult {
         return self.refsFn(self.ctx, name);
     }
 };
@@ -144,15 +193,19 @@ fn walk(
     // Already proven clean on an earlier branch — skip.
     if (visited.contains(name)) return .clean;
 
-    const child_refs = (try resolver.refs(name)) orelse {
-        // `name` itself couldn't be resolved. Report the path that led
+    const child_refs = switch (try resolver.refs(name)) {
+        .ok => |refs| refs,
+        // `name` names no flow file on disk. Report the path that led
         // here, including `name`.
-        var chain: std.ArrayList([]const u8) = .empty;
-        for (path.items) |n| {
-            try chain.append(arena, try arena.dupe(u8, n));
-        }
-        try chain.append(arena, try arena.dupe(u8, name));
-        return .{ .unresolved = .{ .names = try chain.toOwnedSlice(arena) } };
+        .missing => return .{
+            .unresolved = .{ .names = try chainTo(arena, path, name) },
+        },
+        // `name`'s flow file exists but is broken. Same chain shape as
+        // `unresolved`, but a distinct status so the banner can say
+        // "fix this file" rather than "create this file".
+        .parse_failed => return .{
+            .parse_failed = .{ .names = try chainTo(arena, path, name) },
+        },
     };
 
     try path.append(arena, name);
@@ -167,6 +220,23 @@ fn walk(
     // arena-owned copy so the key outlives any borrowed slice.
     try visited.put(arena, try arena.dupe(u8, name), {});
     return .clean;
+}
+
+/// Build the offending chain for a non-resolving flow: every name on
+/// the current DFS path, then `tail` (the offending name itself).
+/// Strings are duped onto `arena` so the chain outlives the walk's
+/// borrowed `path`.
+fn chainTo(
+    arena: std.mem.Allocator,
+    path: *std.ArrayList([]const u8),
+    tail: []const u8,
+) ![][]const u8 {
+    var chain: std.ArrayList([]const u8) = .empty;
+    for (path.items) |n| {
+        try chain.append(arena, try arena.dupe(u8, n));
+    }
+    try chain.append(arena, try arena.dupe(u8, tail));
+    return chain.toOwnedSlice(arena);
 }
 
 // ─── Project-backed resolver ────────────────────────────────────────────
@@ -188,25 +258,42 @@ const ProjectResolver = struct {
     arena: std.mem.Allocator,
     /// Absolute path of the project's `scripts/flows/` directory.
     flows_dir: []const u8,
-    /// flow name → its outgoing Subflow refs (`null` cached for a name
-    /// whose flow is missing or unparseable).
-    cache: std.StringHashMapUnmanaged(?[]const []const u8) = .empty,
+    /// flow name → the cached `RefResult` for it (resolved refs,
+    /// missing, or present-but-broken).
+    cache: std.StringHashMapUnmanaged(RefResult) = .empty,
     /// effective registry name → absolute file path. Built once by
     /// `ensureIndex`. `null` until the first `refs` call scans the dir.
     index: ?std.StringHashMapUnmanaged([]const u8) = null,
+    /// filename basename (without `.flow.jsonc`) → absolute path, for
+    /// every flow file that *failed to parse* during the directory
+    /// scan. A flow whose file is broken can't contribute a registry
+    /// `name`, so a reference to it only resolves when the `flow_ref`
+    /// equals the broken file's basename — the same fallback rule
+    /// `displayNameFromPath` applies to a nameless flow. Built by
+    /// `ensureIndex` alongside `index`.
+    broken: std.StringHashMapUnmanaged([]const u8) = .empty,
+    /// Every `.flow.jsonc` file seen during the directory scan, with
+    /// the `mtime`/`size` observed then. Surfaced on the `Report` so a
+    /// later check can tell whether any referenced file changed.
+    seen_files: std.ArrayListUnmanaged(FileStamp) = .empty,
 
-    fn refs(ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8 {
+    fn refs(ctx: *anyopaque, name: []const u8) anyerror!RefResult {
         const self: *ProjectResolver = @ptrCast(@alignCast(ctx));
         if (self.cache.get(name)) |cached| return cached;
 
-        const result = self.loadRefs(name) catch null;
+        // A filesystem error while resolving is treated as `missing` —
+        // the editor can't prove the flow is fine, so it flags it.
+        const result = self.loadRefs(name) catch RefResult.missing;
         try self.cache.put(self.arena, try self.arena.dupe(u8, name), result);
         return result;
     }
 
     /// Scan `flows_dir` once and index every flow file by its effective
     /// registry name. A directory that can't be opened yields an empty
-    /// index (every reference then resolves to `unresolved`).
+    /// index (every reference then resolves to `unresolved`). Files that
+    /// fail to parse are recorded in `broken` (keyed by basename) rather
+    /// than dropped, so a reference to a broken file is reported as
+    /// `parse_failed`, not `missing`.
     fn ensureIndex(self: *ProjectResolver) !*std.StringHashMapUnmanaged([]const u8) {
         if (self.index) |*idx| return idx;
         self.index = .empty;
@@ -229,12 +316,30 @@ const ProjectResolver = struct {
                 self.arena,
                 &.{ self.flows_dir, entry.name },
             );
+            // Record the file's stamp before parsing — a referenced
+            // file changing on disk (even one that now parses cleanly)
+            // must invalidate a cached check.
+            try self.recordStamp(full);
+
+            const base = flow_io.displayNameFromPath(entry.name);
             // Effective name = top-level `name`, else filename basename.
-            var doc = flow_io.loadFromFile(self.arena, full) catch continue;
+            var doc = flow_io.loadFromFile(self.arena, full) catch {
+                // The file exists but is broken. Index it by basename in
+                // `broken` so a `flow_ref` matching that basename
+                // resolves to `parse_failed` rather than `missing`.
+                if (!self.broken.contains(base)) {
+                    try self.broken.put(
+                        self.arena,
+                        try self.arena.dupe(u8, base),
+                        full,
+                    );
+                }
+                continue;
+            };
             const eff = if (doc.name) |n|
                 try self.arena.dupe(u8, n)
             else
-                try self.arena.dupe(u8, flow_io.displayNameFromPath(entry.name));
+                try self.arena.dupe(u8, base);
             doc.deinit();
 
             // First file wins on a duplicate name — deterministic and
@@ -244,14 +349,45 @@ const ProjectResolver = struct {
         return idx;
     }
 
+    /// `stat` `full` and append a `FileStamp` for it to `seen_files`. A
+    /// stat failure still records the path (with null mtime/size) so the
+    /// file is part of the "changed?" comparison set.
+    fn recordStamp(self: *ProjectResolver, full: []const u8) !void {
+        const io = io_global.io();
+        const st = std.Io.Dir.cwd().statFile(io, full, .{}) catch {
+            try self.seen_files.append(self.arena, .{
+                .path = full,
+                .mtime_ns = null,
+                .size = null,
+            });
+            return;
+        };
+        try self.seen_files.append(self.arena, .{
+            .path = full,
+            .mtime_ns = st.mtime.nanoseconds,
+            .size = st.size,
+        });
+    }
+
     /// Resolve `name` to its flow file via the registry-name index,
     /// parse it, and return the distinct non-empty `Subflow` `flow_ref`
-    /// values it contains. `null` when no flow has that effective name.
-    fn loadRefs(self: *ProjectResolver, name: []const u8) !?[]const []const u8 {
+    /// values it contains. Returns `.missing` when no flow has that
+    /// effective name and no broken file's basename matches, and
+    /// `.parse_failed` when a file exists for it but failed to parse.
+    fn loadRefs(self: *ProjectResolver, name: []const u8) !RefResult {
         const idx = try self.ensureIndex();
-        const full = idx.get(name) orelse return null;
+        const full = idx.get(name) orelse {
+            // Not a resolvable registry name. If a *broken* file's
+            // basename matches, the reference points at a present but
+            // unparseable flow — surface that distinctly.
+            if (self.broken.contains(name)) return .parse_failed;
+            return .missing;
+        };
 
-        var doc = flow_io.loadFromFile(self.arena, full) catch return null;
+        // The file parsed during the scan; a failure here means it
+        // changed (or a transient IO error) between scan and re-read —
+        // treat it as broken rather than missing.
+        var doc = flow_io.loadFromFile(self.arena, full) catch return .parse_failed;
         defer doc.deinit();
 
         var out: std.ArrayList([]const u8) = .empty;
@@ -265,7 +401,7 @@ const ProjectResolver = struct {
             try seen.put(self.arena, ref, {});
             try out.append(self.arena, ref);
         }
-        return try out.toOwnedSlice(self.arena);
+        return .{ .ok = try out.toOwnedSlice(self.arena) };
     }
 };
 
@@ -314,7 +450,7 @@ pub fn analyze(
         try resolver_ctx.cache.put(
             a,
             try a.dupe(u8, entry_name),
-            try refs_copy.toOwnedSlice(a),
+            .{ .ok = try refs_copy.toOwnedSlice(a) },
         );
     }
 
@@ -333,6 +469,7 @@ pub fn analyze(
         .clean => null,
         .cycle => |c| c,
         .unresolved => |c| c,
+        .parse_failed => |c| c,
     };
     if (chain) |c| {
         var out: std.ArrayList(u8) = .empty;
@@ -340,19 +477,33 @@ pub fn analyze(
         chain_text = try out.toOwnedSlice(a);
     }
 
-    return .{ .arena = arena, .status = status, .chain_text = chain_text };
+    // Hand the caller the set of files the resolver stat'd — the
+    // resolver allocated the `FileStamp`s and their paths on the report
+    // arena, so they outlive this call and `deinit` reclaims them.
+    const read_files = try resolver_ctx.seen_files.toOwnedSlice(a);
+
+    return .{
+        .arena = arena,
+        .status = status,
+        .chain_text = chain_text,
+        .read_files = read_files,
+    };
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────
 
 /// In-memory resolver for tests — a flow name → refs map. A name absent
-/// from the map resolves to `null` (unresolved).
+/// from the map resolves to `.missing`; a name present in `broken`
+/// resolves to `.parse_failed`.
 const MapResolver = struct {
     map: std.StringHashMapUnmanaged([]const []const u8),
+    broken: std.StringHashMapUnmanaged(void) = .empty,
 
-    fn refs(ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8 {
+    fn refs(ctx: *anyopaque, name: []const u8) anyerror!RefResult {
         const self: *MapResolver = @ptrCast(@alignCast(ctx));
-        return self.map.get(name);
+        if (self.map.get(name)) |r| return .{ .ok = r };
+        if (self.broken.contains(name)) return .parse_failed;
+        return .missing;
     }
 
     fn resolver(self: *MapResolver) Resolver {
@@ -440,6 +591,23 @@ test "detectCycle: unresolved reference is reported" {
     try std.testing.expect(status == .unresolved);
     try std.testing.expectEqual(@as(usize, 3), status.unresolved.names.len);
     try std.testing.expectEqualStrings("missing", status.unresolved.names[2]);
+}
+
+test "detectCycle: a broken referenced flow reports parse_failed" {
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "a", &.{"b"});
+    try m.map.put(a, "b", &.{"broken"});
+    // "broken" exists but won't parse — distinct from a missing file.
+    try m.broken.put(a, "broken", {});
+
+    const status = try detectCycle(a, "a", m.resolver());
+    try std.testing.expect(status == .parse_failed);
+    try std.testing.expectEqual(@as(usize, 3), status.parse_failed.names.len);
+    try std.testing.expectEqualStrings("broken", status.parse_failed.names[2]);
 }
 
 test "detectCycle: diamond reference graph is clean and walked once" {

--- a/src/flow_cycle.zig
+++ b/src/flow_cycle.zig
@@ -626,6 +626,95 @@ test "detectCycle: diamond reference graph is clean and walked once" {
     try std.testing.expect(status == .clean);
 }
 
+test "detectCycle: cycle reachable only through a node first seen on a clean branch" {
+    // Regression for the classic DFS three-state mistake: the `visited`
+    // (done) set must mean "fully explored AND acyclic", never "seen".
+    //
+    //   entry → x → c        (c first encountered down a clean-looking
+    //   entry → b → c → b     branch via x; the cycle is b → c → b)
+    //
+    // `x` is walked before `b`. While walking `x → c`, `c → b` is
+    // explored — `b` is not yet on the path, so the walk descends into
+    // `b → c`, finds `c` *is* on the path, and reports the cycle. `c`
+    // must therefore never enter the `done` set, and the later
+    // `entry → b` branch must still see the cycle. A walk that marked
+    // `c` "done" on first sight would wrongly return `.clean`.
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "entry", &.{ "x", "b" });
+    try m.map.put(a, "x", &.{"c"});
+    try m.map.put(a, "b", &.{"c"});
+    try m.map.put(a, "c", &.{"b"});
+
+    const status = try detectCycle(a, "entry", m.resolver());
+    try std.testing.expect(status == .cycle);
+    // The offending chain is the b ↔ c loop. The walk descends
+    // entry → x → c → b → c, so the back edge closes at `c`: the chain
+    // is c → b → c, opening and closing on the same name.
+    try std.testing.expectEqual(@as(usize, 3), status.cycle.names.len);
+    try std.testing.expectEqualStrings("c", status.cycle.names[0]);
+    try std.testing.expectEqualStrings("b", status.cycle.names[1]);
+    try std.testing.expectEqualStrings(
+        status.cycle.names[0],
+        status.cycle.names[status.cycle.names.len - 1],
+    );
+}
+
+test "detectCycle: cycle behind a node reached via two clean-prefix paths" {
+    // A node (`c`) reachable via two paths, one of which closes a cycle.
+    //
+    //   entry → d           d's children are walked in order:
+    //   d → c               (1) c → leaf, a genuinely clean subtree
+    //   c → leaf            (2) e → d  closes the cycle d → e → d
+    //   d → e
+    //   e → d
+    //
+    // Child (1) leaves `c` (and `leaf`) in the `done` set. Child (2)
+    // then finds the back edge to `d`. The earlier `done` marking of the
+    // sibling subtree must not suppress the cycle on the later branch.
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "entry", &.{"d"});
+    try m.map.put(a, "d", &.{ "c", "e" });
+    try m.map.put(a, "c", &.{"leaf"});
+    try m.map.put(a, "leaf", &.{});
+    try m.map.put(a, "e", &.{"d"});
+
+    const status = try detectCycle(a, "entry", m.resolver());
+    try std.testing.expect(status == .cycle);
+    try std.testing.expectEqualStrings("d", status.cycle.names[0]);
+    try std.testing.expectEqualStrings(
+        "d",
+        status.cycle.names[status.cycle.names.len - 1],
+    );
+}
+
+test "detectCycle: a node reached via two clean paths is not a false cycle" {
+    // Counterpart to the regression above: a node (`c`) reached twice,
+    // both paths genuinely acyclic, must stay `.clean`. The `done` set
+    // is what makes the second visit a cheap skip — and that skip must
+    // not be mistaken for, nor mistakenly upgraded to, a cycle.
+    var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer a_state.deinit();
+    const a = a_state.allocator();
+
+    var m: MapResolver = .{ .map = .empty };
+    try m.map.put(a, "a", &.{ "x", "y" });
+    try m.map.put(a, "x", &.{"c"});
+    try m.map.put(a, "y", &.{"c"});
+    try m.map.put(a, "c", &.{"leaf"});
+    try m.map.put(a, "leaf", &.{});
+
+    const status = try detectCycle(a, "a", m.resolver());
+    try std.testing.expect(status == .clean);
+}
+
 test "detectCycle: empty entry with no refs is clean" {
     var a_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer a_state.deinit();

--- a/src/flow_cycle.zig
+++ b/src/flow_cycle.zig
@@ -12,8 +12,9 @@
 //!     `FlowReferenceCycle` for this; codegen can't generate a finite
 //!     program from an infinitely-nested flow.
 //!   - **An unresolved reference** — a `Subflow` names a flow whose
-//!     `scripts/flows/<name>.flow.jsonc` file doesn't exist or won't
-//!     parse. flow-codegen raises `UnknownFlowRef`.
+//!     effective registry name (RFC §5: the flow's top-level `name`,
+//!     else its filename basename) matches no `.flow.jsonc` file under
+//!     `scripts/flows/`. flow-codegen raises `UnknownFlowRef`.
 //!
 //! The pure walk (`detectCycle`) is decoupled from the filesystem via
 //! a `Resolver` callback so it can be unit-tested with an in-memory
@@ -63,6 +64,11 @@ pub const Chain = struct {
 pub const Report = struct {
     arena: *std.heap.ArenaAllocator,
     status: Status,
+    /// The offending chain rendered as `a → b → c`, built once when the
+    /// report is generated (the chain only changes when the analysis
+    /// re-runs). Empty for a `clean` status. Owned by `arena`, so the
+    /// UI can display it every frame without re-allocating.
+    chain_text: []const u8 = "",
 
     pub fn deinit(self: *Report) void {
         const child = self.arena.child_allocator;
@@ -165,17 +171,29 @@ fn walk(
 
 // ─── Project-backed resolver ────────────────────────────────────────────
 
-/// Resolver context that reads `<flows_dir>/<name>.flow.jsonc` from
-/// disk. Parses each file once and caches its `Subflow` references on
-/// the report arena, so a diamond reference graph reads each file at
-/// most once.
+/// Resolver context that reads referenced flows from a project's
+/// `scripts/flows/` directory.
+///
+/// A `Subflow`'s `flow_ref` is the referenced flow's *effective
+/// registry name* (RFC §5) — its explicit top-level `name`, or the
+/// filename basename when `name` is absent. The on-disk filename can
+/// therefore differ from the registry name a `flow_ref` carries.
+///
+/// To resolve correctly the resolver scans `scripts/flows/*.flow.jsonc`
+/// exactly once (lazily, on first use), parses each flow's effective
+/// name, and builds a `name → path` index. `refs` then keys on that
+/// index. Each referenced flow is parsed at most once; its `Subflow`
+/// references are cached so a diamond reference graph stays cheap.
 const ProjectResolver = struct {
     arena: std.mem.Allocator,
     /// Absolute path of the project's `scripts/flows/` directory.
     flows_dir: []const u8,
     /// flow name → its outgoing Subflow refs (`null` cached for a name
-    /// whose file is missing or unparseable).
+    /// whose flow is missing or unparseable).
     cache: std.StringHashMapUnmanaged(?[]const []const u8) = .empty,
+    /// effective registry name → absolute file path. Built once by
+    /// `ensureIndex`. `null` until the first `refs` call scans the dir.
+    index: ?std.StringHashMapUnmanaged([]const u8) = null,
 
     fn refs(ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8 {
         const self: *ProjectResolver = @ptrCast(@alignCast(ctx));
@@ -186,20 +204,52 @@ const ProjectResolver = struct {
         return result;
     }
 
-    /// Read and parse `<flows_dir>/<name>.flow.jsonc`, returning the
-    /// distinct non-empty `Subflow` `flow_ref` values it contains.
+    /// Scan `flows_dir` once and index every flow file by its effective
+    /// registry name. A directory that can't be opened yields an empty
+    /// index (every reference then resolves to `unresolved`).
+    fn ensureIndex(self: *ProjectResolver) !*std.StringHashMapUnmanaged([]const u8) {
+        if (self.index) |*idx| return idx;
+        self.index = .empty;
+        const idx = &self.index.?;
+
+        const io = io_global.io();
+        var dir = std.Io.Dir.cwd().openDir(
+            io,
+            self.flows_dir,
+            .{ .iterate = true },
+        ) catch return idx;
+        defer dir.close(io);
+
+        var it = dir.iterate();
+        while (it.next(io) catch null) |entry| {
+            if (entry.kind != .file) continue;
+            if (!std.mem.endsWith(u8, entry.name, flow_io.extension)) continue;
+
+            const full = try std.fs.path.join(
+                self.arena,
+                &.{ self.flows_dir, entry.name },
+            );
+            // Effective name = top-level `name`, else filename basename.
+            var doc = flow_io.loadFromFile(self.arena, full) catch continue;
+            const eff = if (doc.name) |n|
+                try self.arena.dupe(u8, n)
+            else
+                try self.arena.dupe(u8, flow_io.displayNameFromPath(entry.name));
+            doc.deinit();
+
+            // First file wins on a duplicate name — deterministic and
+            // matches flow-codegen's "ambiguous registry key" handling.
+            if (!idx.contains(eff)) try idx.put(self.arena, eff, full);
+        }
+        return idx;
+    }
+
+    /// Resolve `name` to its flow file via the registry-name index,
+    /// parse it, and return the distinct non-empty `Subflow` `flow_ref`
+    /// values it contains. `null` when no flow has that effective name.
     fn loadRefs(self: *ProjectResolver, name: []const u8) !?[]const []const u8 {
-        const path = try std.fs.path.join(
-            self.arena,
-            &.{ self.flows_dir, name },
-        );
-        // `name` is a bare flow name; the on-disk file adds the
-        // extension. Build `<flows_dir>/<name>.flow.jsonc`.
-        const full = try std.fmt.allocPrint(
-            self.arena,
-            "{s}{s}",
-            .{ path, flow_io.extension },
-        );
+        const idx = try self.ensureIndex();
+        const full = idx.get(name) orelse return null;
 
         var doc = flow_io.loadFromFile(self.arena, full) catch return null;
         defer doc.deinit();
@@ -274,7 +324,23 @@ pub fn analyze(
     };
 
     const status = try detectCycle(a, entry_name, resolver);
-    return .{ .arena = arena, .status = status };
+
+    // Render the offending chain once, here, while the report is
+    // generated — the chain only changes when the analysis re-runs, so
+    // the UI never needs to rebuild it per frame.
+    var chain_text: []const u8 = "";
+    const chain: ?Chain = switch (status) {
+        .clean => null,
+        .cycle => |c| c,
+        .unresolved => |c| c,
+    };
+    if (chain) |c| {
+        var out: std.ArrayList(u8) = .empty;
+        try c.format(&out, a);
+        chain_text = try out.toOwnedSlice(a);
+    }
+
+    return .{ .arena = arena, .status = status, .chain_text = chain_text };
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────

--- a/src/flow_cycle.zig
+++ b/src/flow_cycle.zig
@@ -73,6 +73,34 @@ pub const FileStamp = struct {
     size: ?u64,
 };
 
+/// A `.flow.jsonc` path a reference *expected* but the analysis could
+/// not successfully read — either it does not exist (`unresolved`) or it
+/// exists but failed to parse (`parse_failed`). `refreshCycleCheck`
+/// keeps this set alongside `read_files`: a previously-missing target
+/// that later *appears* on disk (or a parse-failed one whose content
+/// changes) can newly resolve a reference — possibly introducing a
+/// cycle — so its appearance must re-trigger the check even though
+/// `read_files` never tracked it.
+pub const MissingStamp = struct {
+    /// The absolute `.flow.jsonc` path the resolver expected for the
+    /// reference — `<flows_dir>/<flow_ref>.flow.jsonc` for a missing
+    /// target (the filename-basename fallback, RFC §5), or the broken
+    /// file's own path for a `parse_failed` one. Owned by the report
+    /// arena.
+    path: []const u8,
+    /// `true` when a file exists at `path` but failed to parse
+    /// (`parse_failed`); `false` when nothing exists there
+    /// (`unresolved`). For a parse-failed target a *content change*
+    /// re-triggers the check (the file may now parse); for a missing one
+    /// the file *appearing at all* re-triggers it.
+    parse_failed: bool,
+    /// `mtime`/`size` observed at analysis time. For a missing target
+    /// these are `null` (nothing to stat); for a parse-failed one they
+    /// stamp the broken file so a later content edit is noticed.
+    mtime_ns: ?i96 = null,
+    size: ?u64 = null,
+};
+
 /// An ordered list of flow names describing an offending reference
 /// path. Owned by the allocator passed to the analysis call.
 pub const Chain = struct {
@@ -104,6 +132,16 @@ pub const Report = struct {
     /// cycle the open flow's own reference set never reveals. Owned by
     /// `arena`.
     read_files: []const FileStamp = &.{},
+    /// Every reference target the analysis could *not* successfully read
+    /// — a missing flow file (`unresolved`) or one that exists but
+    /// failed to parse (`parse_failed`) — with the `.flow.jsonc` path the
+    /// resolver expected for it. `refreshCycleCheck` keeps this so it can
+    /// detect a previously-missing target *appearing* on disk (or a
+    /// parse-failed one changing): either can newly resolve a reference
+    /// and so must re-trigger the check. `read_files` never tracks these
+    /// (it only stamps files that were successfully read). Owned by
+    /// `arena`.
+    unresolved_targets: []const MissingStamp = &.{},
 
     pub fn deinit(self: *Report) void {
         const child = self.arena.child_allocator;
@@ -276,6 +314,13 @@ const ProjectResolver = struct {
     /// the `mtime`/`size` observed then. Surfaced on the `Report` so a
     /// later check can tell whether any referenced file changed.
     seen_files: std.ArrayListUnmanaged(FileStamp) = .empty,
+    /// Every reference target that did *not* resolve to a readable flow
+    /// — keyed by the `.flow.jsonc` path the resolver expected — with a
+    /// `MissingStamp` recording whether a (broken) file exists there.
+    /// Keyed by path (not by `flow_ref`) so a diamond of references that
+    /// all miss the same file records the target once. Surfaced on the
+    /// `Report` so a later check can notice the target appearing.
+    missing_targets: std.StringHashMapUnmanaged(MissingStamp) = .empty,
 
     fn refs(ctx: *anyopaque, name: []const u8) anyerror!RefResult {
         const self: *ProjectResolver = @ptrCast(@alignCast(ctx));
@@ -286,6 +331,40 @@ const ProjectResolver = struct {
         const result = self.loadRefs(name) catch RefResult.missing;
         try self.cache.put(self.arena, try self.arena.dupe(u8, name), result);
         return result;
+    }
+
+    /// Record the `.flow.jsonc` path a non-resolving reference expected,
+    /// so a later check can notice that target appearing (or, for a
+    /// broken file, changing) on disk. `expected` for a `.missing`
+    /// target is the filename-basename fallback path
+    /// `<flows_dir>/<name>.flow.jsonc`; for a `.parse_failed` one it is
+    /// the broken file's own path. Stamps the path so a parse-failed
+    /// file's later content edit is also caught.
+    fn recordMissing(
+        self: *ProjectResolver,
+        expected: []const u8,
+        parse_failed: bool,
+    ) !void {
+        if (self.missing_targets.contains(expected)) return;
+        const io = io_global.io();
+        var stamp: MissingStamp = .{ .path = expected, .parse_failed = parse_failed };
+        if (std.Io.Dir.cwd().statFile(io, expected, .{})) |st| {
+            stamp.mtime_ns = st.mtime.nanoseconds;
+            stamp.size = st.size;
+        } else |_| {}
+        try self.missing_targets.put(self.arena, expected, stamp);
+    }
+
+    /// The `.flow.jsonc` path the filename-basename fallback (RFC §5)
+    /// would place a flow named `name` at — `<flows_dir>/<name>.flow.jsonc`.
+    /// This is the path a *missing* reference expected, so a check can
+    /// stat it later to notice the target appearing.
+    fn expectedPath(self: *ProjectResolver, name: []const u8) ![]const u8 {
+        return std.fmt.allocPrint(
+            self.arena,
+            "{s}{c}{s}{s}",
+            .{ self.flows_dir, std.fs.path.sep, name, flow_io.extension },
+        );
     }
 
     /// Scan `flows_dir` once and index every flow file by its effective
@@ -380,14 +459,24 @@ const ProjectResolver = struct {
             // Not a resolvable registry name. If a *broken* file's
             // basename matches, the reference points at a present but
             // unparseable flow — surface that distinctly.
-            if (self.broken.contains(name)) return .parse_failed;
+            if (self.broken.get(name)) |broken_path| {
+                try self.recordMissing(broken_path, true);
+                return .parse_failed;
+            }
+            // No file resolves this name. Record the path the
+            // basename-fallback rule would expect, so a later check
+            // notices the target appearing on disk.
+            try self.recordMissing(try self.expectedPath(name), false);
             return .missing;
         };
 
         // The file parsed during the scan; a failure here means it
         // changed (or a transient IO error) between scan and re-read —
         // treat it as broken rather than missing.
-        var doc = flow_io.loadFromFile(self.arena, full) catch return .parse_failed;
+        var doc = flow_io.loadFromFile(self.arena, full) catch {
+            try self.recordMissing(full, true);
+            return .parse_failed;
+        };
         defer doc.deinit();
 
         var out: std.ArrayList([]const u8) = .empty;
@@ -482,11 +571,23 @@ pub fn analyze(
     // arena, so they outlive this call and `deinit` reclaims them.
     const read_files = try resolver_ctx.seen_files.toOwnedSlice(a);
 
+    // Also hand over the targets that did *not* resolve, each with the
+    // `.flow.jsonc` path the resolver expected. A later check stats
+    // these so a previously-missing target appearing on disk re-triggers
+    // the analysis (`read_files` can never cover them — they were never
+    // read). All paths/stamps live on the report arena.
+    var missing_targets: std.ArrayList(MissingStamp) = .empty;
+    {
+        var it = resolver_ctx.missing_targets.valueIterator();
+        while (it.next()) |stamp| try missing_targets.append(a, stamp.*);
+    }
+
     return .{
         .arena = arena,
         .status = status,
         .chain_text = chain_text,
         .read_files = read_files,
+        .unresolved_targets = try missing_targets.toOwnedSlice(a),
     };
 }
 

--- a/src/flow_cycle.zig
+++ b/src/flow_cycle.zig
@@ -36,6 +36,12 @@ const std = @import("std");
 const io_global = @import("io_global.zig");
 const flow_io = @import("flow_io.zig");
 
+/// Placeholder used as `DuplicateName.path_a` when the open flow tab
+/// itself collides with an on-disk file. The open tab may be unsaved, so
+/// it has no path to report — this marker tells the banner the conflict
+/// involves the flow the user is editing.
+pub const open_flow_marker = "<open flow>";
+
 /// Outcome of a cycle check.
 pub const Status = union(enum) {
     /// No cycle, every transitively-referenced flow resolved.
@@ -55,6 +61,29 @@ pub const Status = union(enum) {
     /// the broken flow's name. Distinct from `unresolved` so the editor
     /// can tell "fix this file" apart from "create this file".
     parse_failed: Chain,
+    /// Two `.flow.jsonc` files under `scripts/flows/` resolve to the
+    /// *same* effective registry name (RFC §5). flow-codegen's
+    /// `FlowRegistry` rejects this as `DuplicateFlowName` — the project
+    /// is invalid. The editor surfaces it because the silent
+    /// first-file-wins index would otherwise let a cycle hide in the
+    /// shadowed file (its `Subflow` refs are never consulted). The open
+    /// tab's own `entry_name` colliding with an on-disk file is the same
+    /// fault and is reported here too.
+    duplicate_name: DuplicateName,
+};
+
+/// The two `.flow.jsonc` files that share one effective registry name.
+/// All three strings are owned by the report arena.
+pub const DuplicateName = struct {
+    /// The effective registry name both files claim.
+    name: []const u8,
+    /// Absolute path of the file indexed first for `name`. For an
+    /// `entry_name` collision this is the entry's own marker
+    /// `"<open flow>"` (the open tab has no on-disk path here — it may
+    /// be unsaved), with `path_b` the conflicting on-disk file.
+    path_a: []const u8,
+    /// Absolute path of the second file claiming `name`.
+    path_b: []const u8,
 };
 
 /// A snapshot of one `.flow.jsonc` file the analysis read while
@@ -296,9 +325,23 @@ const ProjectResolver = struct {
     arena: std.mem.Allocator,
     /// Absolute path of the project's `scripts/flows/` directory.
     flows_dir: []const u8,
+    /// Effective registry name of the open flow being analyzed. The
+    /// directory scan checks every on-disk flow's effective name against
+    /// this: a collision is the same `DuplicateFlowName` fault as two
+    /// on-disk files clashing, and must be surfaced even though the open
+    /// tab may be unsaved (so it has no entry in the on-disk index).
+    entry_name: []const u8 = "",
     /// flow name → the cached `RefResult` for it (resolved refs,
     /// missing, or present-but-broken).
     cache: std.StringHashMapUnmanaged(RefResult) = .empty,
+    /// First duplicate effective registry name found during the
+    /// directory scan, if any. `ensureIndex` sets this when two
+    /// `.flow.jsonc` files (or one file and the open tab) resolve to the
+    /// same effective name. `analyze` reports it ahead of any cycle
+    /// result — a duplicate name makes the registry itself invalid, and
+    /// the silent first-file-wins index can hide a cycle in the
+    /// shadowed file. All three strings are arena-owned.
+    duplicate: ?DuplicateName = null,
     /// effective registry name → absolute file path. Built once by
     /// `ensureIndex`. `null` until the first `refs` call scans the dir.
     index: ?std.StringHashMapUnmanaged([]const u8) = null,
@@ -421,9 +464,37 @@ const ProjectResolver = struct {
                 try self.arena.dupe(u8, base);
             doc.deinit();
 
-            // First file wins on a duplicate name — deterministic and
-            // matches flow-codegen's "ambiguous registry key" handling.
-            if (!idx.contains(eff)) try idx.put(self.arena, eff, full);
+            // Two `.flow.jsonc` files claiming the same effective
+            // registry name is `DuplicateFlowName` — flow-codegen
+            // rejects the project. Silently keeping the first file would
+            // let a cycle hide in the shadowed one (its `Subflow` refs
+            // are never resolved), so record the clash; `analyze` reports
+            // it ahead of any cycle result. Keep the first one found.
+            if (idx.get(eff)) |first_path| {
+                if (self.duplicate == null) {
+                    self.duplicate = .{
+                        .name = eff,
+                        .path_a = first_path,
+                        .path_b = full,
+                    };
+                }
+                continue;
+            }
+            // The open tab's effective name colliding with an on-disk
+            // file is the same fault — and the open tab may be unsaved,
+            // so it never appears in `idx`. Flag it before indexing the
+            // file so the entry's `<open flow>` marker is `path_a`.
+            if (self.entry_name.len > 0 and
+                std.mem.eql(u8, eff, self.entry_name) and
+                self.duplicate == null)
+            {
+                self.duplicate = .{
+                    .name = eff,
+                    .path_a = try self.arena.dupe(u8, open_flow_marker),
+                    .path_b = full,
+                };
+            }
+            try idx.put(self.arena, eff, full);
         }
         return idx;
     }
@@ -521,6 +592,10 @@ pub fn analyze(
     resolver_ctx.* = .{
         .arena = a,
         .flows_dir = try a.dupe(u8, flows_dir),
+        // The scan checks every on-disk flow's effective name against
+        // the open tab's name — a collision there is `DuplicateFlowName`
+        // too, and the unsaved open tab is otherwise invisible to it.
+        .entry_name = try a.dupe(u8, entry_name),
     };
 
     // Pre-seed the cache with the live (possibly unsaved) entry flow so
@@ -548,7 +623,22 @@ pub fn analyze(
         .refsFn = ProjectResolver.refs,
     };
 
-    const status = try detectCycle(a, entry_name, resolver);
+    const walk_status = try detectCycle(a, entry_name, resolver);
+
+    // The cycle walk only scans the flows directory when it actually
+    // resolves a referenced flow — an entry with no `Subflow` refs never
+    // triggers `ensureIndex`. Force the scan so a duplicate registry
+    // name (or an entry-name collision) is detected regardless.
+    _ = try resolver_ctx.ensureIndex();
+
+    // A duplicate effective registry name makes the whole flow registry
+    // invalid (flow-codegen rejects it) and the silent first-file-wins
+    // index can hide a cycle in the shadowed file — report it ahead of
+    // any cycle/unresolved/parse-failed result the walk produced.
+    const status: Status = if (resolver_ctx.duplicate) |dup|
+        .{ .duplicate_name = dup }
+    else
+        walk_status;
 
     // Render the offending chain once, here, while the report is
     // generated — the chain only changes when the analysis re-runs, so
@@ -559,6 +649,7 @@ pub fn analyze(
         .cycle => |c| c,
         .unresolved => |c| c,
         .parse_failed => |c| c,
+        .duplicate_name => null,
     };
     if (chain) |c| {
         var out: std.ArrayList(u8) = .empty;

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -36,6 +36,7 @@ const App = @import("../app.zig").App;
 const flow_io = @import("../flow_io.zig");
 const io_global = @import("../io_global.zig");
 const flow_cycle = @import("../flow_cycle.zig");
+const io_global = @import("../io_global.zig");
 
 const inspector_w: f32 = 340;
 const split_gap: f32 = 8;
@@ -155,7 +156,9 @@ pub const FlowDocState = struct {
     /// Result of the most recent `Subflow` reference-cycle check
     /// (issue #159). Null until the first check runs. A `clean` status
     /// is kept (rather than null) so the UI can tell "checked, fine"
-    /// apart from "not yet checked". Owns its own arena.
+    /// apart from "not yet checked". Owns its own arena. The report's
+    /// `read_files` field carries the on-disk stamps the check ran
+    /// against — `refreshCycleCheck` re-runs when any of them changes.
     cycle_report: ?flow_cycle.Report = null,
     /// Snapshot of the `Subflow` `flow_ref` set the last cycle check
     /// ran against, joined by `\n`. When the live set diverges from
@@ -222,13 +225,42 @@ fn effectiveName(s: *const FlowDocState) []const u8 {
     return s.doc.name orelse s.display_name;
 }
 
-/// Re-run the `Subflow` reference-cycle check if the live reference set
-/// has changed since the last run (or no check has run yet). Resolves
-/// referenced flows from the open document's own `scripts/flows/`
-/// directory — derived from the document path's parent.
+/// True when any `.flow.jsonc` file the last check read has changed on
+/// disk since — a different `mtime`, a different `size`, or a file that
+/// is now stat-able when it wasn't (or vice versa). An on-disk edit to
+/// a *referenced* flow can create or break a transitive cycle the open
+/// document's own `Subflow` reference set never reveals, so the banner
+/// must not trust a cached "clean" once any referenced file moves.
 ///
-/// Cheap to call every frame: when the reference set is unchanged this
-/// only builds and compares a short joined string and returns.
+/// Cheap: one `statFile` per referenced file. A flow graph references a
+/// handful of files at most, so this stays well within an immediate-mode
+/// frame budget.
+pub fn referencedFilesChanged(report: *const flow_cycle.Report) bool {
+    const io = io_global.io();
+    for (report.read_files) |f| {
+        const st = std.Io.Dir.cwd().statFile(io, f.path, .{}) catch {
+            // The file is no longer stat-able. Stale only if it *was*
+            // stat-able at check time.
+            if (f.mtime_ns != null or f.size != null) return true;
+            continue;
+        };
+        // The file became stat-able since the check, or its mtime/size
+        // moved — either way the cached result may be stale.
+        if (f.mtime_ns == null or f.size == null) return true;
+        if (f.mtime_ns.? != st.mtime.nanoseconds) return true;
+        if (f.size.? != st.size) return true;
+    }
+    return false;
+}
+
+/// Re-run the `Subflow` reference-cycle check if the live reference set
+/// has changed since the last run, if any referenced flow file changed
+/// on disk, or if no check has run yet. Resolves referenced flows from
+/// the open document's own `scripts/flows/` directory — derived from the
+/// document path's parent.
+///
+/// Cheap to call every frame: when nothing changed this only builds and
+/// compares a short joined string and stats a handful of files.
 fn refreshCycleCheck(s: *FlowDocState) void {
     // The tab arena (`ArenaAllocator.free` is a no-op) is never used
     // for per-frame scratch — the snapshot and refs are built on the
@@ -246,10 +278,17 @@ fn refreshCycleCheck(s: *FlowDocState) void {
         snap.append(child, '\n') catch return;
     }
 
-    if (s.cycle_report != null and
-        std.mem.eql(u8, snap.items, s.cycle_refs_snapshot)) return;
+    // Skip the re-analysis only when a check has run, the open flow's
+    // own reference set is unchanged, *and* none of the referenced
+    // files moved on disk. The disk-stamp check guards against a stale
+    // "clean" banner when a transitively-referenced flow is edited.
+    if (s.cycle_report) |*report| {
+        if (std.mem.eql(u8, snap.items, s.cycle_refs_snapshot) and
+            !referencedFilesChanged(report)) return;
+    }
 
-    // Reference set changed (or first run) — re-analyze.
+    // Reference set changed, a referenced file changed, or first run —
+    // re-analyze.
     var refs_arena = std.heap.ArenaAllocator.init(child);
     defer refs_arena.deinit();
     const refs = liveSubflowRefs(refs_arena.allocator(), s.doc) catch return;
@@ -365,6 +404,17 @@ fn renderCycleBanner(s: *FlowDocState) void {
             );
             zgui.textDisabled(
                 "The last flow in the chain has no scripts/flows/<name>.flow.jsonc file.",
+                .{},
+            );
+        },
+        .parse_failed => {
+            zgui.textColored(
+                .{ 1.0, 0.65, 0.2, 1.0 },
+                "Broken Subflow reference: {s}",
+                .{text},
+            );
+            zgui.textDisabled(
+                "The last flow in the chain has a .flow.jsonc file that failed to parse — fix that file.",
                 .{},
             );
         },

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -162,7 +162,12 @@ pub const FlowDocState = struct {
     cycle_report: ?flow_cycle.Report = null,
     /// Snapshot of the `Subflow` `flow_ref` set the last cycle check
     /// ran against, joined by `\n`. When the live set diverges from
-    /// this the check is re-run. Owned by `arena`.
+    /// this the check is re-run. Owned by the child/GPA allocator
+    /// (`arena.child_allocator`), *not* the tab arena: it is replaced on
+    /// every actual re-check, and arena `free` is a no-op, so persisting
+    /// it on the arena would leak the prior snapshot on each
+    /// invalidation. `refreshCycleCheck` frees the previous snapshot
+    /// before storing a new one; `deinit` frees the last one.
     cycle_refs_snapshot: []const u8 = "",
 
     pub fn open(allocator: std.mem.Allocator, path: []const u8) !FlowDocState {
@@ -199,6 +204,12 @@ pub const FlowDocState = struct {
         self.resolved.deinit(allocator);
         self.editor.destroy();
         if (self.cycle_report) |*r| r.deinit();
+        // The snapshot lives on the child/GPA allocator (see the field
+        // doc), so it must be freed explicitly — the arena does not own
+        // it. Freeing an empty `""` slice is a safe no-op.
+        if (self.cycle_refs_snapshot.len > 0) {
+            self.arena.child_allocator.free(self.cycle_refs_snapshot);
+        }
         self.doc.deinit();
         self.arena.deinit();
         allocator.destroy(self.arena);
@@ -263,9 +274,12 @@ pub fn referencedFilesChanged(report: *const flow_cycle.Report) bool {
 /// compares a short joined string and stats a handful of files.
 fn refreshCycleCheck(s: *FlowDocState) void {
     // The tab arena (`ArenaAllocator.free` is a no-op) is never used
-    // for per-frame scratch — the snapshot and refs are built on the
-    // child/GPA allocator and freed before this returns. Only the
-    // single stored snapshot persists, and it lives on the arena.
+    // for the cycle-check scratch *or* the persisted snapshot — both
+    // live on the child/GPA allocator. Per-frame scratch is freed
+    // before this returns; the single stored snapshot is freed and
+    // replaced on each actual re-check (and on `deinit`). Keeping it
+    // off the arena means an editing session does not accumulate one
+    // dead snapshot per invalidation.
     const child = s.arena.child_allocator;
 
     // Build a `\n`-joined snapshot of the current Subflow refs on the
@@ -311,15 +325,18 @@ fn refreshCycleCheck(s: *FlowDocState) void {
         std.log.err("flow: cycle check failed: {s}", .{@errorName(err)});
         if (s.cycle_report) |*old| old.deinit();
         s.cycle_report = null;
+        if (s.cycle_refs_snapshot.len > 0) child.free(s.cycle_refs_snapshot);
         s.cycle_refs_snapshot = "";
         return;
     };
 
-    // Duplicate the snapshot onto the tab arena *before* committing the
-    // new report — if the dup fails we keep the old report/snapshot
-    // pair consistent (rather than leaving an empty snapshot that would
-    // re-run the disk-backed analysis every subsequent frame).
-    const new_snapshot = s.arena.allocator().dupe(u8, snap.items) catch {
+    // Duplicate the snapshot onto the child/GPA allocator *before*
+    // committing the new report — if the dup fails we keep the old
+    // report/snapshot pair consistent (rather than leaving an empty
+    // snapshot that would re-run the disk-backed analysis every
+    // subsequent frame). The snapshot stays off the tab arena so the
+    // prior one can actually be reclaimed below.
+    const new_snapshot = child.dupe(u8, snap.items) catch {
         std.log.err("flow: cycle snapshot alloc failed; keeping prior result", .{});
         var report = new_report;
         report.deinit();
@@ -327,6 +344,9 @@ fn refreshCycleCheck(s: *FlowDocState) void {
     };
 
     if (s.cycle_report) |*old| old.deinit();
+    // Free the previous snapshot before replacing it — without this the
+    // child allocator would accumulate one dead snapshot per re-check.
+    if (s.cycle_refs_snapshot.len > 0) child.free(s.cycle_refs_snapshot);
     s.cycle_report = new_report;
     s.cycle_refs_snapshot = new_snapshot;
 }

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -35,6 +35,7 @@ const ne = zgui.node_editor;
 const App = @import("../app.zig").App;
 const flow_io = @import("../flow_io.zig");
 const io_global = @import("../io_global.zig");
+const flow_cycle = @import("../flow_cycle.zig");
 
 const inspector_w: f32 = 340;
 const split_gap: f32 = 8;
@@ -151,6 +152,15 @@ pub const FlowDocState = struct {
     /// same referenced flow is stat'd at most once per frame regardless of
     /// how many `Subflow` nodes point at it.
     frame_seq: u64 = 0,
+    /// Result of the most recent `Subflow` reference-cycle check
+    /// (issue #159). Null until the first check runs. A `clean` status
+    /// is kept (rather than null) so the UI can tell "checked, fine"
+    /// apart from "not yet checked". Owns its own arena.
+    cycle_report: ?flow_cycle.Report = null,
+    /// Snapshot of the `Subflow` `flow_ref` set the last cycle check
+    /// ran against, joined by `\n`. When the live set diverges from
+    /// this the check is re-run. Owned by `arena`.
+    cycle_refs_snapshot: []const u8 = "",
 
     pub fn open(allocator: std.mem.Allocator, path: []const u8) !FlowDocState {
         const arena = try allocator.create(std.heap.ArenaAllocator);
@@ -185,11 +195,80 @@ pub const FlowDocState = struct {
         for (self.resolved.items) |*r| r.deinit();
         self.resolved.deinit(allocator);
         self.editor.destroy();
+        if (self.cycle_report) |*r| r.deinit();
         self.doc.deinit();
         self.arena.deinit();
         allocator.destroy(self.arena);
     }
 };
+
+/// Build the bare-name `Subflow` reference list of the open document
+/// (its live, possibly-unsaved state). Empty refs are skipped here so
+/// the snapshot and the analysis input agree. Owned by `a`.
+fn liveSubflowRefs(a: std.mem.Allocator, doc: flow_io.FlowDoc) ![]const []const u8 {
+    var out: std.ArrayList([]const u8) = .empty;
+    for (doc.nodes) |n| {
+        if (n.kind != .subflow) continue;
+        if (n.flow_ref.len == 0) continue;
+        try out.append(a, n.flow_ref);
+    }
+    return out.toOwnedSlice(a);
+}
+
+/// The flow document's effective name — the explicit top-level `name`
+/// or, failing that, the filename basename (RFC §5, mirrored by
+/// `flow_io.displayNameFromPath`).
+fn effectiveName(s: *const FlowDocState) []const u8 {
+    return s.doc.name orelse s.display_name;
+}
+
+/// Re-run the `Subflow` reference-cycle check if the live reference set
+/// has changed since the last run (or no check has run yet). Resolves
+/// referenced flows from the open document's own `scripts/flows/`
+/// directory — derived from the document path's parent.
+///
+/// Cheap to call every frame: when the reference set is unchanged this
+/// only builds and compares a short joined string and returns.
+fn refreshCycleCheck(s: *FlowDocState) void {
+    const a = s.arena.allocator();
+
+    // Build a `\n`-joined snapshot of the current Subflow refs.
+    var snap: std.ArrayList(u8) = .empty;
+    defer snap.deinit(a);
+    for (s.doc.nodes) |n| {
+        if (n.kind != .subflow or n.flow_ref.len == 0) continue;
+        snap.appendSlice(a, n.flow_ref) catch return;
+        snap.append(a, '\n') catch return;
+    }
+
+    if (s.cycle_report != null and
+        std.mem.eql(u8, snap.items, s.cycle_refs_snapshot)) return;
+
+    // Reference set changed (or first run) — re-analyze.
+    const child = s.arena.child_allocator;
+
+    var refs_arena = std.heap.ArenaAllocator.init(child);
+    defer refs_arena.deinit();
+    const refs = liveSubflowRefs(refs_arena.allocator(), s.doc) catch return;
+
+    // The flow file lives at `<flows_dir>/<name>.flow.jsonc`; the
+    // referenced flows resolve from the same directory.
+    const flows_dir = std.fs.path.dirname(s.path) orelse ".";
+
+    const new_report = flow_cycle.analyze(
+        child,
+        effectiveName(s),
+        refs,
+        flows_dir,
+    ) catch |err| {
+        std.log.err("flow: cycle check failed: {s}", .{@errorName(err)});
+        return;
+    };
+
+    if (s.cycle_report) |*old| old.deinit();
+    s.cycle_report = new_report;
+    s.cycle_refs_snapshot = a.dupe(u8, snap.items) catch "";
+}
 
 /// Public entry point — `OpenTab.render` dispatches here.
 pub fn render(s: *FlowDocState, app: *App) void {
@@ -206,6 +285,12 @@ pub fn render(s: *FlowDocState, app: *App) void {
     if (zgui.button("Save", .{})) saveFlowDoc(s, app);
     zgui.sameLine(.{});
     zgui.textDisabled("(.flow.jsonc — flat graph editor)", .{});
+
+    // Re-run the Subflow reference-cycle check whenever the live set of
+    // `Subflow` references changes (issue #159). Cheap when unchanged.
+    refreshCycleCheck(s);
+    renderCycleBanner(s);
+
     zgui.separator();
 
     const total_w = zgui.getContentRegionAvail()[0];
@@ -224,6 +309,51 @@ pub fn render(s: *FlowDocState, app: *App) void {
         renderInspector(s);
     }
     zgui.endChild();
+}
+
+/// Draw a warning banner when the most recent `Subflow` reference
+/// check found a cycle or an unresolved reference. A clean (or
+/// not-yet-run) check draws nothing — the editor stays quiet when the
+/// flow graph is fine (issue #159).
+fn renderCycleBanner(s: *FlowDocState) void {
+    const report = &(if (s.cycle_report) |*r| r else return).*;
+    switch (report.status) {
+        .clean => return,
+        .cycle => |chain| {
+            const text = chainText(s, chain) orelse "?";
+            zgui.textColored(
+                .{ 1.0, 0.35, 0.35, 1.0 },
+                "Subflow reference cycle: {s}",
+                .{text},
+            );
+            zgui.textDisabled(
+                "A cyclic flow graph is rejected by codegen at build time.",
+                .{},
+            );
+        },
+        .unresolved => |chain| {
+            const text = chainText(s, chain) orelse "?";
+            zgui.textColored(
+                .{ 1.0, 0.65, 0.2, 1.0 },
+                "Unresolved Subflow reference: {s}",
+                .{text},
+            );
+            zgui.textDisabled(
+                "The last flow in the chain has no scripts/flows/<name>.flow.jsonc file.",
+                .{},
+            );
+        },
+    }
+}
+
+/// Render a `flow_cycle.Chain` to an `a → b → c` string on the tab's
+/// arena. Returns null only on an allocation failure (then the caller
+/// shows a placeholder rather than crashing).
+fn chainText(s: *FlowDocState, chain: flow_cycle.Chain) ?[]const u8 {
+    const a = s.arena.allocator();
+    var out: std.ArrayList(u8) = .empty;
+    chain.format(&out, a) catch return null;
+    return out.toOwnedSlice(a) catch null;
 }
 
 // ─── Canvas ─────────────────────────────────────────────────────────────

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -490,6 +490,20 @@ fn renderCycleBanner(s: *FlowDocState) void {
                 .{},
             );
         },
+        .duplicate_name => |dup| {
+            zgui.textColored(
+                .{ 1.0, 0.35, 0.35, 1.0 },
+                "Duplicate flow name: two flows share the name '{s}' — rename one.",
+                .{dup.name},
+            );
+            zgui.textDisabled("  {s}", .{dup.path_a});
+            zgui.textDisabled("  {s}", .{dup.path_b});
+            zgui.textDisabled(
+                "A flow's registry name is its top-level `name`, else its filename. " ++
+                    "codegen rejects two flows resolving to the same name.",
+                .{},
+            );
+        },
     }
 }
 

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -230,23 +230,26 @@ fn effectiveName(s: *const FlowDocState) []const u8 {
 /// Cheap to call every frame: when the reference set is unchanged this
 /// only builds and compares a short joined string and returns.
 fn refreshCycleCheck(s: *FlowDocState) void {
-    const a = s.arena.allocator();
+    // The tab arena (`ArenaAllocator.free` is a no-op) is never used
+    // for per-frame scratch — the snapshot and refs are built on the
+    // child/GPA allocator and freed before this returns. Only the
+    // single stored snapshot persists, and it lives on the arena.
+    const child = s.arena.child_allocator;
 
-    // Build a `\n`-joined snapshot of the current Subflow refs.
+    // Build a `\n`-joined snapshot of the current Subflow refs on the
+    // child allocator so it is reclaimed every frame.
     var snap: std.ArrayList(u8) = .empty;
-    defer snap.deinit(a);
+    defer snap.deinit(child);
     for (s.doc.nodes) |n| {
         if (n.kind != .subflow or n.flow_ref.len == 0) continue;
-        snap.appendSlice(a, n.flow_ref) catch return;
-        snap.append(a, '\n') catch return;
+        snap.appendSlice(child, n.flow_ref) catch return;
+        snap.append(child, '\n') catch return;
     }
 
     if (s.cycle_report != null and
         std.mem.eql(u8, snap.items, s.cycle_refs_snapshot)) return;
 
     // Reference set changed (or first run) — re-analyze.
-    const child = s.arena.child_allocator;
-
     var refs_arena = std.heap.ArenaAllocator.init(child);
     defer refs_arena.deinit();
     const refs = liveSubflowRefs(refs_arena.allocator(), s.doc) catch return;
@@ -261,13 +264,32 @@ fn refreshCycleCheck(s: *FlowDocState) void {
         refs,
         flows_dir,
     ) catch |err| {
+        // The check failed (e.g. OOM, a filesystem error). Drop the
+        // stale report so the banner reflects "not checked" rather than
+        // a now-incorrect cycle/unresolved status, and clear the
+        // snapshot so the next frame retries instead of trusting a
+        // result that was never produced.
         std.log.err("flow: cycle check failed: {s}", .{@errorName(err)});
+        if (s.cycle_report) |*old| old.deinit();
+        s.cycle_report = null;
+        s.cycle_refs_snapshot = "";
+        return;
+    };
+
+    // Duplicate the snapshot onto the tab arena *before* committing the
+    // new report — if the dup fails we keep the old report/snapshot
+    // pair consistent (rather than leaving an empty snapshot that would
+    // re-run the disk-backed analysis every subsequent frame).
+    const new_snapshot = s.arena.allocator().dupe(u8, snap.items) catch {
+        std.log.err("flow: cycle snapshot alloc failed; keeping prior result", .{});
+        var report = new_report;
+        report.deinit();
         return;
     };
 
     if (s.cycle_report) |*old| old.deinit();
     s.cycle_report = new_report;
-    s.cycle_refs_snapshot = a.dupe(u8, snap.items) catch "";
+    s.cycle_refs_snapshot = new_snapshot;
 }
 
 /// Public entry point — `OpenTab.render` dispatches here.
@@ -317,10 +339,14 @@ pub fn render(s: *FlowDocState, app: *App) void {
 /// flow graph is fine (issue #159).
 fn renderCycleBanner(s: *FlowDocState) void {
     const report = &(if (s.cycle_report) |*r| r else return).*;
+    // `chain_text` was rendered once when the report was generated
+    // (`flow_cycle.analyze`) — the banner just displays it, so the tab
+    // arena doesn't grow per frame. A blank string only happens on a
+    // formatting-alloc failure inside `analyze`; show a placeholder.
+    const text = if (report.chain_text.len > 0) report.chain_text else "?";
     switch (report.status) {
         .clean => return,
-        .cycle => |chain| {
-            const text = chainText(s, chain) orelse "?";
+        .cycle => {
             zgui.textColored(
                 .{ 1.0, 0.35, 0.35, 1.0 },
                 "Subflow reference cycle: {s}",
@@ -331,8 +357,7 @@ fn renderCycleBanner(s: *FlowDocState) void {
                 .{},
             );
         },
-        .unresolved => |chain| {
-            const text = chainText(s, chain) orelse "?";
+        .unresolved => {
             zgui.textColored(
                 .{ 1.0, 0.65, 0.2, 1.0 },
                 "Unresolved Subflow reference: {s}",
@@ -344,16 +369,6 @@ fn renderCycleBanner(s: *FlowDocState) void {
             );
         },
     }
-}
-
-/// Render a `flow_cycle.Chain` to an `a → b → c` string on the tab's
-/// arena. Returns null only on an allocation failure (then the caller
-/// shows a placeholder rather than crashing).
-fn chainText(s: *FlowDocState, chain: flow_cycle.Chain) ?[]const u8 {
-    const a = s.arena.allocator();
-    var out: std.ArrayList(u8) = .empty;
-    chain.format(&out, a) catch return null;
-    return out.toOwnedSlice(a) catch null;
 }
 
 // ─── Canvas ─────────────────────────────────────────────────────────────

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -36,7 +36,6 @@ const App = @import("../app.zig").App;
 const flow_io = @import("../flow_io.zig");
 const io_global = @import("../io_global.zig");
 const flow_cycle = @import("../flow_cycle.zig");
-const io_global = @import("../io_global.zig");
 
 const inspector_w: f32 = 340;
 const split_gap: f32 = 8;

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -161,8 +161,10 @@ pub const FlowDocState = struct {
     /// against — `refreshCycleCheck` re-runs when any of them changes.
     cycle_report: ?flow_cycle.Report = null,
     /// Snapshot of the `Subflow` `flow_ref` set the last cycle check
-    /// ran against, joined by `\n`. When the live set diverges from
-    /// this the check is re-run. Owned by the child/GPA allocator
+    /// ran against, encoded by `buildRefsFingerprint` (each ref
+    /// length-prefixed so the encoding is unambiguous for any ref
+    /// content). When the live set diverges from this the check is
+    /// re-run. Owned by the child/GPA allocator
     /// (`arena.child_allocator`), *not* the tab arena: it is replaced on
     /// every actual re-check, and arena `free` is a no-op, so persisting
     /// it on the arena would leak the prior snapshot on each
@@ -287,6 +289,35 @@ pub fn referencedFilesChanged(report: *const flow_cycle.Report) bool {
     return false;
 }
 
+/// Build the invalidation fingerprint of the open document's live
+/// `Subflow` `flow_ref` set. `refreshCycleCheck` compares this against
+/// the stored `cycle_refs_snapshot` to decide whether the reference set
+/// changed since the last check.
+///
+/// Each ref is **length-prefixed** — its byte length as a fixed-width
+/// little-endian `u64`, then the raw bytes — so the encoding is
+/// unambiguous for any `flow_ref` content. A plain separator (newline,
+/// NUL, …) is not enough: a `flow_ref` is a JSON string and may contain
+/// that separator byte itself, so one ref `"a\nb"` would otherwise
+/// encode the exact same bytes as two refs `"a"`, `"b"` and the check
+/// would wrongly skip re-analysis. With the length prefix no
+/// concatenation of one ref set can collide with a different set.
+///
+/// Empty refs are skipped — same filter as `liveSubflowRefs`, so the
+/// fingerprint and the analysis input agree. Owned by `a`.
+pub fn buildRefsFingerprint(a: std.mem.Allocator, doc: flow_io.FlowDoc) !std.ArrayList(u8) {
+    var snap: std.ArrayList(u8) = .empty;
+    errdefer snap.deinit(a);
+    for (doc.nodes) |n| {
+        if (n.kind != .subflow or n.flow_ref.len == 0) continue;
+        var len_buf: [8]u8 = undefined;
+        std.mem.writeInt(u64, &len_buf, n.flow_ref.len, .little);
+        try snap.appendSlice(a, &len_buf);
+        try snap.appendSlice(a, n.flow_ref);
+    }
+    return snap;
+}
+
 /// Re-run the `Subflow` reference-cycle check if the live reference set
 /// has changed since the last run, if any referenced flow file changed
 /// on disk, or if no check has run yet. Resolves referenced flows from
@@ -294,7 +325,8 @@ pub fn referencedFilesChanged(report: *const flow_cycle.Report) bool {
 /// document path's parent.
 ///
 /// Cheap to call every frame: when nothing changed this only builds and
-/// compares a short joined string and stats a handful of files.
+/// compares a short length-prefixed fingerprint and stats a handful of
+/// files.
 fn refreshCycleCheck(s: *FlowDocState) void {
     // The tab arena (`ArenaAllocator.free` is a no-op) is never used
     // for the cycle-check scratch *or* the persisted snapshot — both
@@ -305,15 +337,12 @@ fn refreshCycleCheck(s: *FlowDocState) void {
     // dead snapshot per invalidation.
     const child = s.arena.child_allocator;
 
-    // Build a `\n`-joined snapshot of the current Subflow refs on the
-    // child allocator so it is reclaimed every frame.
-    var snap: std.ArrayList(u8) = .empty;
+    // Build a length-prefixed fingerprint of the current Subflow refs
+    // on the child allocator so it is reclaimed every frame. The
+    // length prefix keeps the encoding unambiguous for any ref content
+    // (see `buildRefsFingerprint`).
+    var snap = buildRefsFingerprint(child, s.doc) catch return;
     defer snap.deinit(child);
-    for (s.doc.nodes) |n| {
-        if (n.kind != .subflow or n.flow_ref.len == 0) continue;
-        snap.appendSlice(child, n.flow_ref) catch return;
-        snap.append(child, '\n') catch return;
-    }
 
     // Skip the re-analysis only when a check has run, the open flow's
     // own reference set is unchanged, *and* none of the referenced

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -243,9 +243,17 @@ fn effectiveName(s: *const FlowDocState) []const u8 {
 /// document's own `Subflow` reference set never reveals, so the banner
 /// must not trust a cached "clean" once any referenced file moves.
 ///
-/// Cheap: one `statFile` per referenced file. A flow graph references a
-/// handful of files at most, so this stays well within an immediate-mode
-/// frame budget.
+/// Also re-triggers when a reference target the last check could *not*
+/// read becomes readable: a previously-missing `.flow.jsonc` appearing
+/// on disk, or a parse-failed one whose content changed. `read_files`
+/// can never catch these — it only stamps files that were successfully
+/// read — so `unresolved_targets` is checked alongside it. A target
+/// appearing can newly resolve a reference (and even introduce a
+/// cycle), so the stale "unresolved" banner must not survive it.
+///
+/// Cheap: one `statFile` per tracked path (read files plus unresolved
+/// targets). A flow graph references a handful of files at most, so this
+/// stays well within an immediate-mode frame budget.
 pub fn referencedFilesChanged(report: *const flow_cycle.Report) bool {
     const io = io_global.io();
     for (report.read_files) |f| {
@@ -260,6 +268,21 @@ pub fn referencedFilesChanged(report: *const flow_cycle.Report) bool {
         if (f.mtime_ns == null or f.size == null) return true;
         if (f.mtime_ns.? != st.mtime.nanoseconds) return true;
         if (f.size.? != st.size) return true;
+    }
+    // A target the check could not read may now be readable.
+    for (report.unresolved_targets) |t| {
+        const st = std.Io.Dir.cwd().statFile(io, t.path, .{}) catch {
+            // Still not stat-able. Stale only if a (broken) file *was*
+            // present there at check time and has since vanished.
+            if (t.mtime_ns != null or t.size != null) return true;
+            continue;
+        };
+        // A previously-missing target now exists, or a parse-failed
+        // one's mtime/size moved (its content may now parse) — either
+        // way a reference that didn't resolve might now resolve.
+        if (t.mtime_ns == null or t.size == null) return true;
+        if (t.mtime_ns.? != st.mtime.nanoseconds) return true;
+        if (t.size.? != st.size) return true;
     }
     return false;
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -14,6 +14,7 @@ const atlas = @import("atlas.zig");
 const gizmo_io = @import("gizmo_io.zig");
 const flow_io = @import("flow_io.zig");
 const flow_doc = @import("modules/flow_doc.zig");
+const flow_cycle = @import("flow_cycle.zig");
 const gizmos = @import("gizmos.zig");
 const preview = @import("preview.zig");
 const flow_projector = @import("flows/projector.zig");
@@ -5376,5 +5377,221 @@ pub const FlowDocSubflowTests = struct {
             null,
             null,
         ));
+    }
+};
+
+// ─── flow_cycle: Subflow reference-cycle check (issue #159) ──────────────
+
+/// Covers `flow_cycle.detectCycle` (the pure DFS walk over the
+/// `Subflow` reference graph) and `flow_cycle.analyze` (the on-disk,
+/// project-backed resolver). The pure walk is exercised with an
+/// in-memory reference map; `analyze` is exercised against real
+/// `.flow.jsonc` files in a temp `scripts/flows/` directory.
+pub const FlowCycleTests = struct {
+    /// In-memory `flow_cycle.Resolver` backing — a flow name → refs
+    /// map. A name absent from the map resolves to `null` (unresolved).
+    const MapResolver = struct {
+        map: std.StringHashMapUnmanaged([]const []const u8),
+
+        fn refs(ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8 {
+            const self: *MapResolver = @ptrCast(@alignCast(ctx));
+            return self.map.get(name);
+        }
+
+        fn resolver(self: *MapResolver) flow_cycle.Resolver {
+            return .{ .ctx = self, .refsFn = MapResolver.refs };
+        }
+    };
+
+    test "detectCycle reports a clean linear chain" {
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "a", &.{"b"});
+        try m.map.put(a, "b", &.{"c"});
+        try m.map.put(a, "c", &.{});
+
+        const status = try flow_cycle.detectCycle(a, "a", m.resolver());
+        try expect.toBeTrue(status == .clean);
+    }
+
+    test "detectCycle flags a direct self-reference" {
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "a", &.{"a"});
+
+        const status = try flow_cycle.detectCycle(a, "a", m.resolver());
+        try expect.toBeTrue(status == .cycle);
+        try expect.equal(status.cycle.names.len, @as(usize, 2));
+    }
+
+    test "detectCycle reports the offending chain for an indirect cycle" {
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "a", &.{"b"});
+        try m.map.put(a, "b", &.{"c"});
+        try m.map.put(a, "c", &.{"a"});
+
+        const status = try flow_cycle.detectCycle(a, "a", m.resolver());
+        try expect.toBeTrue(status == .cycle);
+        // a → b → c → a
+        try expect.equal(status.cycle.names.len, @as(usize, 4));
+        try expect.toBeTrue(std.mem.eql(u8, status.cycle.names[0], "a"));
+        try expect.toBeTrue(std.mem.eql(u8, status.cycle.names[3], "a"));
+    }
+
+    test "detectCycle finds a cycle that does not include the entry flow" {
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "entry", &.{"b"});
+        try m.map.put(a, "b", &.{"c"});
+        try m.map.put(a, "c", &.{"b"});
+
+        const status = try flow_cycle.detectCycle(a, "entry", m.resolver());
+        try expect.toBeTrue(status == .cycle);
+    }
+
+    test "detectCycle reports an unresolved reference" {
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "a", &.{"b"});
+        try m.map.put(a, "b", &.{"missing"});
+
+        const status = try flow_cycle.detectCycle(a, "a", m.resolver());
+        try expect.toBeTrue(status == .unresolved);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            status.unresolved.names[status.unresolved.names.len - 1],
+            "missing",
+        ));
+    }
+
+    test "detectCycle treats a diamond reference graph as clean" {
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "a", &.{ "b", "c" });
+        try m.map.put(a, "b", &.{"d"});
+        try m.map.put(a, "c", &.{"d"});
+        try m.map.put(a, "d", &.{});
+
+        const status = try flow_cycle.detectCycle(a, "a", m.resolver());
+        try expect.toBeTrue(status == .clean);
+    }
+
+    fn createTempDir(allocator: std.mem.Allocator) ![]const u8 {
+        const ts = timestampSeconds();
+        const dir_name = try std.fmt.allocPrint(
+            allocator,
+            "/tmp/labelle_flowcycle_{d}",
+            .{ts},
+        );
+        try std.Io.Dir.cwd().createDir(io_global.io(), dir_name, .default_dir);
+        return dir_name;
+    }
+
+    fn deleteTempDir(allocator: std.mem.Allocator, dir_path: []const u8) void {
+        std.Io.Dir.cwd().deleteTree(io_global.io(), dir_path) catch {};
+        allocator.free(dir_path);
+    }
+
+    /// Write `<flows_dir>/<name>.flow.jsonc` with a `Subflow` node per
+    /// entry in `refs`.
+    fn writeFlow(
+        allocator: std.mem.Allocator,
+        flows_dir: []const u8,
+        name: []const u8,
+        refs: []const []const u8,
+    ) !void {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(allocator);
+        try buf.appendSlice(allocator, "{ \"event\": { \"type\": \"OnCall\" }, \"nodes\": [");
+        for (refs, 0..) |r, i| {
+            if (i > 0) try buf.append(allocator, ',');
+            try buf.print(allocator,
+                " {{ \"id\": {d}, \"type\": \"Subflow\", \"flow\": \"{s}\", \"pos\": [0, 0] }}",
+                .{ i + 1, r });
+        }
+        try buf.appendSlice(allocator, " ], \"edges\": [] }\n");
+
+        const path = try std.fmt.allocPrint(
+            allocator,
+            "{s}/{s}{s}",
+            .{ flows_dir, name, flow_io.extension },
+        );
+        defer allocator.free(path);
+        try std.Io.Dir.cwd().writeFile(io_global.io(), .{
+            .sub_path = path,
+            .data = buf.items,
+        });
+    }
+
+    test "analyze reads referenced flows from disk and reports a cycle" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // a → b → a, written as real .flow.jsonc files.
+        try writeFlow(allocator, flows_dir, "b", &.{"a"});
+
+        var report = try flow_cycle.analyze(
+            allocator,
+            "a",
+            &.{"b"}, // live (unsaved) Subflow refs of the open doc "a"
+            flows_dir,
+        );
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .cycle);
+    }
+
+    test "analyze reports an unresolved reference for a missing file" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // "a" references "ghost" — no ghost.flow.jsonc on disk.
+        var report = try flow_cycle.analyze(
+            allocator,
+            "a",
+            &.{"ghost"},
+            flows_dir,
+        );
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .unresolved);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            report.status.unresolved.names[report.status.unresolved.names.len - 1],
+            "ghost",
+        ));
+    }
+
+    test "analyze reports clean for an acyclic on-disk reference graph" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // a → b → c, all real files, no cycle.
+        try writeFlow(allocator, flows_dir, "b", &.{"c"});
+        try writeFlow(allocator, flows_dir, "c", &.{});
+
+        var report = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .clean);
     }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -15,6 +15,7 @@ const gizmo_io = @import("gizmo_io.zig");
 const flow_io = @import("flow_io.zig");
 const flow_doc = @import("modules/flow_doc.zig");
 const flow_cycle = @import("flow_cycle.zig");
+const flow_doc = @import("modules/flow_doc.zig");
 const gizmos = @import("gizmos.zig");
 const preview = @import("preview.zig");
 const flow_projector = @import("flows/projector.zig");
@@ -5389,13 +5390,17 @@ pub const FlowDocSubflowTests = struct {
 /// `.flow.jsonc` files in a temp `scripts/flows/` directory.
 pub const FlowCycleTests = struct {
     /// In-memory `flow_cycle.Resolver` backing — a flow name → refs
-    /// map. A name absent from the map resolves to `null` (unresolved).
+    /// map. A name absent from the map resolves to `.missing`; a name
+    /// in `broken` resolves to `.parse_failed`.
     const MapResolver = struct {
         map: std.StringHashMapUnmanaged([]const []const u8),
+        broken: std.StringHashMapUnmanaged(void) = .empty,
 
-        fn refs(ctx: *anyopaque, name: []const u8) anyerror!?[]const []const u8 {
+        fn refs(ctx: *anyopaque, name: []const u8) anyerror!flow_cycle.RefResult {
             const self: *MapResolver = @ptrCast(@alignCast(ctx));
-            return self.map.get(name);
+            if (self.map.get(name)) |r| return .{ .ok = r };
+            if (self.broken.contains(name)) return .parse_failed;
+            return .missing;
         }
 
         fn resolver(self: *MapResolver) flow_cycle.Resolver {
@@ -5731,5 +5736,102 @@ pub const FlowCycleTests = struct {
             report.chain_text,
             "a \u{2192} b \u{2192} a",
         ));
+    }
+
+    /// Write `<flows_dir>/<name>.flow.jsonc` with deliberately broken
+    /// content — valid as a file on disk, but not parseable as a flow
+    /// (here: a top-level array, not an object).
+    fn writeBrokenFlow(
+        allocator: std.mem.Allocator,
+        flows_dir: []const u8,
+        name: []const u8,
+    ) !void {
+        const path = try std.fmt.allocPrint(
+            allocator,
+            "{s}/{s}{s}",
+            .{ flows_dir, name, flow_io.extension },
+        );
+        defer allocator.free(path);
+        try std.Io.Dir.cwd().writeFile(io_global.io(), .{
+            .sub_path = path,
+            .data = "[ this is not valid flow json ]\n",
+        });
+    }
+
+    test "analyze flags a referenced file that exists but fails to parse" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // "a" references "b"; b.flow.jsonc exists on disk but its
+        // content is not parseable. This must be reported distinctly
+        // from a plain missing file — `parse_failed`, not `unresolved`.
+        try writeBrokenFlow(allocator, flows_dir, "b");
+
+        var report = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .parse_failed);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            report.status.parse_failed.names[
+                report.status.parse_failed.names.len - 1
+            ],
+            "b",
+        ));
+        // A genuinely missing file is still `unresolved`, not
+        // `parse_failed` — the two stay distinct.
+        var missing = try flow_cycle.analyze(allocator, "a", &.{"ghost"}, flows_dir);
+        defer missing.deinit();
+        try expect.toBeTrue(missing.status == .unresolved);
+    }
+
+    test "analyze records the referenced files it read on the report" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        try writeFlow(allocator, flows_dir, "b", &.{"c"});
+        try writeFlow(allocator, flows_dir, "c", &.{});
+
+        var report = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer report.deinit();
+        // The resolver scans every `.flow.jsonc` in `flows_dir` to build
+        // its registry-name index, so both files are recorded with a
+        // stat-able mtime.
+        try expect.toBeTrue(report.read_files.len == 2);
+        for (report.read_files) |f| {
+            try expect.toBeTrue(f.mtime_ns != null);
+            try expect.toBeTrue(f.size != null);
+        }
+    }
+
+    test "referencedFilesChanged re-triggers when a referenced file changes on disk" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // Initial graph: a → b → c, acyclic and clean.
+        try writeFlow(allocator, flows_dir, "b", &.{"c"});
+        try writeFlow(allocator, flows_dir, "c", &.{});
+
+        var report = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .clean);
+        // Nothing has changed on disk yet — no re-trigger.
+        try expect.toBeFalse(flow_doc.referencedFilesChanged(&report));
+
+        // Edit a *transitively*-referenced flow so it now closes a cycle
+        // (c → a). The open flow's own Subflow refs ({"b"}) are
+        // unchanged, so only the on-disk stamp reveals the staleness.
+        // `writeFlow` truncates and rewrites `c.flow.jsonc`.
+        try writeFlow(allocator, flows_dir, "c", &.{"a"});
+        try expect.toBeTrue(flow_doc.referencedFilesChanged(&report));
+
+        // Re-running the check now sees the cycle the stale report
+        // missed.
+        var fresh = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer fresh.deinit();
+        try expect.toBeTrue(fresh.status == .cycle);
+        try expect.toBeFalse(flow_doc.referencedFilesChanged(&fresh));
     }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6062,4 +6062,121 @@ pub const FlowCycleTests = struct {
         try expect.toBeTrue(fresh.status == .clean);
         try expect.toBeFalse(flow_doc.referencedFilesChanged(&fresh));
     }
+
+    test "analyze flags two on-disk flows sharing one effective registry name" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // Two distinct files, `one.flow.jsonc` and `two.flow.jsonc`,
+        // both carry the explicit top-level name "shared" — so they
+        // resolve to the *same* effective registry name. flow-codegen's
+        // FlowRegistry rejects this as DuplicateFlowName; the editor's
+        // first-file-wins index would otherwise silently shadow `two`,
+        // potentially hiding a cycle in its `Subflow` refs.
+        try writeNamedFlow(allocator, flows_dir, "one", "shared", &.{});
+        try writeNamedFlow(allocator, flows_dir, "two", "shared", &.{});
+
+        var report = try flow_cycle.analyze(allocator, "entry", &.{}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .duplicate_name);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            report.status.duplicate_name.name,
+            "shared",
+        ));
+        // Both offending files are reported, by their on-disk paths.
+        try expect.toBeTrue(std.mem.endsWith(
+            u8,
+            report.status.duplicate_name.path_a,
+            flow_io.extension,
+        ));
+        try expect.toBeTrue(std.mem.endsWith(
+            u8,
+            report.status.duplicate_name.path_b,
+            flow_io.extension,
+        ));
+        try expect.toBeFalse(std.mem.eql(
+            u8,
+            report.status.duplicate_name.path_a,
+            report.status.duplicate_name.path_b,
+        ));
+    }
+
+    test "analyze surfaces a duplicate name ahead of a cycle hidden in the shadowed file" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // `first.flow.jsonc` (name "dup") is clean; `second.flow.jsonc`
+        // (also name "dup") Subflow-references "entry", which would close
+        // a cycle entry → dup → entry. The first-file-wins index keeps
+        // `first`, so the cycle in `second` is never walked — exactly the
+        // hazard the duplicate-name check exists to surface. The report
+        // must call out the duplicate rather than a misleading clean.
+        try writeNamedFlow(allocator, flows_dir, "first", "dup", &.{});
+        try writeNamedFlow(allocator, flows_dir, "second", "dup", &.{"entry"});
+
+        var report = try flow_cycle.analyze(
+            allocator,
+            "entry",
+            &.{"dup"},
+            flows_dir,
+        );
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .duplicate_name);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            report.status.duplicate_name.name,
+            "dup",
+        ));
+    }
+
+    test "analyze flags the open flow's name colliding with an on-disk file" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // The open (possibly unsaved) tab is being edited as "tick". An
+        // on-disk `other.flow.jsonc` already claims the registry name
+        // "tick" via its top-level `name`. That is the same
+        // DuplicateFlowName fault and must be reported even though the
+        // open tab itself has no entry in the on-disk index.
+        try writeNamedFlow(allocator, flows_dir, "other", "tick", &.{});
+
+        var report = try flow_cycle.analyze(allocator, "tick", &.{}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .duplicate_name);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            report.status.duplicate_name.name,
+            "tick",
+        ));
+        // The open tab has no on-disk path here — it is reported via the
+        // `<open flow>` marker, with the conflicting file as `path_b`.
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            report.status.duplicate_name.path_a,
+            flow_cycle.open_flow_marker,
+        ));
+        try expect.toBeTrue(std.mem.endsWith(
+            u8,
+            report.status.duplicate_name.path_b,
+            flow_io.extension,
+        ));
+    }
+
+    test "analyze stays clean when every flow has a distinct registry name" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // Distinct names — no duplicate, no entry-name collision.
+        try writeNamedFlow(allocator, flows_dir, "one", "alpha", &.{});
+        try writeNamedFlow(allocator, flows_dir, "two", "beta", &.{});
+
+        var report = try flow_cycle.analyze(allocator, "entry", &.{}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .clean);
+    }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5910,4 +5910,65 @@ pub const FlowCycleTests = struct {
         try expect.toBeTrue(fresh.status == .cycle);
         try expect.toBeFalse(flow_doc.referencedFilesChanged(&fresh));
     }
+
+    test "referencedFilesChanged re-triggers when a previously-missing referenced file is created" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // The open doc "a" references "b", but b.flow.jsonc does not
+        // exist yet — the check reports `unresolved`. `read_files` only
+        // stamps files that were successfully read (here just none, or
+        // whatever the directory scan saw), so it can never notice "b"
+        // appearing; `unresolved_targets` must carry the expected path.
+        var report = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .unresolved);
+        // The missing target is recorded with its expected `.flow.jsonc`
+        // path so a later check can stat it.
+        try expect.toBeTrue(report.unresolved_targets.len == 1);
+        try expect.toBeFalse(report.unresolved_targets[0].parse_failed);
+        // Nothing has appeared on disk yet — no re-trigger.
+        try expect.toBeFalse(flow_doc.referencedFilesChanged(&report));
+
+        // Create the previously-missing referenced flow. It even closes
+        // a cycle (b → a). The open flow's own Subflow refs ({"b"}) are
+        // unchanged, so only the appearance of the missing target can
+        // reveal the staleness.
+        try writeFlow(allocator, flows_dir, "b", &.{"a"});
+        try expect.toBeTrue(flow_doc.referencedFilesChanged(&report));
+
+        // Re-running the check now resolves "b" and sees the cycle the
+        // stale "unresolved" report could not.
+        var fresh = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer fresh.deinit();
+        try expect.toBeTrue(fresh.status == .cycle);
+        try expect.toBeFalse(flow_doc.referencedFilesChanged(&fresh));
+    }
+
+    test "referencedFilesChanged re-triggers when a parse-failed referenced file is fixed" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // "a" references "b"; b.flow.jsonc exists but does not parse —
+        // the check reports `parse_failed` and stamps the broken file.
+        try writeBrokenFlow(allocator, flows_dir, "b");
+
+        var report = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .parse_failed);
+        try expect.toBeTrue(report.unresolved_targets.len == 1);
+        try expect.toBeTrue(report.unresolved_targets[0].parse_failed);
+        try expect.toBeFalse(flow_doc.referencedFilesChanged(&report));
+
+        // Rewrite the broken file with valid, acyclic content.
+        try writeFlow(allocator, flows_dir, "b", &.{});
+        try expect.toBeTrue(flow_doc.referencedFilesChanged(&report));
+
+        var fresh = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer fresh.deinit();
+        try expect.toBeTrue(fresh.status == .clean);
+        try expect.toBeFalse(flow_doc.referencedFilesChanged(&fresh));
+    }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5576,6 +5576,97 @@ pub const FlowCycleTests = struct {
         try expect.toBeTrue(status == .clean);
     }
 
+    /// Build a `flow_io.FlowDoc` carrying one `Subflow` node per entry
+    /// in `flow_refs`. Only `nodes` is populated — `buildRefsFingerprint`
+    /// reads nothing else. Caller owns `nodes` (allocated on `a`).
+    fn docWithSubflowRefs(
+        a: std.mem.Allocator,
+        flow_refs: []const []const u8,
+    ) !flow_io.FlowDoc {
+        const nodes = try a.alloc(flow_io.Node, flow_refs.len);
+        for (flow_refs, 0..) |r, i| {
+            nodes[i] = .{
+                .id = @intCast(i + 1),
+                .type_name = "Subflow",
+                .kind = .subflow,
+                .flow_ref = r,
+            };
+        }
+        return .{ .arena = undefined, .nodes = nodes };
+    }
+
+    test "buildRefsFingerprint distinguishes ref sets that collide under newline-joining" {
+        // A `flow_ref` is a JSON string and may contain a newline.
+        // Joining refs with `\n` is ambiguous: one ref "a\nb" produces
+        // the exact same bytes as two refs "a", "b". The fingerprint
+        // must keep these distinct so a changed reference set is never
+        // mistaken for "unchanged" and the cycle check re-runs.
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        const doc_one = try docWithSubflowRefs(a, &.{"a\nb"});
+        const doc_two = try docWithSubflowRefs(a, &.{ "a", "b" });
+
+        var fp_one = try flow_doc.buildRefsFingerprint(a, doc_one);
+        defer fp_one.deinit(a);
+        var fp_two = try flow_doc.buildRefsFingerprint(a, doc_two);
+        defer fp_two.deinit(a);
+
+        try expect.toBeTrue(!std.mem.eql(u8, fp_one.items, fp_two.items));
+    }
+
+    test "buildRefsFingerprint is stable for an identical ref set" {
+        // Same refs in the same order must produce identical bytes —
+        // otherwise the check would re-run every frame.
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        const doc_a = try docWithSubflowRefs(a, &.{ "alpha", "beta\ngamma" });
+        const doc_b = try docWithSubflowRefs(a, &.{ "alpha", "beta\ngamma" });
+
+        var fp_a = try flow_doc.buildRefsFingerprint(a, doc_a);
+        defer fp_a.deinit(a);
+        var fp_b = try flow_doc.buildRefsFingerprint(a, doc_b);
+        defer fp_b.deinit(a);
+
+        try expect.toBeTrue(std.mem.eql(u8, fp_a.items, fp_b.items));
+    }
+
+    test "buildRefsFingerprint encoding cannot be reproduced by a different ref split" {
+        // Length-prefixing must defeat *every* re-split, not just the
+        // newline case. A plain NUL separator is also insufficient — a
+        // `flow_ref` may contain a NUL — so ["x\x00y"] and ["x", "y"]
+        // must differ too, as must order-only changes.
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        const sets = [_][]const []const u8{
+            &.{"xy"},
+            &.{ "x", "y" },
+            &.{ "y", "x" },
+            &.{"x\x00y"},
+            &.{ "x\ny", "z" },
+            &.{ "x", "y\nz" },
+        };
+        var seen: std.ArrayList([]const u8) = .empty;
+        defer {
+            for (seen.items) |s| a.free(s);
+            seen.deinit(a);
+        }
+        for (sets) |set| {
+            const doc = try docWithSubflowRefs(a, set);
+            var fp = try flow_doc.buildRefsFingerprint(a, doc);
+            defer fp.deinit(a);
+            for (seen.items) |prev| {
+                try expect.toBeTrue(!std.mem.eql(u8, prev, fp.items));
+            }
+            try seen.append(a, try a.dupe(u8, fp.items));
+        }
+    }
+
     fn createTempDir(allocator: std.mem.Allocator) ![]const u8 {
         const ts = timestampSeconds();
         const dir_name = try std.fmt.allocPrint(

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5594,4 +5594,142 @@ pub const FlowCycleTests = struct {
         defer report.deinit();
         try expect.toBeTrue(report.status == .clean);
     }
+
+    /// Write `<flows_dir>/<file>.flow.jsonc` carrying an explicit
+    /// top-level `name` (its effective registry name) that differs from
+    /// the filename, with a `Subflow` node per entry in `refs`.
+    fn writeNamedFlow(
+        allocator: std.mem.Allocator,
+        flows_dir: []const u8,
+        file: []const u8,
+        reg_name: []const u8,
+        refs: []const []const u8,
+    ) !void {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(allocator);
+        try buf.print(allocator,
+            "{{ \"name\": \"{s}\", \"event\": {{ \"type\": \"OnCall\" }}, \"nodes\": [",
+            .{reg_name});
+        for (refs, 0..) |r, i| {
+            if (i > 0) try buf.append(allocator, ',');
+            try buf.print(allocator,
+                " {{ \"id\": {d}, \"type\": \"Subflow\", \"flow\": \"{s}\", \"pos\": [0, 0] }}",
+                .{ i + 1, r });
+        }
+        try buf.appendSlice(allocator, " ], \"edges\": [] }\n");
+
+        const path = try std.fmt.allocPrint(
+            allocator,
+            "{s}/{s}{s}",
+            .{ flows_dir, file, flow_io.extension },
+        );
+        defer allocator.free(path);
+        try std.Io.Dir.cwd().writeFile(io_global.io(), .{
+            .sub_path = path,
+            .data = buf.items,
+        });
+    }
+
+    test "analyze resolves a reference by registry name, not filename" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // The open doc "a" references "tick_logic" — a registry name.
+        // On disk that flow lives in `b_file.flow.jsonc`, whose
+        // top-level `name` is "tick_logic". Keying on the filename
+        // would mis-report this as unresolved.
+        try writeNamedFlow(allocator, flows_dir, "b_file", "tick_logic", &.{});
+
+        var report = try flow_cycle.analyze(
+            allocator,
+            "a",
+            &.{"tick_logic"},
+            flows_dir,
+        );
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .clean);
+    }
+
+    test "analyze detects a cycle through registry-name resolution" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // a → reg_b → a, where reg_b's flow file is `b_file.flow.jsonc`
+        // (filename ≠ registry name) and it Subflow-references "a".
+        try writeNamedFlow(allocator, flows_dir, "b_file", "reg_b", &.{"a"});
+
+        var report = try flow_cycle.analyze(
+            allocator,
+            "a",
+            &.{"reg_b"},
+            flows_dir,
+        );
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .cycle);
+    }
+
+    test "analyze flags a reference that matches a filename but not a registry name" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // `b_file.flow.jsonc` has registry name "reg_b". A Subflow that
+        // references the *filename* "b_file" must NOT resolve — only the
+        // effective registry name "reg_b" is a valid target.
+        try writeNamedFlow(allocator, flows_dir, "b_file", "reg_b", &.{});
+
+        var report = try flow_cycle.analyze(
+            allocator,
+            "a",
+            &.{"b_file"},
+            flows_dir,
+        );
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .unresolved);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            report.status.unresolved.names[report.status.unresolved.names.len - 1],
+            "b_file",
+        ));
+    }
+
+    test "analyze still resolves a flow with no name by its filename" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        // `plain.flow.jsonc` has no top-level `name`; its effective
+        // registry name falls back to the filename basename "plain".
+        try writeFlow(allocator, flows_dir, "plain", &.{});
+
+        var report = try flow_cycle.analyze(
+            allocator,
+            "a",
+            &.{"plain"},
+            flows_dir,
+        );
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .clean);
+    }
+
+    test "analyze populates chain_text once for a cycle" {
+        const allocator = std.testing.allocator;
+        const flows_dir = try createTempDir(allocator);
+        defer deleteTempDir(allocator, flows_dir);
+
+        try writeFlow(allocator, flows_dir, "b", &.{"a"});
+
+        var report = try flow_cycle.analyze(allocator, "a", &.{"b"}, flows_dir);
+        defer report.deinit();
+        try expect.toBeTrue(report.status == .cycle);
+        // chain_text is rendered at analysis time: a → b → a.
+        try expect.toBeTrue(report.chain_text.len > 0);
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            report.chain_text,
+            "a \u{2192} b \u{2192} a",
+        ));
+    }
 };

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5500,6 +5500,82 @@ pub const FlowCycleTests = struct {
         try expect.toBeTrue(status == .clean);
     }
 
+    test "detectCycle catches a cycle reachable only through a node first seen on a clean branch" {
+        // Regression for the classic three-state DFS mistake: the
+        // "done" set must mean "fully explored AND acyclic", never just
+        // "seen". `c` is first reached down the clean-looking `entry →
+        // x → c` branch; the real cycle is `b → c → b`. A walk that
+        // marked `c` done on first sight would skip `c` on the later
+        // `entry → b` branch and wrongly report `.clean`.
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "entry", &.{ "x", "b" });
+        try m.map.put(a, "x", &.{"c"});
+        try m.map.put(a, "b", &.{"c"});
+        try m.map.put(a, "c", &.{"b"});
+
+        const status = try flow_cycle.detectCycle(a, "entry", m.resolver());
+        try expect.toBeTrue(status == .cycle);
+        // Walk descends entry → x → c → b → c; the back edge closes at
+        // `c`, so the offending chain is c → b → c.
+        try expect.equal(status.cycle.names.len, @as(usize, 3));
+        try expect.toBeTrue(std.mem.eql(u8, status.cycle.names[0], "c"));
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            status.cycle.names[status.cycle.names.len - 1],
+            "c",
+        ));
+    }
+
+    test "detectCycle catches a cycle behind a node reached via two clean-prefix paths" {
+        // `d`'s children are walked in order: (1) `c → leaf` is a
+        // genuinely clean subtree that leaves `c`/`leaf` in the done
+        // set; (2) `e → d` then closes the `d → e → d` cycle. The
+        // earlier done-marking of the sibling subtree must not suppress
+        // the cycle on the later branch.
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "entry", &.{"d"});
+        try m.map.put(a, "d", &.{ "c", "e" });
+        try m.map.put(a, "c", &.{"leaf"});
+        try m.map.put(a, "leaf", &.{});
+        try m.map.put(a, "e", &.{"d"});
+
+        const status = try flow_cycle.detectCycle(a, "entry", m.resolver());
+        try expect.toBeTrue(status == .cycle);
+        try expect.toBeTrue(std.mem.eql(u8, status.cycle.names[0], "d"));
+        try expect.toBeTrue(std.mem.eql(
+            u8,
+            status.cycle.names[status.cycle.names.len - 1],
+            "d",
+        ));
+    }
+
+    test "detectCycle treats a node reached via two genuinely clean paths as clean" {
+        // Counterpart false-positive guard: `c` is reached twice, both
+        // paths acyclic. The done-set skip on the second visit must not
+        // be mistaken for a cycle.
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        var m: MapResolver = .{ .map = .empty };
+        try m.map.put(a, "a", &.{ "x", "y" });
+        try m.map.put(a, "x", &.{"c"});
+        try m.map.put(a, "y", &.{"c"});
+        try m.map.put(a, "c", &.{"leaf"});
+        try m.map.put(a, "leaf", &.{});
+
+        const status = try flow_cycle.detectCycle(a, "a", m.resolver());
+        try expect.toBeTrue(status == .clean);
+    }
+
     fn createTempDir(allocator: std.mem.Allocator) ![]const u8 {
         const ts = timestampSeconds();
         const dir_name = try std.fmt.allocPrint(

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -15,7 +15,6 @@ const gizmo_io = @import("gizmo_io.zig");
 const flow_io = @import("flow_io.zig");
 const flow_doc = @import("modules/flow_doc.zig");
 const flow_cycle = @import("flow_cycle.zig");
-const flow_doc = @import("modules/flow_doc.zig");
 const gizmos = @import("gizmos.zig");
 const preview = @import("preview.zig");
 const flow_projector = @import("flows/projector.zig");


### PR DESCRIPTION
## Summary

Implements an editor-side `Subflow` reference-cycle check for the `.flow.jsonc` flow editor (RFC §4). Until now, a cyclic flow-reference graph was only rejected by `flow-codegen` at build time; the editor accepted it silently.

## What it does

- **`src/flow_cycle.zig`** — a depth-first walk over the `Subflow` reference graph.
  - `detectCycle` is pure over an abstract `Resolver` callback, so the walk is unit-testable with an in-memory reference map.
  - `analyze` wires the resolver to read `scripts/flows/<name>.flow.jsonc` files from the open project (caching each file once), and classifies the graph as `clean`, a reference `cycle`, or an `unresolved` reference — reporting the offending chain of flow names in each non-clean case.
  - The open document's *live* (possibly unsaved) `Subflow` references are pre-seeded into the resolver, so an in-editor edit is checked immediately.
- **`src/modules/flow_doc.zig`** — runs the check when a flow loads and re-runs it whenever the live set of `Subflow` references changes. A warning banner shows the offending chain (`a → b → a`) in the flow tab; a clean flow shows nothing.

## On reusing flow-codegen

The ticket suggested reusing `flow-codegen`'s `FlowRegistry` / `detectReferenceCycle`. The published `flow_codegen` v0.1.0 package (the URL dep this repo pins) predates the `.flow.jsonc` schema — it still parses the older `.flow.zon` format and exposes no registry or cycle-detection surface. Reusing it was impractical, so an equivalent depth-first walk is implemented here, as the ticket's fallback allows.

## Testing

- `zig build` — passes.
- `zig build test` — 257/257 pass, including new `FlowCycleTests` (pure walk: linear, self-reference, indirect cycle, cycle off the entry path, unresolved reference, diamond graph; plus on-disk `analyze` against real `.flow.jsonc` fixtures) and `flow_cycle.zig`'s own `test` blocks.
- `zig build gui-test` — 16/16 pass.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)