### PR TITLE
refactor(preview): cleanup #138 deferred + close #136

### DIFF
--- a/src/app.zig
+++ b/src/app.zig
@@ -14,6 +14,7 @@ const project = @import("project.zig");
 const tree_view = @import("tree_view.zig");
 const compiler = @import("compiler.zig");
 const preview = @import("preview.zig");
+const buf = @import("buf.zig");
 const config = @import("config.zig");
 const module = @import("module.zig");
 const compiler_output = @import("modules/compiler_output.zig");
@@ -1065,37 +1066,16 @@ pub const App = struct {
     }
 
     /// Append `bytes` to the Compiler Output panel's live preview
-    /// tail buffer (#127). Bounded by `preview_tail_cap` — when the
-    /// buffer would exceed the cap, the oldest bytes are dropped from
-    /// the front so the *recent* tail (where the build error or panic
-    /// trace lives) is what the user sees. Called from the panel's
-    /// per-frame `consumeStderr` drain; safe to call with an empty
-    /// slice.
+    /// tail buffer (#127). Bounded by `preview.stderr_cap` (16 KiB,
+    /// shared with the producer-side stderr buffer) — when the
+    /// buffer would exceed the cap, the oldest bytes are dropped
+    /// from the front so the *recent* tail (where the build error
+    /// or panic trace lives) is what the user sees. Called from the
+    /// panel's per-frame `consumeStderr` drain; safe to call with
+    /// an empty slice. Cursor is null because the panel doesn't
+    /// carry a separate read offset.
     pub fn appendPreviewTail(self: *Self, bytes: []const u8) void {
-        if (bytes.len == 0) return;
-        // Cap matches `preview.stderr_buf`'s cap (16 KiB) so the panel
-        // never holds more than two windows' worth of stderr in flight.
-        const preview_tail_cap: usize = 16 * 1024;
-        if (bytes.len >= preview_tail_cap) {
-            // Single record already exceeds the cap — keep only the
-            // tail end.
-            self.preview_tail.clearRetainingCapacity();
-            const start = bytes.len - preview_tail_cap;
-            self.preview_tail.appendSlice(self.allocator, bytes[start..]) catch return;
-            return;
-        }
-        // Drop from the front if appending `bytes` would overflow.
-        if (self.preview_tail.items.len + bytes.len > preview_tail_cap) {
-            const need_to_drop = self.preview_tail.items.len + bytes.len - preview_tail_cap;
-            const remaining = self.preview_tail.items.len - need_to_drop;
-            std.mem.copyForwards(
-                u8,
-                self.preview_tail.items[0..remaining],
-                self.preview_tail.items[need_to_drop..],
-            );
-            self.preview_tail.shrinkRetainingCapacity(remaining);
-        }
-        self.preview_tail.appendSlice(self.allocator, bytes) catch return;
+        buf.appendCapped(&self.preview_tail, self.allocator, bytes, preview.stderr_cap, null);
     }
 
     pub fn stopPreview(self: *Self) void {

--- a/src/buf.zig
+++ b/src/buf.zig
@@ -13,3 +13,112 @@ pub fn writeZeroed(dst: []u8, src: []const u8) void {
     const n = @min(dst.len, src.len);
     @memcpy(dst[0..n], src[0..n]);
 }
+
+/// Append `chunk` to a rolling tail buffer, dropping from the front
+/// when the result would exceed `cap`. Optional `cursor` is a
+/// consumer-side read offset that gets shifted by the same amount
+/// the front drops, so a paired (producer-here, consumer-elsewhere)
+/// can keep emitting new bytes after a rotation instead of
+/// re-emitting the survivors.
+///
+/// Behaviour summary:
+///   - `chunk.len == 0`: no-op.
+///   - `chunk.len >= cap`: clear `buf` and keep the tail of `chunk`
+///     (the latest `cap` bytes). `cursor.*` resets to 0.
+///   - `buf.len + chunk.len > cap`: drop just enough bytes from the
+///     front to fit, copy the survivors forward in place, shift
+///     `cursor.*` by the drop count (clamped to 0).
+///   - Append `chunk` to whatever's left.
+///
+/// Allocation failures are silently dropped — same trade-off the
+/// pre-refactor inline copies made (see #139 nit 4). Caller is
+/// expected to have its own bounded retry path if it cares.
+pub fn appendCapped(
+    list: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    chunk: []const u8,
+    cap: usize,
+    cursor: ?*usize,
+) void {
+    if (chunk.len == 0) return;
+    if (chunk.len >= cap) {
+        list.clearRetainingCapacity();
+        const tail_off = chunk.len - cap;
+        list.appendSlice(allocator, chunk[tail_off..]) catch return;
+        if (cursor) |c| c.* = 0;
+        return;
+    }
+    if (list.items.len + chunk.len > cap) {
+        const overflow = list.items.len + chunk.len - cap;
+        const drop = @min(overflow, list.items.len);
+        const remaining = list.items.len - drop;
+        std.mem.copyForwards(u8, list.items[0..remaining], list.items[drop..]);
+        list.shrinkRetainingCapacity(remaining);
+        if (cursor) |c| {
+            c.* = if (c.* > drop) c.* - drop else 0;
+        }
+    }
+    list.appendSlice(allocator, chunk) catch return;
+}
+
+const testing = std.testing;
+
+test "appendCapped no-op on empty chunk" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(testing.allocator);
+    try list.appendSlice(testing.allocator, "abc");
+    appendCapped(&list, testing.allocator, "", 100, null);
+    try testing.expectEqualStrings("abc", list.items);
+}
+
+test "appendCapped fits within cap" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(testing.allocator);
+    appendCapped(&list, testing.allocator, "hello", 100, null);
+    try testing.expectEqualStrings("hello", list.items);
+}
+
+test "appendCapped drops front when overflow" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(testing.allocator);
+    try list.appendSlice(testing.allocator, "abcdefgh");
+    appendCapped(&list, testing.allocator, "XYZ", 10, null); // 8+3 > 10 → drop 1
+    try testing.expectEqualStrings("bcdefghXYZ", list.items);
+}
+
+test "appendCapped giant chunk keeps only the tail" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(testing.allocator);
+    try list.appendSlice(testing.allocator, "old");
+    appendCapped(&list, testing.allocator, "0123456789ABCDEF", 4, null);
+    try testing.expectEqualStrings("CDEF", list.items);
+}
+
+test "appendCapped shifts cursor by drop amount" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(testing.allocator);
+    try list.appendSlice(testing.allocator, "abcdefgh"); // len=8
+    var cursor: usize = 5;
+    appendCapped(&list, testing.allocator, "XYZ", 10, &cursor); // drop 1
+    try testing.expectEqual(@as(usize, 4), cursor);
+}
+
+test "appendCapped resets cursor to 0 on giant chunk" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(testing.allocator);
+    var cursor: usize = 3;
+    appendCapped(&list, testing.allocator, "0123456789", 4, &cursor);
+    try testing.expectEqual(@as(usize, 0), cursor);
+}
+
+test "appendCapped clamps cursor to 0 when drop exceeds cursor" {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(testing.allocator);
+    try list.appendSlice(testing.allocator, "abcdefgh");
+    var cursor: usize = 2;
+    appendCapped(&list, testing.allocator, "XYZ", 10, &cursor); // drop=1, cursor=2 → 1
+    try testing.expectEqual(@as(usize, 1), cursor);
+    // And a bigger drop that exceeds the cursor:
+    appendCapped(&list, testing.allocator, "PPP", 10, &cursor); // drop=3, cursor=1 → 0
+    try testing.expectEqual(@as(usize, 0), cursor);
+}

--- a/src/preview.zig
+++ b/src/preview.zig
@@ -38,6 +38,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const project = @import("project.zig");
 const io_global = @import("io_global.zig");
+const buf_mod = @import("buf.zig");
 
 extern "c" fn close(fd: c_int) c_int;
 extern "c" fn read(fd: c_int, buf: [*]u8, len: usize) isize;
@@ -121,6 +122,14 @@ pub const Bye = struct {
 /// alive, no connection yet) from "really crashed" (child exited)
 /// — see #134-follow-up. For now, generous flat budget.
 pub const connecting_timeout_ms: i64 = 60_000;
+
+/// Cap on the stderr ring-buffer kept inside `PreviewSession` and
+/// mirrored by `App.preview_tail` in the Compiler Output panel. Two
+/// callers (producer-side in `appendStderrChunk`, consumer-side in
+/// `appendPreviewTail`) — sharing the constant guarantees the two
+/// caps can't drift; a smaller consumer cap would silently lose
+/// bytes the producer already streamed (#139 cleanup).
+pub const stderr_cap: usize = 16 * 1024;
 
 /// Heartbeat watchdog window for the `.running` state (#79).
 ///
@@ -1169,21 +1178,40 @@ pub const PreviewSession = struct {
         const pid = child.id orelse return; // already waited/killed
         var status: c_int = 0;
         const rc = waitpid(@intCast(pid), &status, WNOHANG);
-        if (rc <= 0) return; // 0 = still running; -1 = error (race with kill); leave for the next tick
-        // Decode wait(2) status — same shape as `<sys/wait.h>` macros
-        // (`WIFEXITED` / `WEXITSTATUS` / `WIFSIGNALED` / `WTERMSIG`).
-        // The high byte is the exit code on a normal exit; the low 7
-        // bits are the terminating signal otherwise. Keep the reason
-        // string short — the panel surfaces it inline.
+        if (rc == 0) return; // still running
+        if (rc < 0) {
+            // waitpid error. EINTR = signal during syscall, retry next
+            // tick. Everything else (notably ECHILD when something
+            // else reaped the child) is permanent — sitting here would
+            // wait the full `connecting_timeout_ms` backstop, which on
+            // the 60s pin is a baffling user experience for what's
+            // already a crashed session (#136 / #139 nit 3).
+            if (std.posix.errno(rc) == .INTR) return;
+            std.log.warn("preview: waitpid failed errno={s}; marking crashed", .{@tagName(std.posix.errno(rc))});
+            self.drainChildStderr();
+            self.markCrashed("labelle reaper failed");
+            return;
+        }
+        // rc > 0 — decode wait(2) status with the idiomatic posix
+        // helpers (#139 nit 2). The previous inline bit-ops worked,
+        // but now read like the stdlib does.
         var reason_buf: [64]u8 = undefined;
-        const exited_normally = (status & 0x7F) == 0;
-        const exit_code: c_int = (status >> 8) & 0xFF;
+        const status_u32: u32 = @bitCast(status);
+        const exited_normally = std.posix.W.IFEXITED(status_u32);
+        const exit_code: u8 = std.posix.W.EXITSTATUS(status_u32);
         const reason: []const u8 = blk: {
             if (exited_normally) {
                 break :blk std.fmt.bufPrint(&reason_buf, "labelle exited (code {d})", .{exit_code}) catch "labelle exited";
+            } else if (std.posix.W.IFSIGNALED(status_u32)) {
+                const sig = std.posix.W.TERMSIG(status_u32);
+                break :blk std.fmt.bufPrint(&reason_buf, "labelle killed by signal {d}", .{@intFromEnum(sig)}) catch "labelle killed";
             } else {
-                const sig = status & 0x7F;
-                break :blk std.fmt.bufPrint(&reason_buf, "labelle killed by signal {d}", .{sig}) catch "labelle killed";
+                // Stopped/continued statuses don't fit the "child
+                // exited" exit-decoding contract. The kernel
+                // shouldn't surface those under WNOHANG without
+                // WUNTRACED/WCONTINUED, so this branch is mostly a
+                // belt-and-suspenders log site.
+                break :blk "labelle status unclear";
             }
         };
         // A clean exit (code 0) from an already-`running` session is
@@ -1268,28 +1296,7 @@ pub const PreviewSession = struct {
     /// the dropped prefix). `pub` so the tests can drive it without
     /// a real subprocess.
     pub fn appendStderrChunk(self: *Self, chunk: []const u8) void {
-        const stderr_cap: usize = 16 * 1024;
-        if (chunk.len == 0) return;
-        if (chunk.len >= stderr_cap) {
-            self.stderr_buf.clearRetainingCapacity();
-            const tail_off = chunk.len - stderr_cap;
-            self.stderr_buf.appendSlice(self.allocator, chunk[tail_off..]) catch return;
-            self.stderr_cursor = 0;
-            return;
-        }
-        if (self.stderr_buf.items.len + chunk.len > stderr_cap) {
-            const overflow = self.stderr_buf.items.len + chunk.len - stderr_cap;
-            const drop = @min(overflow, self.stderr_buf.items.len);
-            const remaining = self.stderr_buf.items.len - drop;
-            std.mem.copyForwards(
-                u8,
-                self.stderr_buf.items[0..remaining],
-                self.stderr_buf.items[drop..],
-            );
-            self.stderr_buf.shrinkRetainingCapacity(remaining);
-            self.stderr_cursor = if (self.stderr_cursor > drop) self.stderr_cursor - drop else 0;
-        }
-        self.stderr_buf.appendSlice(self.allocator, chunk) catch return;
+        buf_mod.appendCapped(&self.stderr_buf, self.allocator, chunk, stderr_cap, &self.stderr_cursor);
     }
 
     fn markCrashed(self: *Self, reason: []const u8) void {


### PR DESCRIPTION
## Summary

Closes [#139](https://github.com/labelle-toolkit/labelle-gui/issues/139) and [#136](https://github.com/labelle-toolkit/labelle-gui/issues/136). All four nits deferred from #138's review land here; #139 nit 3 happens to be exactly the change #136 asks for, so one PR closes both.

Three files: \`src/buf.zig\` (helper + tests), \`src/preview.zig\`, \`src/app.zig\`.

## Changes

1. **Shared 16 KiB stderr cap.** Was \`preview_tail_cap\` in \`app.zig:appendPreviewTail\` + \`stderr_cap\` in \`preview.zig:appendStderrChunk\` — same value, two places. Promoted to \`pub const stderr_cap\` in \`preview.zig\`; the panel-side caller references it.
2. **Idiomatic wait(2) decode.** \`tryWaitChild\` uses \`std.posix.W.IFEXITED / EXITSTATUS / IFSIGNALED / TERMSIG\` instead of raw \`(status & 0x7F)\` / \`(status >> 8) & 0xFF\`. Same semantics, reads like the stdlib does.
3. **Don't backstop a permanently-failed reaper** (closes #136). The \`rc < 0\` branch of \`tryWaitChild\` used to early-return unconditionally, conflating a transient \`EINTR\` with permanent failures like \`ECHILD\` — and \`ECHILD\` parked the session against the 60s \`connecting_timeout_ms\` backstop for what was already a dead child. Now \`EINTR\` retries silently as before, but any other errno marks the session \`.crashed\` immediately with a \`\"labelle reaper failed\"\` reason. The 60s backstop stays as the absolute last resort (cold \`zig build\` can take that long), but a reaper-failure surface ticks within one frame instead of one minute.
4. **\`buf.appendCapped\` helper.** \`appendStderrChunk\` and \`appendPreviewTail\` were near-identical clear-or-drop-front / \`copyForwards\` / \`shrinkRetainingCapacity\` / \`appendSlice\` rotations. Factored into \`src/buf.zig\` with an optional cursor pointer (stderr side has one; panel mirror doesn't). Both call sites collapse to a one-liner.

## Test plan

- [x] \`zig build\` clean
- [x] \`zig build test\` — 374/374 (7 new in \`buf.zig\` for \`appendCapped\`: no-op, fits, overflow drop, giant tail-only, cursor shift, cursor reset, cursor clamp)
- [x] \`zig build gui-test\` — 25/25
- [ ] Reviewer: spot-check the \`rc < 0\` path on a real \`labelle run\` that fails during \`zig build\` — confirm the panel surfaces the crash within ~1 frame rather than waiting the full 60s. ECHILD specifically is hard to provoke synthetically; the \`reaper failed\` log message is the canary.

## Out of scope

- Streaming the subprocess's stderr to Compiler Output during \`.connecting\` (the \"Bonus\" item in #136's body). That's a UX surface change rather than a robustness fix; if it lands it should be its own PR with its own visual test plan.
- \`preview_tail_cap\` being a *different* size from \`stderr_cap\`. The new shared constant locks them together; if a future panel ever needs a bigger window it should take a separate const, not start the cap-drift cycle over.