### PR TITLE
Make editor file saves atomic (#166)

### DIFF
--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -781,14 +781,19 @@ fn writeCoord(a: std.mem.Allocator, out: *std.ArrayList(u8), v: f32) !void {
     }
 }
 
-/// Write `doc` back to disk at `path`, truncating any existing file.
+/// Write `doc` back to disk at `path`, replacing any existing file.
+/// The write is atomic — see `io_global.writeFileAtomic` — so a crash
+/// mid-save can never corrupt the flow graph on disk.
 pub fn saveToFile(child_allocator: std.mem.Allocator, path: []const u8, doc: FlowDoc) !void {
     const text = try render(child_allocator, doc);
     defer child_allocator.free(text);
-    try std.Io.Dir.cwd().writeFile(io_global.io(), .{
-        .sub_path = path,
-        .data = text,
-    });
+    try io_global.writeFileAtomic(
+        std.Io.Dir.cwd(),
+        io_global.io(),
+        path,
+        text,
+        child_allocator,
+    );
 }
 
 // ─── Path helpers ──────────────────────────────────────────────────────

--- a/src/io_global.zig
+++ b/src/io_global.zig
@@ -47,3 +47,60 @@ pub fn environ() std.process.Environ {
     if (!_initialized) initLazy();
     return _global_environ;
 }
+
+/// Monotonic counter so two atomic writes racing inside the same
+/// process (or the same wall-clock nanosecond) never pick the same
+/// temp-file name.
+var _atomic_counter: std.atomic.Value(u64) = .init(0);
+
+/// Write `data` to `path` atomically: render into a temporary file in
+/// the *same directory* as `path`, then rename that temp file over
+/// `path`. POSIX `rename` (and the Windows equivalent the stdlib uses)
+/// replaces the destination in a single step, so a crash or I/O error
+/// mid-write can only leave either the old file fully intact or the new
+/// file fully in place — never a truncated, half-written destination.
+///
+/// The temp file lives next to `path` (not in `/tmp`) because `rename`
+/// is only atomic *within one filesystem*; a temp file on a different
+/// mount would force a non-atomic copy.
+///
+/// On any error before the rename succeeds the temp file is deleted, so
+/// a failed save never leaves a stray `.tmp` sibling behind.
+///
+/// This does NOT create `path`'s parent directory — it matches the
+/// plain-`writeFile` behaviour of the callers it replaced.
+pub fn writeFileAtomic(
+    dir: std.Io.Dir,
+    handle: std.Io,
+    path: []const u8,
+    data: []const u8,
+    allocator: std.mem.Allocator,
+) !void {
+    const dir_part = std.fs.path.dirname(path) orelse ".";
+    const base_part = std.fs.path.basename(path);
+
+    // `.<basename>.tmp.<pid>.<counter>` — dot-prefixed so it reads as a
+    // hidden sibling, and disambiguated by pid + an in-process counter.
+    const seq = _atomic_counter.fetchAdd(1, .monotonic);
+    const tmp_name = try std.fmt.allocPrint(
+        allocator,
+        ".{s}.tmp.{d}.{d}",
+        .{ base_part, std.Thread.getCurrentId(), seq },
+    );
+    defer allocator.free(tmp_name);
+
+    const tmp_path = try std.fs.path.join(allocator, &.{ dir_part, tmp_name });
+    defer allocator.free(tmp_path);
+
+    // Write the full payload into the temp file. On any failure delete
+    // the temp file so no stray `.tmp` is left behind.
+    {
+        errdefer dir.deleteFile(handle, tmp_path) catch {};
+        try dir.writeFile(handle, .{ .sub_path = tmp_path, .data = data });
+    }
+
+    // Atomically swap the temp file into place. If the rename itself
+    // fails, the temp file is still on disk — clean it up.
+    errdefer dir.deleteFile(handle, tmp_path) catch {};
+    try dir.rename(tmp_path, dir, path, handle);
+}

--- a/src/scene_io.zig
+++ b/src/scene_io.zig
@@ -440,10 +440,13 @@ pub fn parsePrefab(allocator: std.mem.Allocator, raw: []const u8) !LoadedPrefab 
 pub fn savePrefab(allocator: std.mem.Allocator, path: []const u8, loaded: LoadedPrefab) !void {
     const text = try renderPrefabJsonc(allocator, loaded);
     defer allocator.free(text);
-    try std.Io.Dir.cwd().writeFile(io_global.io(), .{
-        .sub_path = path,
-        .data = text,
-    });
+    try io_global.writeFileAtomic(
+        std.Io.Dir.cwd(),
+        io_global.io(),
+        path,
+        text,
+        allocator,
+    );
 }
 
 /// Emit the prefab as `{ "components": { ... }, "children": [ ... ] }`.
@@ -1377,15 +1380,20 @@ fn isManagedPrefabTopLevelKey(name: []const u8) bool {
 
 // ─── Writer ────────────────────────────────────────────────────────────
 
-/// Write the in-memory scene + extras back to disk at `path`. Truncates
-/// any existing file at the path.
+/// Write the in-memory scene + extras back to disk at `path`, replacing
+/// any existing file. The write is atomic — see
+/// `io_global.writeFileAtomic` — so a crash mid-save can never corrupt
+/// the scene on disk.
 pub fn saveScene(allocator: std.mem.Allocator, path: []const u8, loaded: LoadedScene) !void {
     const text = try renderSceneJsonc(allocator, loaded);
     defer allocator.free(text);
-    try std.Io.Dir.cwd().writeFile(io_global.io(), .{
-        .sub_path = path,
-        .data = text,
-    });
+    try io_global.writeFileAtomic(
+        std.Io.Dir.cwd(),
+        io_global.io(),
+        path,
+        text,
+        allocator,
+    );
 }
 
 /// Render the loaded scene back to JSONC. Managed fields (`name`,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4738,3 +4738,144 @@ pub const FlowIoTests = struct {
         try expect.toBeTrue(!project_tree.isFlowDocPath(dir, "/proj/scenes/a.jsonc"));
     }
 };
+
+/// Covers `io_global.writeFileAtomic` — the shared atomic-save helper
+/// behind `flow_io.saveToFile`, `scene_io.saveScene`, and
+/// `scene_io.savePrefab` (issue #166). The crash-safety guarantee can't
+/// be exercised without fault injection, so these tests pin the
+/// observable contract: the right bytes land at `path`, an overwrite
+/// fully replaces the previous content, and a successful save leaves no
+/// `.tmp` sibling behind.
+pub const AtomicWriteTests = struct {
+    fn createTempDir(allocator: std.mem.Allocator) ![]const u8 {
+        const ts = timestampSeconds();
+        const Counter = struct {
+            var i: u64 = 0;
+        };
+        Counter.i += 1;
+        const dir_name = try std.fmt.allocPrint(
+            allocator,
+            "/tmp/labelle_atomic_{d}_{d}",
+            .{ ts, Counter.i },
+        );
+        try std.Io.Dir.cwd().createDir(io_global.io(), dir_name, .default_dir);
+        return dir_name;
+    }
+
+    fn deleteTempDir(allocator: std.mem.Allocator, dir_path: []const u8) void {
+        std.Io.Dir.cwd().deleteTree(io_global.io(), dir_path) catch {};
+        allocator.free(dir_path);
+    }
+
+    fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+        return std.Io.Dir.cwd().readFileAlloc(
+            io_global.io(),
+            path,
+            allocator,
+            .limited(1024 * 1024),
+        );
+    }
+
+    /// Number of directory entries whose name contains ".tmp" — a
+    /// successful atomic save must leave zero of these.
+    fn countTempFiles(dir_path: []const u8) !usize {
+        var dir = try std.Io.Dir.cwd().openDir(io_global.io(), dir_path, .{ .iterate = true });
+        defer dir.close(io_global.io());
+        var it = dir.iterate();
+        var count: usize = 0;
+        while (try it.next(io_global.io())) |entry| {
+            if (std.mem.indexOf(u8, entry.name, ".tmp") != null) count += 1;
+        }
+        return count;
+    }
+
+    test "writes content to a fresh file" {
+        const allocator = std.testing.allocator;
+        const tmp = try createTempDir(allocator);
+        defer deleteTempDir(allocator, tmp);
+
+        const path = try std.fs.path.join(allocator, &.{ tmp, "out.txt" });
+        defer allocator.free(path);
+
+        try io_global.writeFileAtomic(
+            std.Io.Dir.cwd(),
+            io_global.io(),
+            path,
+            "hello atomic world",
+            allocator,
+        );
+
+        const got = try readFile(allocator, path);
+        defer allocator.free(got);
+        try std.testing.expectEqualStrings("hello atomic world", got);
+    }
+
+    test "overwriting an existing file replaces its content" {
+        const allocator = std.testing.allocator;
+        const tmp = try createTempDir(allocator);
+        defer deleteTempDir(allocator, tmp);
+
+        const path = try std.fs.path.join(allocator, &.{ tmp, "scene.jsonc" });
+        defer allocator.free(path);
+
+        // Seed a longer original — a non-atomic truncating write would
+        // leave trailing stale bytes if the new payload were shorter.
+        try std.Io.Dir.cwd().writeFile(io_global.io(), .{
+            .sub_path = path,
+            .data = "ORIGINAL CONTENT THAT IS FAIRLY LONG AND SHOULD BE GONE",
+        });
+
+        try io_global.writeFileAtomic(
+            std.Io.Dir.cwd(),
+            io_global.io(),
+            path,
+            "new",
+            allocator,
+        );
+
+        const got = try readFile(allocator, path);
+        defer allocator.free(got);
+        try std.testing.expectEqualStrings("new", got);
+    }
+
+    test "successful save leaves no leftover temp file" {
+        const allocator = std.testing.allocator;
+        const tmp = try createTempDir(allocator);
+        defer deleteTempDir(allocator, tmp);
+
+        const path = try std.fs.path.join(allocator, &.{ tmp, "prefab.jsonc" });
+        defer allocator.free(path);
+
+        try io_global.writeFileAtomic(
+            std.Io.Dir.cwd(),
+            io_global.io(),
+            path,
+            "{ \"components\": {} }\n",
+            allocator,
+        );
+
+        // Only the destination file should remain — the `.tmp` sibling
+        // must have been renamed away, not left in the directory.
+        try expect.equal(try countTempFiles(tmp), 0);
+    }
+
+    test "scene_io.saveScene writes atomically with no temp leftover" {
+        const allocator = std.testing.allocator;
+        const tmp = try createTempDir(allocator);
+        defer deleteTempDir(allocator, tmp);
+
+        const path = try std.fs.path.join(allocator, &.{ tmp, "main.jsonc" });
+        defer allocator.free(path);
+
+        const src = "{ \"name\": \"main\", \"entities\": [] }\n";
+        var scene = try scene_io.parseScene(allocator, src);
+        defer scene.deinit();
+
+        try scene_io.saveScene(allocator, path, scene);
+
+        const got = try readFile(allocator, path);
+        defer allocator.free(got);
+        try expect.toBeTrue(std.mem.indexOf(u8, got, "\"main\"") != null);
+        try expect.equal(try countTempFiles(tmp), 0);
+    }
+};


### PR DESCRIPTION
## Problem

Closes #166.

The editor's on-disk writers did a direct, truncating overwrite — no atomicity, no backup:

- `flow_io.saveToFile` (`src/flow_io.zig`)
- `scene_io.saveScene` / `scene_io.savePrefab` (`src/scene_io.zig`)

All three render the whole file then call `std.Io.Dir.writeFile`, which truncates the destination *before* writing. A crash or I/O error mid-write leaves the original destroyed and only partially rewritten — corrupted and unrecoverable, worse for large files.

## Change

Add one shared helper, `io_global.writeFileAtomic`, that:

- writes the payload to a temp file in the **same directory** as the destination (`rename` is only atomic within a single filesystem — a `/tmp` temp file would force a non-atomic copy);
- atomically renames the temp file over the destination (POSIX `rename` / the Windows replace-if-exists path the stdlib's `dirRename` uses);
- on **any** error before the rename succeeds, deletes the temp file so a failed save never leaves a stray `.tmp` sibling behind;
- does **not** create the destination's parent directory — matching the prior `writeFile` behaviour of all three callers (no silent new behaviour).

The temp name is `.<basename>.tmp.<tid>.<counter>` — dot-prefixed hidden sibling, disambiguated by thread id plus a process-wide monotonic counter so concurrent saves never collide.

`flow_io.saveToFile`, `scene_io.saveScene`, and `scene_io.savePrefab` now delegate to the helper. Success behaviour is unchanged — the same bytes land at `path`; only crash-safety improves.

## Tests

New `AtomicWriteTests` scope in `src/tests.zig` (follows the existing `/tmp` temp-dir pattern):

- content written correctly to a fresh file;
- overwriting an existing (deliberately longer) file fully replaces its content — a non-atomic truncating write would leave trailing stale bytes;
- a successful save leaves zero `.tmp` files in the directory;
- `scene_io.saveScene` end-to-end through the helper.

A fault-injected mid-write test isn't included — it's impractical without fault injection; the tests pin the success-path and no-leftover-temp guarantees.

`zig build`, `zig build test` (244/244), and `zig build gui-test` (16/16) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)