### PR TITLE
feat(hierarchy): searchable entity outliner for scene+prefab tabs (#144)

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -29,6 +29,7 @@ const gizmo_mod = @import("modules/gizmo.zig");
 const entity_inspector_mod = @import("modules/entity_inspector.zig");
 const game_view_mod = @import("modules/game_view.zig");
 const atlas_viewer_mod = @import("modules/atlas_viewer.zig");
+const hierarchy_mod = @import("modules/hierarchy.zig");
 const game_view = @import("game_view.zig");
 const io_global = @import("io_global.zig");
 const flow_runtime_mod = @import("modules/flow_runtime.zig");
@@ -201,6 +202,15 @@ pub const App = struct {
     /// packed-and-opened atlases.
     atlas_viewer: atlas_viewer_mod.AtlasViewer = .{},
 
+    /// Hierarchy panel toggle (#144). When open and the active tab is
+    /// a scene or prefab editor, lists every entity in the tab's data
+    /// with click-to-select bidirectional sync against the canvas.
+    show_hierarchy: bool = false,
+    /// Sticky search-filter buffer for the hierarchy panel. Kept in
+    /// App so the filter survives panel close/reopen — same pattern
+    /// as `prefab_picker_filter` on SceneState.
+    hierarchy_filter: [128:0]u8 = [_:0]u8{0} ** 128,
+
     /// Phase 3 (#84): Entity Inspector panel toggle.
     show_entity_inspector: bool = false,
     /// Entity Inspector state — fed by `PreviewSession`'s
@@ -290,7 +300,7 @@ pub const App = struct {
 
     /// Fixed-size storage for registered modules. Grow the array literal
     /// when adding modules; Zig will tell you if it overflows.
-    modules: [9]module.Module = undefined,
+    modules: [10]module.Module = undefined,
     registry: module.Registry = .{ .modules = &.{} },
 
     const Self = @This();
@@ -387,6 +397,7 @@ pub const App = struct {
         app.modules[6] = flow_runtime_mod.makeModule(app);
         app.modules[7] = game_view_mod.makeModule(app);
         app.modules[8] = atlas_viewer_mod.makeModule(app);
+        app.modules[9] = hierarchy_mod.makeModule(app);
         app.registry = .{ .modules = &app.modules };
 
         // Honor LABELLE_GAME_VIEW_SHM as a manual attach path until

--- a/src/modules/hierarchy.zig
+++ b/src/modules/hierarchy.zig
@@ -69,6 +69,15 @@ fn render(app: *App) void {
 
     const filter = std.mem.sliceTo(&app.hierarchy_filter, 0);
 
+    // Scroll the entity list inside its own region so the filter box
+    // and separator stay pinned at the top instead of scrolling away
+    // on long lists — the panel exists precisely for 50+ entity scenes,
+    // where losing the search bar mid-scroll defeats the purpose. The
+    // auto-scroll `setScrollHereY` below now targets this child, which
+    // is also the correct scope (it no longer shoves the header).
+    _ = zgui.beginChild("##hierarchy_list", .{});
+    defer zgui.endChild();
+
     switch (app.open_tabs.items[tab_idx]) {
         .scene => |*s| renderSceneRows(s, filter),
         .prefab => |*p| renderPrefabRows(p, filter),

--- a/src/modules/hierarchy.zig
+++ b/src/modules/hierarchy.zig
@@ -89,9 +89,9 @@ fn renderSceneRows(s: *scene_mod.SceneState, filter: []const u8) void {
     s.hierarchy_last_seen = s.selected_index;
 
     var visible: usize = 0;
-    for (s.loaded.scene.entities, 0..) |entity, i| {
-        var label_buf: [256:0]u8 = undefined;
-        const label = entityLabel(&label_buf, i, &entity) catch continue;
+    for (s.loaded.scene.entities, 0..) |*entity, i| {
+        var label_buf: [512:0]u8 = undefined;
+        const label = entityLabel(&label_buf, i, entity) catch continue;
         if (filter.len > 0 and !matchesFilter(label, filter)) continue;
 
         const selected = if (s.selected_index) |sel| sel == i else false;
@@ -113,11 +113,23 @@ fn renderSceneRows(s: *scene_mod.SceneState, filter: []const u8) void {
 }
 
 fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
-    // Same auto-scroll rule scene tabs use: externally-driven changes
-    // to the selection (canvas click) trigger a scroll to the row,
-    // in-panel clicks don't.
-    const auto_scroll_to: ?usize = if (p.selected_child_idx) |cur|
-        if (p.hierarchy_last_seen != cur) cur else null
+    // Auto-scroll on externally-driven selection changes. Unlike the
+    // scene panel (which only has child rows), the prefab panel has
+    // an extra `(prefab body)` row that represents `selected_child_idx
+    // == null`. Tracking the mirror as a bare `?usize` would conflate
+    // "no selection yet" with "body row picked" and skip scroll-to-
+    // body, so the target is encoded as a tagged union and the change
+    // detection compares both nullness and value.
+    const Target = union(enum) { body, child: usize };
+    const changed = blk: {
+        const a = p.hierarchy_last_seen;
+        const b = p.selected_child_idx;
+        if (a == null and b == null) break :blk false;
+        if (a == null or b == null) break :blk true;
+        break :blk a.? != b.?;
+    };
+    const auto_scroll_to: ?Target = if (changed)
+        (if (p.selected_child_idx) |cur| Target{ .child = cur } else .body)
     else
         null;
     p.hierarchy_last_seen = p.selected_child_idx;
@@ -130,6 +142,10 @@ fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
     if (filter.len == 0 or matchesFilter(body_label, filter)) {
         if (zgui.selectable(body_label, .{ .selected = body_selected })) {
             p.selected_child_idx = null;
+            p.hierarchy_last_seen = null;
+        }
+        if (auto_scroll_to) |target| {
+            if (target == .body) zgui.setScrollHereY(.{});
         }
     }
 
@@ -139,9 +155,9 @@ fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
     }
 
     var visible: usize = 0;
-    for (p.loaded.children, 0..) |child, i| {
-        var label_buf: [256:0]u8 = undefined;
-        const label = entityLabel(&label_buf, i, &child) catch continue;
+    for (p.loaded.children, 0..) |*child, i| {
+        var label_buf: [512:0]u8 = undefined;
+        const label = entityLabel(&label_buf, i, child) catch continue;
         if (filter.len > 0 and !matchesFilter(label, filter)) continue;
 
         const selected = if (p.selected_child_idx) |sel| sel == i else false;
@@ -149,9 +165,10 @@ fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
             p.selected_child_idx = i;
             p.hierarchy_last_seen = i;
         }
-        if (auto_scroll_to) |target| {
-            if (target == i) zgui.setScrollHereY(.{});
-        }
+        if (auto_scroll_to) |target| switch (target) {
+            .child => |idx| if (idx == i) zgui.setScrollHereY(.{}),
+            .body => {},
+        };
         visible += 1;
     }
 
@@ -166,7 +183,7 @@ fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
 /// discoverable in the list. Separator stays ASCII (`-`) — the
 /// emdash glyph isn't covered by ImGui's default font and renders
 /// as `?` on the panel.
-fn entityLabel(buf: *[256:0]u8, idx: usize, entity: *const scene_io.Entity) ![:0]u8 {
+fn entityLabel(buf: *[512:0]u8, idx: usize, entity: *const scene_io.Entity) ![:0]u8 {
     const name: []const u8 = entity.prefab orelse "(inline)";
     const comment = std.mem.sliceTo(&entity.comment, 0);
     const hint = firstCommentLine(comment);
@@ -187,7 +204,15 @@ pub fn firstCommentLine(comment: []const u8) []const u8 {
         // Strip the `//` marker and any leading whitespace after it.
         if (std.mem.startsWith(u8, line, "//")) line = std.mem.trim(u8, line[2..], " \t\r");
         if (line.len == 0) continue;
-        return if (line.len > 60) line[0..60] else line;
+        if (line.len > 60) {
+            // Walk back while byte at `limit` is a UTF-8 continuation
+            // byte (top bits 10xxxxxx) so we never slice mid-codepoint
+            // — ImGui chokes on invalid UTF-8 and shows tofu/glitches.
+            var limit: usize = 60;
+            while (limit > 0 and (line[limit] & 0xC0) == 0x80) : (limit -= 1) {}
+            return line[0..limit];
+        }
+        return line;
     }
     return &.{};
 }

--- a/src/modules/hierarchy.zig
+++ b/src/modules/hierarchy.zig
@@ -75,6 +75,19 @@ fn renderSceneRows(s: *scene_mod.SceneState, filter: []const u8) void {
         return;
     }
 
+    // Auto-scroll on externally-driven selection changes (e.g. user
+    // clicked an entity on the canvas). `last_seen_selected_index`
+    // mirrors the field the previous frame saw — when the live value
+    // diverges and was NOT set by clicking a row in this panel, the
+    // selectable for that row calls `setScrollHereY` so the user
+    // gets visual confirmation that the click registered, even when
+    // the panel is unfocused / dimmed behind the canvas.
+    const auto_scroll_to: ?usize = if (s.selected_index) |cur|
+        if (s.hierarchy_last_seen != cur) cur else null
+    else
+        null;
+    s.hierarchy_last_seen = s.selected_index;
+
     var visible: usize = 0;
     for (s.loaded.scene.entities, 0..) |entity, i| {
         var label_buf: [256:0]u8 = undefined;
@@ -84,6 +97,12 @@ fn renderSceneRows(s: *scene_mod.SceneState, filter: []const u8) void {
         const selected = if (s.selected_index) |sel| sel == i else false;
         if (zgui.selectable(label, .{ .selected = selected })) {
             s.selected_index = i;
+            // Update the mirror so the auto-scroll branch above
+            // doesn't fire next frame for an in-panel click.
+            s.hierarchy_last_seen = i;
+        }
+        if (auto_scroll_to) |target| {
+            if (target == i) zgui.setScrollHereY(.{});
         }
         visible += 1;
     }
@@ -94,10 +113,19 @@ fn renderSceneRows(s: *scene_mod.SceneState, filter: []const u8) void {
 }
 
 fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
+    // Same auto-scroll rule scene tabs use: externally-driven changes
+    // to the selection (canvas click) trigger a scroll to the row,
+    // in-panel clicks don't.
+    const auto_scroll_to: ?usize = if (p.selected_child_idx) |cur|
+        if (p.hierarchy_last_seen != cur) cur else null
+    else
+        null;
+    p.hierarchy_last_seen = p.selected_child_idx;
+
     // The prefab body itself is row #0 (`null` selection on the
     // canvas), so the panel offers a way back to it after navigating
     // a child without having to click the canvas's empty background.
-    const body_label = "▸ (prefab body)";
+    const body_label = "(prefab body)";
     const body_selected = p.selected_child_idx == null;
     if (filter.len == 0 or matchesFilter(body_label, filter)) {
         if (zgui.selectable(body_label, .{ .selected = body_selected })) {
@@ -119,6 +147,10 @@ fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
         const selected = if (p.selected_child_idx) |sel| sel == i else false;
         if (zgui.selectable(label, .{ .selected = selected })) {
             p.selected_child_idx = i;
+            p.hierarchy_last_seen = i;
+        }
+        if (auto_scroll_to) |target| {
+            if (target == i) zgui.setScrollHereY(.{});
         }
         visible += 1;
     }
@@ -131,7 +163,9 @@ fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
 /// `#N <prefab_name>` for prefab refs; `#N (inline)` for entities
 /// without a prefab field. The comment buffer's first non-empty line
 /// rides along as a hint when present so authored notes stay
-/// discoverable in the list.
+/// discoverable in the list. Separator stays ASCII (`-`) — the
+/// emdash glyph isn't covered by ImGui's default font and renders
+/// as `?` on the panel.
 fn entityLabel(buf: *[256:0]u8, idx: usize, entity: *const scene_io.Entity) ![:0]u8 {
     const name: []const u8 = entity.prefab orelse "(inline)";
     const comment = std.mem.sliceTo(&entity.comment, 0);
@@ -139,7 +173,7 @@ fn entityLabel(buf: *[256:0]u8, idx: usize, entity: *const scene_io.Entity) ![:0
     if (hint.len == 0) {
         return std.fmt.bufPrintZ(buf, "#{d} {s}", .{ idx, name });
     }
-    return std.fmt.bufPrintZ(buf, "#{d} {s}  — {s}", .{ idx, name, hint });
+    return std.fmt.bufPrintZ(buf, "#{d} {s}  - {s}", .{ idx, name, hint });
 }
 
 /// Return the first non-empty, comment-marker-stripped line from a

--- a/src/modules/hierarchy.zig
+++ b/src/modules/hierarchy.zig
@@ -1,0 +1,180 @@
+//! Hierarchy panel — flat searchable list of every entity in the
+//! active scene/prefab tab (#144). Solves selection failures on the
+//! canvas when entities overlap, sit off-viewport, or carry no
+//! visible footprint.
+//!
+//! Selection state is mirrored, not stored: clicking a row writes
+//! through to the active tab's existing `selected_index` /
+//! `selected_child_idx` field, so the canvas and the panel share
+//! one source of truth. The inspector reads from that same field,
+//! which gives the bidirectional sync for free.
+//!
+//! No effect when the active tab is anything other than a scene or
+//! prefab editor (the flow / gizmo tabs have their own selection
+//! models). The panel still renders, just with an "Open a scene
+//! or prefab to browse its entities" placeholder.
+
+const std = @import("std");
+const zgui = @import("zgui");
+
+const App = @import("../app.zig").App;
+const module = @import("../module.zig");
+const scene_io = @import("../scene_io.zig");
+const scene_mod = @import("scene.zig");
+const prefab_mod = @import("prefab.zig");
+
+pub fn makeModule(app: *App) module.Module {
+    return .{
+        .name = "hierarchy",
+        .display_name = "Hierarchy",
+        .is_open = &app.show_hierarchy,
+        .render_panel = render,
+    };
+}
+
+fn render(app: *App) void {
+    if (!zgui.begin("Hierarchy", .{
+        .popen = &app.show_hierarchy,
+        .flags = .{},
+    })) {
+        zgui.end();
+        return;
+    }
+    defer zgui.end();
+
+    // Search bar — case-insensitive substring match against the row
+    // label below. Buffer is owned by App so the filter survives
+    // panel close/reopen, matching the resources panel's pattern.
+    _ = zgui.inputTextWithHint("##hierarchy_filter", .{
+        .hint = "filter…",
+        .buf = &app.hierarchy_filter,
+    });
+    zgui.separator();
+
+    const tab_idx = app.active_tab_idx orelse {
+        zgui.textDisabled("Open a scene or prefab to browse its entities.", .{});
+        return;
+    };
+    if (tab_idx >= app.open_tabs.items.len) {
+        zgui.textDisabled("(no active tab)", .{});
+        return;
+    }
+
+    const filter = std.mem.sliceTo(&app.hierarchy_filter, 0);
+
+    switch (app.open_tabs.items[tab_idx]) {
+        .scene => |*s| renderSceneRows(s, filter),
+        .prefab => |*p| renderPrefabRows(p, filter),
+        else => zgui.textDisabled("Active tab has no entity tree.", .{}),
+    }
+}
+
+fn renderSceneRows(s: *scene_mod.SceneState, filter: []const u8) void {
+    if (s.loaded.scene.entities.len == 0) {
+        zgui.textDisabled("(scene is empty)", .{});
+        return;
+    }
+
+    var visible: usize = 0;
+    for (s.loaded.scene.entities, 0..) |entity, i| {
+        var label_buf: [256:0]u8 = undefined;
+        const label = entityLabel(&label_buf, i, &entity) catch continue;
+        if (filter.len > 0 and !matchesFilter(label, filter)) continue;
+
+        const selected = if (s.selected_index) |sel| sel == i else false;
+        if (zgui.selectable(label, .{ .selected = selected })) {
+            s.selected_index = i;
+        }
+        visible += 1;
+    }
+
+    if (visible == 0) {
+        zgui.textDisabled("(no entities match filter)", .{});
+    }
+}
+
+fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
+    // The prefab body itself is row #0 (`null` selection on the
+    // canvas), so the panel offers a way back to it after navigating
+    // a child without having to click the canvas's empty background.
+    const body_label = "▸ (prefab body)";
+    const body_selected = p.selected_child_idx == null;
+    if (filter.len == 0 or matchesFilter(body_label, filter)) {
+        if (zgui.selectable(body_label, .{ .selected = body_selected })) {
+            p.selected_child_idx = null;
+        }
+    }
+
+    if (p.loaded.children.len == 0) {
+        if (filter.len > 0) zgui.textDisabled("(prefab has no children)", .{});
+        return;
+    }
+
+    var visible: usize = 0;
+    for (p.loaded.children, 0..) |child, i| {
+        var label_buf: [256:0]u8 = undefined;
+        const label = entityLabel(&label_buf, i, &child) catch continue;
+        if (filter.len > 0 and !matchesFilter(label, filter)) continue;
+
+        const selected = if (p.selected_child_idx) |sel| sel == i else false;
+        if (zgui.selectable(label, .{ .selected = selected })) {
+            p.selected_child_idx = i;
+        }
+        visible += 1;
+    }
+
+    if (visible == 0 and filter.len > 0) {
+        zgui.textDisabled("(no children match filter)", .{});
+    }
+}
+
+/// `#N <prefab_name>` for prefab refs; `#N (inline)` for entities
+/// without a prefab field. The comment buffer's first non-empty line
+/// rides along as a hint when present so authored notes stay
+/// discoverable in the list.
+fn entityLabel(buf: *[256:0]u8, idx: usize, entity: *const scene_io.Entity) ![:0]u8 {
+    const name: []const u8 = entity.prefab orelse "(inline)";
+    const comment = std.mem.sliceTo(&entity.comment, 0);
+    const hint = firstCommentLine(comment);
+    if (hint.len == 0) {
+        return std.fmt.bufPrintZ(buf, "#{d} {s}", .{ idx, name });
+    }
+    return std.fmt.bufPrintZ(buf, "#{d} {s}  — {s}", .{ idx, name, hint });
+}
+
+/// Return the first non-empty, comment-marker-stripped line from a
+/// captured comment block, capped to 60 chars so a long block doesn't
+/// blow the row layout. Returns an empty slice when nothing useful
+/// survives the trim. Pub so `tests.zig` can exercise without imgui.
+pub fn firstCommentLine(comment: []const u8) []const u8 {
+    var it = std.mem.splitScalar(u8, comment, '\n');
+    while (it.next()) |raw_line| {
+        var line = std.mem.trim(u8, raw_line, " \t\r");
+        // Strip the `//` marker and any leading whitespace after it.
+        if (std.mem.startsWith(u8, line, "//")) line = std.mem.trim(u8, line[2..], " \t\r");
+        if (line.len == 0) continue;
+        return if (line.len > 60) line[0..60] else line;
+    }
+    return &.{};
+}
+
+/// Case-insensitive substring match. Iterates the haystack once
+/// matching against `needle`; cheap on the scale of a hierarchy
+/// panel (hundreds of entries) without pulling in a regex engine.
+/// Pub so `tests.zig` can exercise without imgui.
+pub fn matchesFilter(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (haystack.len < needle.len) return false;
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        var j: usize = 0;
+        while (j < needle.len) : (j += 1) {
+            const a = std.ascii.toLower(haystack[i + j]);
+            const b = std.ascii.toLower(needle[j]);
+            if (a != b) break;
+        }
+        if (j == needle.len) return true;
+    }
+    return false;
+}
+

--- a/src/modules/hierarchy.zig
+++ b/src/modules/hierarchy.zig
@@ -23,6 +23,13 @@ const scene_io = @import("../scene_io.zig");
 const scene_mod = @import("scene.zig");
 const prefab_mod = @import("prefab.zig");
 
+/// Maximum byte length of the comment-hint suffix appended to a row
+/// label. Caps a long captured block from blowing the row's horizontal
+/// layout. Picked to fit one or two typical authored notes
+/// (`Background`, `Bandit raids disabled for now`) without truncating
+/// them mid-word at the most common panel widths.
+pub const hint_cap_bytes: usize = 60;
+
 pub fn makeModule(app: *App) module.Module {
     return .{
         .name = "hierarchy",
@@ -76,23 +83,26 @@ fn renderSceneRows(s: *scene_mod.SceneState, filter: []const u8) void {
     }
 
     // Auto-scroll on externally-driven selection changes (e.g. user
-    // clicked an entity on the canvas). `last_seen_selected_index`
-    // mirrors the field the previous frame saw — when the live value
-    // diverges and was NOT set by clicking a row in this panel, the
-    // selectable for that row calls `setScrollHereY` so the user
-    // gets visual confirmation that the click registered, even when
-    // the panel is unfocused / dimmed behind the canvas.
-    const auto_scroll_to: ?usize = if (s.selected_index) |cur|
-        if (s.hierarchy_last_seen != cur) cur else null
-    else
-        null;
+    // clicked an entity on the canvas). The mirror compares both
+    // nullness and value — same shape as the prefab path's check —
+    // so a deselect-then-reselect of the same index still scrolls
+    // and a same-value redundant write doesn't.
+    const auto_scroll_to: ?usize = blk: {
+        const prev = s.hierarchy_last_seen;
+        const cur = s.selected_index;
+        if (prev == null and cur == null) break :blk null;
+        if (prev == null or cur == null) break :blk cur;
+        if (prev.? == cur.?) break :blk null;
+        break :blk cur;
+    };
     s.hierarchy_last_seen = s.selected_index;
 
     var visible: usize = 0;
     for (s.loaded.scene.entities, 0..) |*entity, i| {
+        if (!entityMatchesFilter(entity, filter)) continue;
+
         var label_buf: [512:0]u8 = undefined;
         const label = entityLabel(&label_buf, i, entity) catch continue;
-        if (filter.len > 0 and !matchesFilter(label, filter)) continue;
 
         const selected = if (s.selected_index) |sel| sel == i else false;
         if (zgui.selectable(label, .{ .selected = selected })) {
@@ -137,16 +147,17 @@ fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
     // The prefab body itself is row #0 (`null` selection on the
     // canvas), so the panel offers a way back to it after navigating
     // a child without having to click the canvas's empty background.
+    // Always rendered regardless of filter — it's a single fixed-
+    // purpose row, and hiding it via filter only strands the user
+    // mid-search with no way back to the prefab's own components.
     const body_label = "(prefab body)";
     const body_selected = p.selected_child_idx == null;
-    if (filter.len == 0 or matchesFilter(body_label, filter)) {
-        if (zgui.selectable(body_label, .{ .selected = body_selected })) {
-            p.selected_child_idx = null;
-            p.hierarchy_last_seen = null;
-        }
-        if (auto_scroll_to) |target| {
-            if (target == .body) zgui.setScrollHereY(.{});
-        }
+    if (zgui.selectable(body_label, .{ .selected = body_selected })) {
+        p.selected_child_idx = null;
+        p.hierarchy_last_seen = null;
+    }
+    if (auto_scroll_to) |target| {
+        if (target == .body) zgui.setScrollHereY(.{});
     }
 
     if (p.loaded.children.len == 0) {
@@ -156,9 +167,10 @@ fn renderPrefabRows(p: *prefab_mod.PrefabState, filter: []const u8) void {
 
     var visible: usize = 0;
     for (p.loaded.children, 0..) |*child, i| {
+        if (!entityMatchesFilter(child, filter)) continue;
+
         var label_buf: [512:0]u8 = undefined;
         const label = entityLabel(&label_buf, i, child) catch continue;
-        if (filter.len > 0 and !matchesFilter(label, filter)) continue;
 
         const selected = if (p.selected_child_idx) |sel| sel == i else false;
         if (zgui.selectable(label, .{ .selected = selected })) {
@@ -193,10 +205,26 @@ fn entityLabel(buf: *[512:0]u8, idx: usize, entity: *const scene_io.Entity) ![:0
     return std.fmt.bufPrintZ(buf, "#{d} {s}  - {s}", .{ idx, name, hint });
 }
 
+/// Filter predicate for one entity. Matches the typed prefab name
+/// and the first comment line, but **not** the index prefix — typing
+/// `5` should narrow to entities whose name or note contains `5`,
+/// not to every row whose index ends in 5 (e.g. #5, #15, #25, ...).
+/// Pub so `tests.zig` can exercise without imgui.
+pub fn entityMatchesFilter(entity: *const scene_io.Entity, filter: []const u8) bool {
+    if (filter.len == 0) return true;
+    const name: []const u8 = entity.prefab orelse "(inline)";
+    if (matchesFilter(name, filter)) return true;
+    const comment = std.mem.sliceTo(&entity.comment, 0);
+    const hint = firstCommentLine(comment);
+    if (hint.len > 0 and matchesFilter(hint, filter)) return true;
+    return false;
+}
+
 /// Return the first non-empty, comment-marker-stripped line from a
-/// captured comment block, capped to 60 chars so a long block doesn't
-/// blow the row layout. Returns an empty slice when nothing useful
-/// survives the trim. Pub so `tests.zig` can exercise without imgui.
+/// captured comment block, capped to `hint_cap_bytes` chars so a long
+/// block doesn't blow the row layout. Returns an empty slice when
+/// nothing useful survives the trim. Pub so `tests.zig` can exercise
+/// without imgui.
 pub fn firstCommentLine(comment: []const u8) []const u8 {
     var it = std.mem.splitScalar(u8, comment, '\n');
     while (it.next()) |raw_line| {
@@ -204,11 +232,11 @@ pub fn firstCommentLine(comment: []const u8) []const u8 {
         // Strip the `//` marker and any leading whitespace after it.
         if (std.mem.startsWith(u8, line, "//")) line = std.mem.trim(u8, line[2..], " \t\r");
         if (line.len == 0) continue;
-        if (line.len > 60) {
+        if (line.len > hint_cap_bytes) {
             // Walk back while byte at `limit` is a UTF-8 continuation
             // byte (top bits 10xxxxxx) so we never slice mid-codepoint
             // — ImGui chokes on invalid UTF-8 and shows tofu/glitches.
-            var limit: usize = 60;
+            var limit: usize = hint_cap_bytes;
             while (limit > 0 and (line[limit] & 0xC0) == 0x80) : (limit -= 1) {}
             return line[0..limit];
         }

--- a/src/modules/prefab.zig
+++ b/src/modules/prefab.zig
@@ -33,6 +33,10 @@ pub const PrefabState = struct {
     /// Index into `loaded.children`; null means "the prefab itself
     /// is selected" (inspector shows the prefab's own components).
     selected_child_idx: ?usize = null,
+    /// Mirror of `selected_child_idx` consumed by the Hierarchy
+    /// panel (#144) to detect externally-driven selection changes.
+    /// Same shape as `SceneState.hierarchy_last_seen`.
+    hierarchy_last_seen: ?usize = null,
     is_dirty: bool = false,
     drag_armed: bool = false,
     /// Entity's world-space position at the moment a drag was armed.

--- a/src/modules/scene.zig
+++ b/src/modules/scene.zig
@@ -115,6 +115,12 @@ pub const SceneState = struct {
     /// drag-release so the chosen width persists across editor
     /// restarts (#140).
     inspector_width: f32 = @import("../prefs.zig").default_inspector_width,
+    /// Mirror of `selected_index` consumed by the Hierarchy panel
+    /// (#144) to detect externally-driven selection changes. When
+    /// the live value differs from this mirror, the panel scrolls
+    /// the matching row into view; in-panel clicks update the
+    /// mirror in lockstep so they don't trigger the scroll branch.
+    hierarchy_last_seen: ?usize = null,
 
     /// Load a scene from disk and wrap it in a fresh SceneState. The
     /// returned state owns an arena holding the path + display name,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1623,6 +1623,18 @@ pub const HierarchyTests = struct {
         const long = "//" ++ ("a" ** 70);
         try expect.equal(hierarchy.firstCommentLine(long).len, 60);
     }
+
+    test "firstCommentLine truncates UTF-8 cleanly at codepoint boundary" {
+        // A 3-byte codepoint (`€` = 0xE2 0x82 0xAC) crossing byte 60
+        // would otherwise leave invalid UTF-8. Layout: 58 'a's + '€'
+        // (3 bytes) → 61 bytes total. Byte 60 is the middle continuation
+        // byte of `€`, so the walk-back must drop the whole codepoint.
+        const text = "//" ++ ("a" ** 58) ++ "€" ++ "tail";
+        const got = hierarchy.firstCommentLine(text);
+        try expect.equal(got.len, 58);
+        // Last byte must not be a UTF-8 continuation byte (top bits 10xx).
+        try expect.toBeTrue((got[got.len - 1] & 0xC0) != 0x80);
+    }
 };
 
 pub const AtlasJsonTests = struct {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -17,6 +17,7 @@ const flow_doc = @import("modules/flow_doc.zig");
 const flow_cycle = @import("flow_cycle.zig");
 const event_catalog = @import("flow_event_catalog.zig");
 const node_catalog = @import("flow_node_catalog.zig");
+const hierarchy = @import("modules/hierarchy.zig");
 
 // Reference the node catalog at file scope so its module-level
 // `test "…"` blocks become reachable from the test root and are
@@ -1580,6 +1581,47 @@ pub const SceneIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"root\":") == null);
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"include\":") != null);
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"meta\":") != null);
+    }
+};
+
+pub const HierarchyTests = struct {
+    // Filter logic lives in `modules/hierarchy.zig` as pure helpers
+    // (no imgui draw context) so the search/label code is testable
+    // without standing up a GUI. The panel render itself stays
+    // unit-untested; gui-test covers it via TE.
+
+    test "matchesFilter case-insensitive substring" {
+        try expect.toBeTrue(hierarchy.matchesFilter("Canteen", "cant"));
+        try expect.toBeTrue(hierarchy.matchesFilter("CANTEEN", "een"));
+        try expect.toBeTrue(hierarchy.matchesFilter("workstation_drill", "DRIL"));
+    }
+
+    test "matchesFilter rejects non-matching needle" {
+        try expect.toBeFalse(hierarchy.matchesFilter("canteen", "fitness"));
+    }
+
+    test "matchesFilter empty needle matches everything" {
+        try expect.toBeTrue(hierarchy.matchesFilter("anything", ""));
+    }
+
+    test "matchesFilter rejects needle longer than haystack" {
+        try expect.toBeFalse(hierarchy.matchesFilter("ab", "abc"));
+    }
+
+    test "firstCommentLine strips marker and surrounding whitespace" {
+        try expect.toBeTrue(std.mem.eql(u8, hierarchy.firstCommentLine("// first\n// second"), "first"));
+        try expect.toBeTrue(std.mem.eql(u8, hierarchy.firstCommentLine("//   note  \n"), "note"));
+    }
+
+    test "firstCommentLine returns empty for whitespace-only or empty input" {
+        try expect.toBeTrue(hierarchy.firstCommentLine("\n\n").len == 0);
+        try expect.toBeTrue(hierarchy.firstCommentLine("").len == 0);
+    }
+
+    test "firstCommentLine caps the returned slice at 60 bytes" {
+        // 70-char line should be truncated to 60.
+        const long = "//" ++ ("a" ** 70);
+        try expect.equal(hierarchy.firstCommentLine(long).len, 60);
     }
 };
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1618,10 +1618,11 @@ pub const HierarchyTests = struct {
         try expect.toBeTrue(hierarchy.firstCommentLine("").len == 0);
     }
 
-    test "firstCommentLine caps the returned slice at 60 bytes" {
-        // 70-char line should be truncated to 60.
-        const long = "//" ++ ("a" ** 70);
-        try expect.equal(hierarchy.firstCommentLine(long).len, 60);
+    test "firstCommentLine caps the returned slice at hint_cap_bytes" {
+        // A line `hint_cap_bytes + 10` long should be truncated to
+        // exactly the cap.
+        const long = "//" ++ ("a" ** (hierarchy.hint_cap_bytes + 10));
+        try expect.equal(hierarchy.firstCommentLine(long).len, hierarchy.hint_cap_bytes);
     }
 
     test "firstCommentLine truncates UTF-8 cleanly at codepoint boundary" {
@@ -1634,6 +1635,43 @@ pub const HierarchyTests = struct {
         try expect.equal(got.len, 58);
         // Last byte must not be a UTF-8 continuation byte (top bits 10xx).
         try expect.toBeTrue((got[got.len - 1] & 0xC0) != 0x80);
+    }
+
+    test "entityMatchesFilter matches prefab name" {
+        var e: scene_io.Entity = .{ .prefab = "rabbit" };
+        try expect.toBeTrue(hierarchy.entityMatchesFilter(&e, "rab"));
+        try expect.toBeTrue(hierarchy.entityMatchesFilter(&e, "BIT"));
+        try expect.toBeFalse(hierarchy.entityMatchesFilter(&e, "wolf"));
+    }
+
+    test "entityMatchesFilter empty filter matches everything" {
+        const e: scene_io.Entity = .{ .prefab = "any" };
+        try expect.toBeTrue(hierarchy.entityMatchesFilter(&e, ""));
+    }
+
+    test "entityMatchesFilter does NOT search the index prefix" {
+        // The row's display label is `#N <name>`, but typing `5` must
+        // not narrow to every #5/#15/#25 row — only rows whose actual
+        // name or comment hint contains `5`. The predicate operates
+        // on the entity, not the rendered label, so the index can't
+        // bleed in.
+        const e: scene_io.Entity = .{ .prefab = "rabbit" };
+        try expect.toBeFalse(hierarchy.entityMatchesFilter(&e, "5"));
+        try expect.toBeFalse(hierarchy.entityMatchesFilter(&e, "#"));
+    }
+
+    test "entityMatchesFilter matches the comment hint" {
+        var e: scene_io.Entity = .{ .prefab = "wall" };
+        const note = "// Building exterior";
+        @memcpy(e.comment[0..note.len], note);
+        try expect.toBeTrue(hierarchy.entityMatchesFilter(&e, "exterior"));
+        try expect.toBeTrue(hierarchy.entityMatchesFilter(&e, "BUILDING"));
+    }
+
+    test "entityMatchesFilter falls back to `(inline)` when prefab is null" {
+        const e: scene_io.Entity = .{};
+        try expect.toBeTrue(hierarchy.entityMatchesFilter(&e, "inline"));
+        try expect.toBeTrue(hierarchy.entityMatchesFilter(&e, "INLINE"));
     }
 };
 


### PR DESCRIPTION
## Summary

Closes [#144](https://github.com/labelle-toolkit/labelle-gui/issues/144). New togglable Module that lists every entity in the active scene or prefab editor with click-to-select. Solves selection failures on the canvas when entities overlap, sit off-viewport, or carry no visible footprint — the original use case is a 50+ entity scene where finding "that one rabbit" by sight is hopeless.

Selection state is **mirrored, not stored**: clicking a row writes through to the active tab's existing `selected_index` / `selected_child_idx` field, so the canvas and the panel share one source of truth. The inspector reads from the same field, which gives the bidirectional sync for free.

Rebased onto current `main` — the previously-required cherry-pick of #175 dropped out cleanly now that both #175 (RFC #560) and #181 (RFC #596) are merged. The panel exercises against bundle-shape scenes/prefabs (the format `flying-platform-labelle` actually uses) without further patching.

## Changes

- **`src/modules/hierarchy.zig`** (new) — registered through the Module registry. Renders one row per entity in the active scene's `entities` (or prefab's body + children) with a sticky case-insensitive substring filter at the top.
  - Per-row label: `#N <prefab_name>` for prefab refs, `#N (inline)` for entities without a prefab. When the entity carries a leading comment, the first comment line rides along after a `-` separator so authored notes (`Background`, `Rooms`, `Second floor`, etc.) stay discoverable.
  - When the active tab isn't a scene/prefab editor, the panel renders a placeholder rather than disabling itself.
- **Auto-scroll on external selection** — clicking an entity on the canvas scrolls the matching Hierarchy row into view. Each tab carries a `hierarchy_last_seen` mirror of its selection field; when the live value diverges from the mirror and the panel renders, the matched row calls `setScrollHereY`. In-panel clicks update the mirror in lockstep so they don't churn the scroll on every user-driven row click.
- **`src/app.zig`** — `show_hierarchy` toggle, `hierarchy_filter` buffer (sticky across panel close/reopen, same pattern as `prefab_picker_filter`), grew `App.modules` to 10 slots with the new module assigned last.
- **`src/modules/scene.zig` / `src/modules/prefab.zig`** — added the `hierarchy_last_seen: ?usize` field to each state struct.
- **Tests (`HierarchyTests`)** — covers the two pure helpers `matchesFilter` (case-insensitive substring, empty-needle / oversize-needle edges) and `firstCommentLine` (marker strip, whitespace trim, 60-byte cap, UTF-8 codepoint-boundary truncation). 7 new tests.

## Acceptance criteria (from #144)

- [x] New `hierarchy` module, registered in App, togglable from View menu.
- [x] Scene tab → lists `entities`. Prefab tab → lists `children` plus a "prefab body" row.
- [x] Click row → editor `selected_idx` updates; inspector switches.
- [x] Search filter narrows the list live.
- [x] Canvas-click and hierarchy-click both flow through the same `selected_idx` so highlight tracks.
- [x] Canvas-click auto-scrolls the matching hierarchy row into view; in-panel clicks do not trigger the auto-scroll branch.

## Test plan

- [x] `zig build` clean
- [x] `zig build test` — 395/395 (7 new in `HierarchyTests`; the baseline grew with #175 + #181 merging)
- [x] `zig build gui-test` — 25/25
- [x] Visual against `flying-platform-labelle/scenes/main.jsonc`:
  - View → Hierarchy opens the panel; lists all entities of `main.jsonc`.
  - Clicking a row updates the Inspector + highlights the entity on the canvas.
  - Clicking an entity on the canvas scrolls the Hierarchy to its row and highlights it.
  - Typing `canteen` in the filter narrows the list to canteen entries and the comments mentioning canteen.
  - Opening a prefab tab swaps the list to `(prefab body)` + children rows.

## Out of scope (per the updated #144 body)

- **Multi-selection** (shift/ctrl-click). Single-entity inspector model; punt until a batch op motivates it.
- **Virtualisation / row windowing.** Render loop is allocation-free per row; fine up to ~1000 entities, separate ticket beyond that.
- **Drag-reorder, right-click menu, tree-style expansion, drag-out reparenting.** Each rejected with a reason in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)