### PR TITLE
feat(scene): drag-drop prefab from project tree onto viewport (#85)

### DIFF
--- a/src/modules/dnd.zig
+++ b/src/modules/dnd.zig
@@ -55,3 +55,44 @@ pub fn packComponent(stem: []const u8) ComponentPayload {
 pub fn unpackComponent(payload: *const ComponentPayload) []const u8 {
     return payload.name[0..payload.name_len];
 }
+
+/// Payload identifier for a prefab `.jsonc` file dragged from the
+/// project tree onto a scene viewport (issue #85). The prefab is
+/// identified by its filename stem (e.g. "canteen") — the same key
+/// the engine uses when a scene entity writes
+/// `{ "prefab": "canteen" }`. Distinct from `COMPONENT_TYPE` so the
+/// two drag kinds can coexist without the wrong target accepting
+/// the wrong payload.
+pub const PREFAB_TYPE: [:0]const u8 = "labelle_prefab_name";
+
+/// Plain-data payload carried by a prefab drag. Same fixed-buffer
+/// shape as `ComponentPayload` so the two share `PAYLOAD_NAME_CAP`
+/// and the receive-side `@memcpy` pattern is identical. We carry
+/// the *stem* (basename minus `.jsonc`), not the absolute path —
+/// the engine + `prefab_index` both key on stem, and a stem is
+/// always shorter than the OS-level path it came from.
+pub const PrefabPayload = extern struct {
+    /// Valid prefix length of `name`. Always ≤ PAYLOAD_NAME_CAP.
+    name_len: u8,
+    /// Zero-padded prefab stem bytes (e.g. "canteen", "movement_node").
+    name: [PAYLOAD_NAME_CAP]u8,
+};
+
+/// Build a prefab payload from a caller-supplied stem. Truncates if
+/// the stem exceeds `PAYLOAD_NAME_CAP` — OS path limits make that
+/// effectively impossible, but the clamp keeps us robust against a
+/// malformed tree entry.
+pub fn packPrefab(stem: []const u8) PrefabPayload {
+    var p: PrefabPayload = .{ .name_len = 0, .name = [_]u8{0} ** PAYLOAD_NAME_CAP };
+    const n = @min(stem.len, PAYLOAD_NAME_CAP);
+    @memcpy(p.name[0..n], stem[0..n]);
+    p.name_len = @intCast(n);
+    return p;
+}
+
+/// Read the prefab stem back out of a received payload. Returns a
+/// slice into the payload buffer — caller must dupe before the
+/// next imgui frame.
+pub fn unpackPrefab(payload: *const PrefabPayload) []const u8 {
+    return payload.name[0..payload.name_len];
+}

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -440,7 +440,7 @@ fn renderViewport(
         openPrefabFromEntity(app, s, idx);
     }
     if (prefab_drop) |drop| {
-        handlePrefabDrop(s, drop);
+        handlePrefabDrop(s, app, drop);
     }
 }
 
@@ -451,7 +451,13 @@ fn renderViewport(
 /// drag source already filters to `prefabs/**/*.jsonc`, so reaching
 /// here with an empty stem would mean somebody else is emitting
 /// `PREFAB_TYPE`.
-fn handlePrefabDrop(s: *SceneState, drop: viewport.PrefabDrop) void {
+///
+/// Snap math: passes `0` as the snap origin to match the viewport's
+/// default `snap_origin` (which the scene editor leaves at `{0, 0}`
+/// because it doesn't surface a UI for that field). If `snap_origin`
+/// ever becomes per-tab, thread it through here so a drop lands on
+/// the same cell a drag-to-move on the same world coord would.
+fn handlePrefabDrop(s: *SceneState, app: *App, drop: viewport.PrefabDrop) void {
     const name = drop.name();
     if (name.len == 0) {
         std.log.warn("scene: prefab drop ignored, empty stem", .{});
@@ -464,6 +470,11 @@ fn handlePrefabDrop(s: *SceneState, drop: viewport.PrefabDrop) void {
     }
     addPrefabEntity(s, name, world) catch |err| {
         std.log.err("scene: addPrefabEntity failed for {s}: {s}", .{ name, @errorName(err) });
+        // Surface to the status bar so the user knows the drop hit
+        // and failed — otherwise the gesture would noop visually
+        // with only a log line for evidence. Same shape as the
+        // "Add entity from prefab" failure path uses.
+        app.setStatus("Add prefab failed!");
     };
 }
 

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -398,6 +398,12 @@ fn renderViewport(
     var right_click: ?[2]f32 = null;
     var right_click_entity: ?usize = null;
     var double_click: ?usize = null;
+    // Drag-drop prefab sink (#85). Filled when the user drops a prefab
+    // file from the project tree on the viewport. The stem is copied
+    // into the sink's own buffer (see `viewport.PrefabDrop`), so it
+    // outlives ImGui's payload memory; we still consume it before
+    // returning since the next frame might emit another drop.
+    var prefab_drop: ?viewport.PrefabDrop = null;
     viewport.render(
         .{
             .pan = &s.pan,
@@ -411,6 +417,7 @@ fn renderViewport(
             .double_click_entity = &double_click,
             .grid_step = s.grid_step,
             .snap_enabled = s.snap_enabled,
+            .prefab_drop = &prefab_drop,
         },
         s.loaded.scene.entities,
         s.loaded.extras.entity_components,
@@ -432,6 +439,32 @@ fn renderViewport(
     if (double_click) |idx| {
         openPrefabFromEntity(app, s, idx);
     }
+    if (prefab_drop) |drop| {
+        handlePrefabDrop(s, drop);
+    }
+}
+
+/// Resolve a drag-drop prefab landing on the scene viewport (#85).
+/// Applies the scene's snap setting to the drop position and routes
+/// to the same `addPrefabEntity` helper the toolbar / right-click
+/// flows use. Empty names (malformed payload) log and noop; the
+/// drag source already filters to `prefabs/**/*.jsonc`, so reaching
+/// here with an empty stem would mean somebody else is emitting
+/// `PREFAB_TYPE`.
+fn handlePrefabDrop(s: *SceneState, drop: viewport.PrefabDrop) void {
+    const name = drop.name();
+    if (name.len == 0) {
+        std.log.warn("scene: prefab drop ignored, empty stem", .{});
+        return;
+    }
+    var world = drop.world;
+    if (s.snap_enabled and s.grid_step > 0) {
+        world[0] = viewport.snapValue(world[0], 0, s.grid_step);
+        world[1] = viewport.snapValue(world[1], 0, s.grid_step);
+    }
+    addPrefabEntity(s, name, world) catch |err| {
+        std.log.err("scene: addPrefabEntity failed for {s}: {s}", .{ name, @errorName(err) });
+    };
 }
 
 /// Per-entity right-click context menu — currently just Delete, room

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -227,18 +227,35 @@ pub fn render(
         .flags = .{ .mouse_button_left = true, .mouse_button_middle = true },
     });
 
-    // Drag-drop target for components from the project tree (#143).
-    // Must attach to the LAST submitted item (the invisibleButton
-    // above) so `beginDragDropTarget` picks up the canvas region.
-    // Gated on `component_drop` being non-null — only editors that
-    // know how to consume the drop (the prefab editor today) wire
-    // this sink.
-    // One `beginDragDropTarget` covers both kinds — ImGui filters by
-    // payload type inside `acceptDragDropPayload`, so the two sinks
-    // never cross-fire. Gated together on at least one being wired:
-    // the scene tab wires `prefab_drop` (#85); the prefab tab wires
+    // Drag-drop target — must attach to the LAST submitted item (the
+    // invisibleButton above) so `beginDragDropTarget` picks up the
+    // canvas region. One `beginDragDropTarget` covers both payload
+    // kinds — ImGui filters by payload type inside
+    // `acceptDragDropPayload`, so the two sinks never cross-fire.
+    // Gated together on at least one being wired: the scene tab
+    // wires `prefab_drop` (#85); the prefab tab wires
     // `component_drop` (#143); other tabs wire neither.
     if (state.component_drop != null or state.prefab_drop != null) {
+        // Drop-zone discovery: when a compatible payload is in flight
+        // anywhere in the imgui context, tint the canvas border so
+        // the user can tell the viewport will accept the drop. ImGui
+        // draws its own default highlight on the active target rect,
+        // but that only triggers once the cursor enters the target —
+        // this paints the moment a drag starts so the user can spot
+        // where to aim before getting there (#85 spec calls it out).
+        if (zgui.getDragDropPayload()) |payload| {
+            const accepts = (state.component_drop != null and payload.isDataType(dnd.COMPONENT_TYPE)) or
+                (state.prefab_drop != null and payload.isDataType(dnd.PREFAB_TYPE));
+            if (accepts) {
+                dl.addRect(.{
+                    .pmin = canvas_min,
+                    .pmax = canvas_max,
+                    .col = 0x80_55_aa_ff, // soft blue, semi-transparent
+                    .thickness = 3.0,
+                });
+            }
+        }
+
         if (zgui.beginDragDropTarget()) {
             defer zgui.endDragDropTarget();
             if (state.component_drop) |sink| {

--- a/src/modules/viewport.zig
+++ b/src/modules/viewport.zig
@@ -35,6 +35,22 @@ pub const ComponentDrop = struct {
     }
 };
 
+/// One-shot sink for a prefab drag-drop that landed on the canvas
+/// (#85). Same shape as `ComponentDrop` — the prefab name is copied
+/// into a fixed buffer so the caller doesn't depend on ImGui's
+/// payload buffer past the accept callback — plus the drop's
+/// world-space coordinate so the caller can place the new entity
+/// where the cursor released.
+pub const PrefabDrop = struct {
+    name_buf: [dnd.PAYLOAD_NAME_CAP]u8 = [_]u8{0} ** dnd.PAYLOAD_NAME_CAP,
+    name_len: u8 = 0,
+    world: [2]f32 = .{ 0, 0 },
+
+    pub fn name(self: *const PrefabDrop) []const u8 {
+        return self.name_buf[0..self.name_len];
+    }
+};
+
 /// Mutable per-tab state the viewport reads and writes.
 pub const State = struct {
     pan: *[2]f32,
@@ -83,6 +99,14 @@ pub const State = struct {
     /// prefab's body Sprite and the component as an unmodeled extra.
     /// Null in editor tabs that don't accept component drops.
     component_drop: ?*?ComponentDrop = null,
+    /// Optional sink for "a prefab `.jsonc` dragged from the project
+    /// tree's prefabs/ folder was dropped on the canvas" (#85). The
+    /// viewport fills the `PrefabDrop` with the prefab stem + drop
+    /// world position; the caller routes through `addPrefabEntity`.
+    /// Null in tabs that don't accept prefab drops (the prefab
+    /// editor passes null — dropping a prefab on a different prefab
+    /// would edit a file other than the active tab, surprising).
+    prefab_drop: ?*?PrefabDrop = null,
     /// World-space spacing for the visual grid AND, when snapping is on,
     /// the snap step. One number drives both so the grid the user sees
     /// is the grid their drags land on. Default 16 matches what most 2D
@@ -209,18 +233,43 @@ pub fn render(
     // Gated on `component_drop` being non-null — only editors that
     // know how to consume the drop (the prefab editor today) wire
     // this sink.
-    if (state.component_drop) |sink| {
+    // One `beginDragDropTarget` covers both kinds — ImGui filters by
+    // payload type inside `acceptDragDropPayload`, so the two sinks
+    // never cross-fire. Gated together on at least one being wired:
+    // the scene tab wires `prefab_drop` (#85); the prefab tab wires
+    // `component_drop` (#143); other tabs wire neither.
+    if (state.component_drop != null or state.prefab_drop != null) {
         if (zgui.beginDragDropTarget()) {
             defer zgui.endDragDropTarget();
-            if (zgui.acceptDragDropPayload(dnd.COMPONENT_TYPE, .{})) |raw| {
-                if (raw.data) |ptr| {
-                    const p: *const dnd.ComponentPayload = @ptrCast(@alignCast(ptr));
-                    const stem = dnd.unpackComponent(p);
-                    var out: ComponentDrop = .{};
-                    const n = @min(stem.len, out.name_buf.len);
-                    @memcpy(out.name_buf[0..n], stem[0..n]);
-                    out.name_len = @intCast(n);
-                    sink.* = out;
+            if (state.component_drop) |sink| {
+                if (zgui.acceptDragDropPayload(dnd.COMPONENT_TYPE, .{})) |raw| {
+                    if (raw.data) |ptr| {
+                        const p: *const dnd.ComponentPayload = @ptrCast(@alignCast(ptr));
+                        const stem = dnd.unpackComponent(p);
+                        var out: ComponentDrop = .{};
+                        const n = @min(stem.len, out.name_buf.len);
+                        @memcpy(out.name_buf[0..n], stem[0..n]);
+                        out.name_len = @intCast(n);
+                        sink.* = out;
+                    }
+                }
+            }
+            if (state.prefab_drop) |sink| {
+                if (zgui.acceptDragDropPayload(dnd.PREFAB_TYPE, .{})) |raw| {
+                    if (raw.data) |ptr| {
+                        const p: *const dnd.PrefabPayload = @ptrCast(@alignCast(ptr));
+                        const stem = dnd.unpackPrefab(p);
+                        var out: PrefabDrop = .{};
+                        const n = @min(stem.len, out.name_buf.len);
+                        @memcpy(out.name_buf[0..n], stem[0..n]);
+                        out.name_len = @intCast(n);
+                        // Mouse pos at the drop instant maps through
+                        // the same world transform other drops/clicks
+                        // use, so snap-to-grid downstream lands on the
+                        // expected cell.
+                        out.world = worldFromScreen(zgui.getMousePos(), canvas_min, state.pan.*, state.zoom.*);
+                        sink.* = out;
+                    }
                 }
             }
         }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4548,6 +4548,139 @@ pub const ComponentDndTests = struct {
     }
 };
 
+pub const PrefabDndTests = struct {
+    // Mirrors `ComponentDndTests`. pack/unpack are the contract
+    // between the project tree (drag source on `prefabs/**/*.jsonc`)
+    // and the scene viewport (drop target). Pure data helpers — no
+    // ImGui context needed.
+
+    test "packPrefab round-trips a short stem" {
+        const stem = "canteen";
+        const p = dnd.packPrefab(stem);
+        try expect.equal(@as(usize, p.name_len), stem.len);
+        try expect.equal(std.mem.eql(u8, dnd.unpackPrefab(&p), stem), true);
+    }
+
+    test "packPrefab round-trips a snake_case stem" {
+        // Real prefab names use snake_case (e.g. movement_node,
+        // bandit_raid_enabled). Pack must preserve underscores.
+        const stem = "movement_node";
+        const p = dnd.packPrefab(stem);
+        try expect.equal(@as(usize, p.name_len), stem.len);
+        try expect.equal(std.mem.eql(u8, dnd.unpackPrefab(&p), stem), true);
+    }
+
+    test "packPrefab truncates a stem longer than PAYLOAD_NAME_CAP" {
+        var oversize: [dnd.PAYLOAD_NAME_CAP + 1]u8 = undefined;
+        @memset(&oversize, 'x');
+        const p = dnd.packPrefab(&oversize);
+        try expect.equal(@as(usize, p.name_len), dnd.PAYLOAD_NAME_CAP);
+    }
+
+    test "packPrefab zero-pads the unused tail" {
+        const p = dnd.packPrefab("canteen");
+        // Tail must be zeroed for the same reason packComponent's is —
+        // the struct is memcpy'd into ImGui's buffer wholesale.
+        try expect.equal(p.name[7], @as(u8, 0));
+        try expect.equal(p.name[p.name.len - 1], @as(u8, 0));
+    }
+};
+
+pub const TreeViewClassifierTests = struct {
+    // `isComponentFile` / `isPrefabFile` decide which file leaves
+    // become drag sources. They're `pub fn` to be reachable from
+    // here; the production code only calls them from `renderFolder`.
+
+    test "isComponentFile accepts a top-level .zig under components/" {
+        const prefix = "/proj/components/";
+        try expect.toBeTrue(tree_view.isComponentFile(
+            "/proj/components/bed.zig",
+            "bed.zig",
+            prefix,
+        ));
+    }
+
+    test "isComponentFile rejects a .zig in a subfolder" {
+        // Non-recursive by design — only top-level component files
+        // are draggable. Nested .zig (e.g. shared helpers) shouldn't
+        // surface as a drag source.
+        const prefix = "/proj/components/";
+        try expect.toBeFalse(tree_view.isComponentFile(
+            "/proj/components/shared/helper.zig",
+            "helper.zig",
+            prefix,
+        ));
+    }
+
+    test "isComponentFile rejects non-.zig files" {
+        const prefix = "/proj/components/";
+        try expect.toBeFalse(tree_view.isComponentFile(
+            "/proj/components/notes.md",
+            "notes.md",
+            prefix,
+        ));
+    }
+
+    test "isComponentFile rejects when prefix is empty (bufPrint failure)" {
+        try expect.toBeFalse(tree_view.isComponentFile(
+            "/proj/components/bed.zig",
+            "bed.zig",
+            "",
+        ));
+    }
+
+    test "isPrefabFile accepts a .jsonc directly under prefabs/" {
+        const prefix = "/proj/prefabs/";
+        try expect.toBeTrue(tree_view.isPrefabFile(
+            "/proj/prefabs/canteen.jsonc",
+            "canteen.jsonc",
+            prefix,
+        ));
+    }
+
+    test "isPrefabFile accepts a .jsonc in a subfolder (recursive)" {
+        // Real projects nest prefabs (e.g.
+        // flying-platform-labelle/prefabs/rooms/canteen.jsonc).
+        // This is the key behavioral difference from
+        // `isComponentFile`.
+        const prefix = "/proj/prefabs/";
+        try expect.toBeTrue(tree_view.isPrefabFile(
+            "/proj/prefabs/rooms/canteen.jsonc",
+            "canteen.jsonc",
+            prefix,
+        ));
+    }
+
+    test "isPrefabFile rejects non-.jsonc files" {
+        const prefix = "/proj/prefabs/";
+        try expect.toBeFalse(tree_view.isPrefabFile(
+            "/proj/prefabs/notes.md",
+            "notes.md",
+            prefix,
+        ));
+    }
+
+    test "isPrefabFile rejects .jsonc outside prefabs/" {
+        // Scene .jsonc files share the extension but live under
+        // scenes/. They must not become drag sources for the
+        // viewport.
+        const prefix = "/proj/prefabs/";
+        try expect.toBeFalse(tree_view.isPrefabFile(
+            "/proj/scenes/main.jsonc",
+            "main.jsonc",
+            prefix,
+        ));
+    }
+
+    test "isPrefabFile rejects when prefix is empty (bufPrint failure)" {
+        try expect.toBeFalse(tree_view.isPrefabFile(
+            "/proj/prefabs/canteen.jsonc",
+            "canteen.jsonc",
+            "",
+        ));
+    }
+};
+
 pub const MatchingPrefabSpriteTests = struct {
     // Helper covers the "drop component → find same-named prefab →
     // copy its body Sprite" pairing. Full happy path needs a real

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -158,13 +158,22 @@ pub const TreeView = struct {
 
         // Same idea for `prefabs/` — any `.jsonc` file under this
         // prefix (including subdirectories like `prefabs/rooms/`)
-        // becomes a drag source for the scene viewport (#85).
+        // becomes a drag source for the scene viewport (#85). A
+        // bufPrint failure here (project root longer than
+        // `path_buf_size`) yields an empty prefix → `isPrefabFile`
+        // returns false for every entry and the drag source silently
+        // never shows up. Log once per frame so the failure is
+        // visible. Matches the `components_prefix` pattern above by
+        // omission today — bug #143 carries the same risk.
         var prefabs_prefix_buf: [path_buf_size]u8 = undefined;
         const prefabs_prefix = std.fmt.bufPrint(
             &prefabs_prefix_buf,
             "{s}/{s}/",
             .{ base_path, project.ProjectFolders.prefabs },
-        ) catch "";
+        ) catch blk: {
+            std.log.warn("tree_view: project root too long for prefabs_prefix_buf; drag-drop of prefab files disabled this frame", .{});
+            break :blk "";
+        };
 
         // Render each top-level project folder. Entries that contain a
         // path separator (`scripts/flows`) are skipped — they belong
@@ -435,7 +444,7 @@ pub const TreeView = struct {
 /// project's `components/` folder. Non-recursive: only top-level
 /// files match. Used by `renderFolder` to wrap the file-leaf in a
 /// drag-source so the prefab editor can accept it (#143).
-fn isComponentFile(full_path: []const u8, file_name: []const u8, components_prefix: []const u8) bool {
+pub fn isComponentFile(full_path: []const u8, file_name: []const u8, components_prefix: []const u8) bool {
     if (components_prefix.len == 0) return false;
     if (!std.mem.endsWith(u8, file_name, ".zig")) return false;
     if (!std.mem.startsWith(u8, full_path, components_prefix)) return false;

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -156,6 +156,16 @@ pub const TreeView = struct {
             .{ base_path, project.ProjectFolders.components },
         ) catch "";
 
+        // Same idea for `prefabs/` — any `.jsonc` file under this
+        // prefix (including subdirectories like `prefabs/rooms/`)
+        // becomes a drag source for the scene viewport (#85).
+        var prefabs_prefix_buf: [path_buf_size]u8 = undefined;
+        const prefabs_prefix = std.fmt.bufPrint(
+            &prefabs_prefix_buf,
+            "{s}/{s}/",
+            .{ base_path, project.ProjectFolders.prefabs },
+        ) catch "";
+
         // Render each top-level project folder. Entries that contain a
         // path separator (`scripts/flows`) are skipped — they belong
         // under their parent in the tree, and the recursive walker
@@ -167,7 +177,7 @@ pub const TreeView = struct {
             var folder_path_buf: [path_buf_size:0]u8 = undefined;
             const folder_path = std.fmt.bufPrintZ(&folder_path_buf, "{s}/{s}", .{ base_path, folder_name }) catch continue;
 
-            if (self.renderDirectoryRow(folder_path, folder_name, managed_paths, components_prefix)) {
+            if (self.renderDirectoryRow(folder_path, folder_name, managed_paths, components_prefix, prefabs_prefix)) {
                 file_selected = true;
             }
         }
@@ -187,6 +197,7 @@ pub const TreeView = struct {
         display_name: []const u8,
         managed_paths: []const []const u8,
         components_prefix: []const u8,
+        prefabs_prefix: []const u8,
     ) bool {
         var file_selected = false;
         const is_open_state = self.isOpen(folder_path);
@@ -216,7 +227,7 @@ pub const TreeView = struct {
             defer zgui.unindent(.{});
 
             const line_top_y = zgui.getCursorScreenPos()[1];
-            if (self.renderFolder(folder_path, managed_paths, components_prefix)) {
+            if (self.renderFolder(folder_path, managed_paths, components_prefix, prefabs_prefix)) {
                 file_selected = true;
             }
             const line_bottom_y = zgui.getCursorScreenPos()[1];
@@ -250,7 +261,7 @@ pub const TreeView = struct {
     /// files. Subdirectories whose absolute path matches a
     /// `managed_paths` entry are suppressed because they're already
     /// rendered at top level (e.g. `scripts/flows`).
-    fn renderFolder(self: *Self, folder_path: []const u8, managed_paths: []const []const u8, components_prefix: []const u8) bool {
+    fn renderFolder(self: *Self, folder_path: []const u8, managed_paths: []const []const u8, components_prefix: []const u8, prefabs_prefix: []const u8) bool {
         var file_selected = false;
 
         const files = self.getFilesForFolder(folder_path) catch {
@@ -285,7 +296,7 @@ pub const TreeView = struct {
             }
 
             if (file_entry.is_directory) {
-                if (self.renderDirectoryRow(full_path, file_entry.name, managed_paths, components_prefix)) {
+                if (self.renderDirectoryRow(full_path, file_entry.name, managed_paths, components_prefix, prefabs_prefix)) {
                     file_selected = true;
                 }
             } else {
@@ -334,6 +345,31 @@ pub const TreeView = struct {
                             .once,
                         );
                         zgui.text("⚙ {s}", .{stem});
+                    }
+                }
+
+                // Drag source for prefab `.jsonc` files (#85). Recursive:
+                // any `.jsonc` anywhere under `prefabs/` qualifies (a
+                // real project keeps them in subfolders like
+                // `prefabs/rooms/canteen.jsonc`). The scene viewport's
+                // drop target unpacks the stem and routes through
+                // `addPrefabEntity`, same as the toolbar / right-click
+                // "Add prefab" flows.
+                if (isPrefabFile(full_path, file_entry.name, prefabs_prefix)) {
+                    if (zgui.beginDragDropSource(.{})) {
+                        defer zgui.endDragDropSource();
+                        const stem = file_entry.name[0 .. file_entry.name.len - ".jsonc".len];
+                        const payload = dnd.packPrefab(stem);
+                        _ = zgui.setDragDropPayload(
+                            dnd.PREFAB_TYPE,
+                            std.mem.asBytes(&payload),
+                            .once,
+                        );
+                        // Same icon family as the prefab-tab tab label;
+                        // distinct from the ⚙ component glyph so the
+                        // tooltip can't be confused with a component
+                        // drag mid-flight.
+                        zgui.text("⌖ {s}", .{stem});
                     }
                 }
             }
@@ -411,4 +447,16 @@ fn isComponentFile(full_path: []const u8, file_name: []const u8, components_pref
     // still carry a '/' here and is rejected.
     const remainder = full_path[components_prefix.len..];
     return std.mem.indexOfScalar(u8, remainder, '/') == null;
+}
+
+/// True when `full_path` is a `.jsonc` file anywhere under the
+/// project's `prefabs/` folder — including subdirectories like
+/// `prefabs/rooms/canteen.jsonc`. Recursive (in contrast to
+/// `isComponentFile`) because real projects keep prefabs in
+/// subfolders. Used by `renderFolder` to wrap the file-leaf in a
+/// drag-source the scene viewport accepts (#85).
+pub fn isPrefabFile(full_path: []const u8, file_name: []const u8, prefabs_prefix: []const u8) bool {
+    if (prefabs_prefix.len == 0) return false;
+    if (!std.mem.endsWith(u8, file_name, ".jsonc")) return false;
+    return std.mem.startsWith(u8, full_path, prefabs_prefix);
 }


### PR DESCRIPTION
## Summary

Closes [#85](https://github.com/labelle-toolkit/labelle-gui/issues/85). Prefab `.jsonc` rows in the project tree become drag sources; the scene viewport canvas accepts them and routes through the existing `addPrefabEntity` helper at the dropped world position — same code path the toolbar "Add prefab" and right-click "Add entity from prefab…" flows use. Mirrors the component drag-drop pattern that PR #143/#147 introduced.

### Changes

- **`src/modules/dnd.zig`** — new `PREFAB_TYPE` literal, `PrefabPayload` extern struct, `packPrefab`/`unpackPrefab` helpers. Reuses `PAYLOAD_NAME_CAP` so receive-side memcpy stays uniform with the existing component pair.
- **`src/tree_view.zig`** — computes a per-frame `prefabs_prefix` alongside the existing `components_prefix`, propagates it through `renderDirectoryRow` / `renderFolder`. New `isPrefabFile` helper (recursive — real projects keep prefabs in subfolders like `prefabs/rooms/canteen.jsonc`). File leaves matching the prefix open a `beginDragDropSource` and emit `PREFAB_TYPE`. Drag tooltip uses ⌖ so it's visually distinguishable from a ⚙ component drag mid-flight.
- **`src/modules/viewport.zig`** — new `PrefabDrop` struct + `State.prefab_drop` sink, mirroring `ComponentDrop`/`component_drop`. Adds a `world: [2]f32` field captured at drop instant via `worldFromScreen(getMousePos(), …)`. The existing single `beginDragDropTarget` block now handles both kinds — ImGui filters `acceptDragDropPayload` by type so they never cross-fire.
- **`src/modules/scene.zig`** — passes `&prefab_drop` to `viewport.render`; consumes it via a new `handlePrefabDrop` helper that applies snap-to-grid (same `snapValue` drag-to-move uses) before calling `addPrefabEntity`. Prefab editor passes `null` for `prefab_drop` — dropping a prefab on another prefab's canvas would edit a file other than the active tab, surprising.
- **`src/tests.zig`** — `PrefabDndTests` (4 cases) mirrors `ComponentDndTests` for the new payload helpers. `TreeViewClassifierTests` (9 cases) pins the recursive vs non-recursive contrast between `isPrefabFile` and `isComponentFile` and exercises empty-prefix / wrong-extension / wrong-folder rejection.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — 380/380 (13 new in `PrefabDndTests` + `TreeViewClassifierTests`)
- [x] `zig build gui-test` — 25/25
- [x] Visual against `flying-platform-labelle`:
  - Drag `prefabs/rooms/canteen.jsonc` onto `scenes/colony.jsonc` viewport → `canteen` entity added at the drop position, selected in the inspector. Same `(unsaved)` indicator the toolbar path produces.
  - "Add prefab" toolbar flow produces an entity visually identical to the drag-drop result (same marker, same selection state) — confirms the two paths share the entire downstream rendering and selection logic.
  - Dragging `scenes/main.jsonc` over the viewport → no payload registered, no drop accepted.
  - Dropping a prefab onto a prefab-editor tab's viewport → no-op (its sink is `null`, only `component_drop` is wired there from #143).
- [ ] Reviewer: confirm the snap-on-drop path lines up with what drag-to-move does for an already-placed entity (move + drop at the same world coord should land on the same cell).

## Not in scope

- **OS-level drops** (file manager → editor). ImGui's drag-drop API is intra-window; OS drops need a separate native handler.
- **Multi-file drag.** Single payload per drag for v1.
- **Drag of non-prefab files** (scenes / scripts / resources). Only prefabs make conceptual sense on the scene viewport.

## Out-of-scope follow-up surfaced during testing

The `flying-platform-labelle` reference project has migrated past the legacy scene format twice since this PR was first drafted — most recently to the **RFC #596 bundle shape** (commit `91eb475`): scenes are now top-level arrays with PascalCase component keys as siblings of `prefab` refs (no `"components"` / `"overrides"` / `"root"` wrappers), and file-level directives live in a leading `meta:` entry. The gui's `scene_io.zig` still parses the original legacy schema, so opening a current `flying-platform-labelle` scene fails with `UnexpectedToken`. Issue #174 originally targeted the intermediate RFC #560 wrapping; that scope is now stale and the issue needs to be re-aimed at #596 before any writer work lands — otherwise a save would emit a format the engine no longer accepts. Filed/tracked separately; not a blocker for this PR (drag-drop is additive plumbing and runs only after a scene tab opens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)