### PR TITLE
feat(tree): drag-drop sprite names onto sprite_name input (#143 phase 8)

### DIFF
--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -47,6 +47,12 @@ pub const Atlas = struct {
     /// `resources[i].name` from `project.labelle`. Useful for
     /// diagnostics — "sprite X belongs to atlas Y".
     name: []const u8,
+    /// Absolute path to the JSON manifest this atlas was loaded from.
+    /// Empty when constructed via `loadFromPaths` (the Atlas Viewer
+    /// uses that entry point for atlases outside `resources`). The
+    /// tree-view uses this to match a file row to its sprite list
+    /// when expanding an atlas manifest inline (#143 phase 8).
+    json_path: []const u8 = "",
     texture_id: c_uint,
     width: u32,
     height: u32,
@@ -58,6 +64,7 @@ pub const Atlas = struct {
         while (it.next()) |entry| allocator.free(entry.key_ptr.*);
         self.frames.deinit(allocator);
         allocator.free(self.name);
+        if (self.json_path.len > 0) allocator.free(self.json_path);
         if (self.texture_id != 0) {
             gl.deleteTextures(1, &self.texture_id);
         }
@@ -136,6 +143,19 @@ pub const Index = struct {
         const a = self.atlases.items[ref.atlas];
         return .{ @floatFromInt(a.width), @floatFromInt(a.height) };
     }
+
+    /// Look up a loaded atlas by its absolute JSON path. Returns the
+    /// `Atlas` so the caller can iterate its `frames` (e.g. the
+    /// tree-view expanding a manifest file inline as a list of
+    /// draggable sprite names). `null` when no atlas's `json_path`
+    /// matches — either the file isn't a project resource or it
+    /// failed to load during `build`.
+    pub fn atlasByJsonPath(self: Index, json_path: []const u8) ?*const Atlas {
+        for (self.atlases.items) |*a| {
+            if (a.json_path.len > 0 and std.mem.eql(u8, a.json_path, json_path)) return a;
+        }
+        return null;
+    }
 };
 
 /// A subset of `project.ProjectConfig.resources` needed by the atlas
@@ -154,7 +174,14 @@ fn loadOne(allocator: std.mem.Allocator, project_dir: []const u8, r: Resource) !
     const tex_path = try std.fs.path.join(allocator, &.{ project_dir, r.texture });
     defer allocator.free(tex_path);
 
-    return loadFromPaths(allocator, r.name, json_path, tex_path);
+    var atlas = try loadFromPaths(allocator, r.name, json_path, tex_path);
+    errdefer atlas.deinit(allocator);
+    // Project-loaded atlases get their absolute manifest path stamped
+    // so the tree-view can match a file row to its sprite list. The
+    // viewer-only entry point (`loadFromPaths` directly) skips this
+    // because that atlas isn't part of the project's resources block.
+    atlas.json_path = try allocator.dupe(u8, json_path);
+    return atlas;
 }
 
 /// Load a single atlas from explicit JSON + PNG paths (not project-

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -58,11 +58,18 @@ pub const Atlas = struct {
     height: u32,
     /// `name → Frame` for every entry in this atlas's JSON.
     frames: std.StringHashMapUnmanaged(Frame) = .empty,
+    /// Pre-sorted view of `frames`'s keys (alpha-asc). Built once at
+    /// load time so the tree-view's atlas-expansion render path
+    /// (#143 phase 8) doesn't re-collect + re-sort the hashmap every
+    /// frame. The slices reference the same strings owned by
+    /// `frames` — no extra dupes.
+    sorted_frame_keys: []const []const u8 = &.{},
 
     pub fn deinit(self: *Atlas, allocator: std.mem.Allocator) void {
         var it = self.frames.iterator();
         while (it.next()) |entry| allocator.free(entry.key_ptr.*);
         self.frames.deinit(allocator);
+        if (self.sorted_frame_keys.len > 0) allocator.free(self.sorted_frame_keys);
         allocator.free(self.name);
         if (self.json_path.len > 0) allocator.free(self.json_path);
         if (self.texture_id != 0) {
@@ -302,6 +309,24 @@ pub fn parseFramesFromJsonText(allocator: std.mem.Allocator, raw: []const u8, at
         errdefer allocator.free(name_copy);
         try atlas.frames.put(allocator, name_copy, frame);
     }
+
+    // Materialise the alpha-sorted key view once at load. The
+    // tree-view's atlas-expansion render path iterates this slice
+    // every frame; rebuilding + sorting it on each frame instead
+    // would cost N allocs + an O(N log N) sort per open atlas at
+    // 60 fps (#143 phase 8 review feedback). Slices alias the
+    // frame-map's keys — no extra dupes, no double free.
+    var keys = try allocator.alloc([]const u8, atlas.frames.count());
+    errdefer allocator.free(keys);
+    var k_it = atlas.frames.iterator();
+    var k_i: usize = 0;
+    while (k_it.next()) |kv| : (k_i += 1) keys[k_i] = kv.key_ptr.*;
+    std.mem.sort([]const u8, keys, {}, struct {
+        fn lessThan(_: void, lhs: []const u8, rhs: []const u8) bool {
+            return std.mem.lessThan(u8, lhs, rhs);
+        }
+    }.lessThan);
+    atlas.sorted_frame_keys = keys;
 }
 
 fn jsonU32(v: ?std.json.Value) ?u32 {

--- a/src/modules/dnd.zig
+++ b/src/modules/dnd.zig
@@ -96,3 +96,41 @@ pub fn packPrefab(stem: []const u8) PrefabPayload {
 pub fn unpackPrefab(payload: *const PrefabPayload) []const u8 {
     return payload.name[0..payload.name_len];
 }
+
+/// Payload identifier for a sprite name dragged from an expanded
+/// atlas manifest in the project tree onto an entity's `sprite_name`
+/// inspector input (#143 phase 8). The sprite is identified by its
+/// atlas-frame key — the same string the engine looks up against the
+/// `name → Frame` map a TexturePacker manifest produces. Distinct
+/// from the other types so the inspector field accepts only sprite
+/// drops, never a prefab or component.
+pub const SPRITE_TYPE: [:0]const u8 = "labelle_sprite_name";
+
+/// Plain-data payload carried by a sprite drag. Same fixed-buffer
+/// shape as `ComponentPayload` / `PrefabPayload` so the receive side
+/// uses the same `@memcpy` pattern; the cap (`PAYLOAD_NAME_CAP`)
+/// matches the `Sprite.sprite_name` buffer's writable region.
+pub const SpritePayload = extern struct {
+    /// Valid prefix length of `name`. Always ≤ PAYLOAD_NAME_CAP.
+    name_len: u8,
+    /// Zero-padded sprite key bytes (e.g. "player_idle_0").
+    name: [PAYLOAD_NAME_CAP]u8,
+};
+
+/// Build a sprite payload from a caller-supplied frame name.
+/// Truncates if the name exceeds `PAYLOAD_NAME_CAP` (a TexturePacker
+/// manifest key longer than 128 bytes is effectively impossible).
+pub fn packSprite(name: []const u8) SpritePayload {
+    var p: SpritePayload = .{ .name_len = 0, .name = [_]u8{0} ** PAYLOAD_NAME_CAP };
+    const n = @min(name.len, PAYLOAD_NAME_CAP);
+    @memcpy(p.name[0..n], name[0..n]);
+    p.name_len = @intCast(n);
+    return p;
+}
+
+/// Read the sprite name back out of a received payload. Returns a
+/// slice into the payload buffer — caller must dupe (or memcpy into
+/// the inspector's edit buffer) before the next imgui frame.
+pub fn unpackSprite(payload: *const SpritePayload) []const u8 {
+    return payload.name[0..payload.name_len];
+}

--- a/src/modules/inspector/sprite.zig
+++ b/src/modules/inspector/sprite.zig
@@ -9,6 +9,7 @@ const zgui = @import("zgui");
 
 const scene_io = @import("../../scene_io.zig");
 const atlas = @import("../../atlas.zig");
+const dnd = @import("../dnd.zig");
 const InspectorSection = @import("section.zig").InspectorSection;
 
 /// Canonical Sprite.pivot values, matching the engine's pivot enum
@@ -71,6 +72,22 @@ fn render(
     // doesn't kiss the border.
     zgui.setNextItemWidth(@max(60, zgui.getContentRegionAvail()[0] - trailing - 4));
     if (zgui.inputText(sprite_name_label, .{ .buf = &sprite.sprite_name })) is_dirty.* = true;
+    // Drop target: accept a sprite name dragged from the project
+    // tree's expanded atlas manifest (#143 phase 8). The drop replaces
+    // the field contents rather than appending — same UX as picking
+    // from a combo. `acceptDragDropPayload` returns the payload bytes
+    // ImGui has already validated as `SPRITE_TYPE`-tagged.
+    if (zgui.beginDragDropTarget()) {
+        defer zgui.endDragDropTarget();
+        if (zgui.acceptDragDropPayload(dnd.SPRITE_TYPE, .{})) |payload| {
+            const data: *const dnd.SpritePayload = @ptrCast(@alignCast(payload.data));
+            const name = dnd.unpackSprite(data);
+            @memset(&sprite.sprite_name, 0);
+            const n = @min(name.len, sprite.sprite_name.len);
+            @memcpy(sprite.sprite_name[0..n], name[0..n]);
+            is_dirty.* = true;
+        }
+    }
     if (is_missing) {
         zgui.sameLine(.{});
         zgui.textColored(.{ 1.0, 0.5, 0.4, 1.0 }, "(missing)", .{});

--- a/src/modules/project_tree.zig
+++ b/src/modules/project_tree.zig
@@ -11,6 +11,7 @@ const App = @import("../app.zig").App;
 const module = @import("../module.zig");
 const config = @import("../config.zig");
 const project = @import("../project.zig");
+const atlas = @import("../atlas.zig");
 const flow_io = @import("../flow_io.zig");
 
 pub fn makeModule(app: *App) module.Module {
@@ -126,7 +127,8 @@ fn render(app: *App) void {
             // the gizmo editor. The three are mutually exclusive
             // (different folders and/or extensions) so a single
             // click never opens more than one.
-            if (app.tree_view.render(proj.getProjectDir())) {
+            const atlas_idx_opt: ?*const atlas.Index = if (app.atlas_index) |*idx| idx else null;
+            if (app.tree_view.render(proj.getProjectDir(), atlas_idx_opt)) {
                 if (app.tree_view.getSelectedPath()) |path| {
                     const proj_dir = proj.getProjectDir();
                     if (isScenePath(proj_dir, path)) {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4755,6 +4755,42 @@ pub const PrefabDndTests = struct {
     }
 };
 
+pub const SpriteDndTests = struct {
+    // Mirrors `ComponentDndTests` / `PrefabDndTests`. pack/unpack are
+    // the contract between the project tree's expanded-atlas drag
+    // source and the inspector's `sprite_name` drop target (#143
+    // phase 8). Pure data helpers — no ImGui context needed.
+
+    test "packSprite round-trips a short name" {
+        const name = "coin";
+        const p = dnd.packSprite(name);
+        try expect.equal(@as(usize, p.name_len), name.len);
+        try expect.equal(std.mem.eql(u8, dnd.unpackSprite(&p), name), true);
+    }
+
+    test "packSprite round-trips an atlas-frame key with underscores and digits" {
+        // TexturePacker keys frequently include suffixes like
+        // `_idle_0`. The pack path must preserve them byte-for-byte.
+        const name = "player_idle_0";
+        const p = dnd.packSprite(name);
+        try expect.equal(@as(usize, p.name_len), name.len);
+        try expect.equal(std.mem.eql(u8, dnd.unpackSprite(&p), name), true);
+    }
+
+    test "packSprite truncates a name longer than PAYLOAD_NAME_CAP" {
+        var oversize: [dnd.PAYLOAD_NAME_CAP + 1]u8 = undefined;
+        @memset(&oversize, 'x');
+        const p = dnd.packSprite(&oversize);
+        try expect.equal(@as(usize, p.name_len), dnd.PAYLOAD_NAME_CAP);
+    }
+
+    test "packSprite zero-pads the unused tail" {
+        const p = dnd.packSprite("coin");
+        try expect.equal(p.name[4], @as(u8, 0));
+        try expect.equal(p.name[p.name.len - 1], @as(u8, 0));
+    }
+};
+
 pub const TreeViewClassifierTests = struct {
     // `isComponentFile` / `isPrefabFile` decide which file leaves
     // become drag sources. They're `pub fn` to be reachable from

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -439,21 +439,13 @@ pub const TreeView = struct {
 
         const line_top_y = zgui.getCursorScreenPos()[1];
 
-        // Collect sprite names and sort so render order is stable
-        // across frames — `Atlas.frames` is a HashMap, so its iterator
-        // order can shift after rehash. The user expects an alpha-
-        // ordered list, same as the file tree.
-        var names: std.ArrayListUnmanaged([]const u8) = .empty;
-        defer names.deinit(self.allocator);
-        var it = a.frames.iterator();
-        while (it.next()) |kv| names.append(self.allocator, kv.key_ptr.*) catch break;
-        std.mem.sort([]const u8, names.items, {}, struct {
-            fn lessThan(_: void, lhs: []const u8, rhs: []const u8) bool {
-                return std.mem.lessThan(u8, lhs, rhs);
-            }
-        }.lessThan);
-
-        for (names.items) |sprite_name| {
+        // Iterate the pre-sorted view built once at load time
+        // (`Atlas.sorted_frame_keys`). Doing the alloc + sort per
+        // frame here would have cost N allocs + O(N log N) per open
+        // atlas at 60 fps (#143 phase 8 review feedback). The HashMap
+        // is immutable post-load so the sorted view never goes
+        // stale.
+        for (a.sorted_frame_keys) |sprite_name| {
             var row_buf: [512:0]u8 = undefined;
             const row_label = std.fmt.bufPrintZ(
                 &row_buf,
@@ -473,10 +465,11 @@ pub const TreeView = struct {
                     std.mem.asBytes(&payload),
                     .once,
                 );
-                // ◆ glyph distinguishes sprite drags from component
-                // (⚙) and prefab (⌖) drags mid-flight so the user can
-                // see what kind of payload they grabbed.
-                zgui.text("◆ {s}", .{sprite_name});
+                // Use the same file glyph the row carries — it's part
+                // of the merged FontAwesome atlas (see icons.zig) so
+                // we don't depend on the fallback font covering a
+                // BMP symbol like U+25C6.
+                zgui.text("{s} {s}", .{ FolderIcons.file, sprite_name });
             }
         }
 

--- a/src/tree_view.zig
+++ b/src/tree_view.zig
@@ -3,6 +3,7 @@ const zgui = @import("zgui");
 const project = @import("project.zig");
 const icons = @import("icons.zig");
 const io_global = @import("io_global.zig");
+const atlas = @import("atlas.zig");
 const dnd = @import("modules/dnd.zig");
 
 /// Icons for each folder type (FontAwesome icons)
@@ -119,8 +120,15 @@ pub const TreeView = struct {
     }
 
     /// Render the tree view widget
-    /// Returns true if a file was selected
-    pub fn render(self: *Self, project_path: ?[]const u8) bool {
+    /// Returns true if a file was selected.
+    ///
+    /// `atlas_index` is optional: when non-null, any `.json` file
+    /// whose absolute path matches a loaded atlas's manifest becomes
+    /// expandable inline (caret + per-sprite drag-source rows) instead
+    /// of a plain leaf. Pass `null` while no project is open or the
+    /// atlas index hasn't built yet — the tree falls back to the
+    /// non-expanding leaf behaviour.
+    pub fn render(self: *Self, project_path: ?[]const u8, atlas_index: ?*const atlas.Index) bool {
         var file_selected = false;
 
         if (project_path == null) {
@@ -186,7 +194,7 @@ pub const TreeView = struct {
             var folder_path_buf: [path_buf_size:0]u8 = undefined;
             const folder_path = std.fmt.bufPrintZ(&folder_path_buf, "{s}/{s}", .{ base_path, folder_name }) catch continue;
 
-            if (self.renderDirectoryRow(folder_path, folder_name, managed_paths, components_prefix, prefabs_prefix)) {
+            if (self.renderDirectoryRow(folder_path, folder_name, managed_paths, components_prefix, prefabs_prefix, atlas_index)) {
                 file_selected = true;
             }
         }
@@ -207,6 +215,7 @@ pub const TreeView = struct {
         managed_paths: []const []const u8,
         components_prefix: []const u8,
         prefabs_prefix: []const u8,
+        atlas_index: ?*const atlas.Index,
     ) bool {
         var file_selected = false;
         const is_open_state = self.isOpen(folder_path);
@@ -236,7 +245,7 @@ pub const TreeView = struct {
             defer zgui.unindent(.{});
 
             const line_top_y = zgui.getCursorScreenPos()[1];
-            if (self.renderFolder(folder_path, managed_paths, components_prefix, prefabs_prefix)) {
+            if (self.renderFolder(folder_path, managed_paths, components_prefix, prefabs_prefix, atlas_index)) {
                 file_selected = true;
             }
             const line_bottom_y = zgui.getCursorScreenPos()[1];
@@ -270,7 +279,7 @@ pub const TreeView = struct {
     /// files. Subdirectories whose absolute path matches a
     /// `managed_paths` entry are suppressed because they're already
     /// rendered at top level (e.g. `scripts/flows`).
-    fn renderFolder(self: *Self, folder_path: []const u8, managed_paths: []const []const u8, components_prefix: []const u8, prefabs_prefix: []const u8) bool {
+    fn renderFolder(self: *Self, folder_path: []const u8, managed_paths: []const []const u8, components_prefix: []const u8, prefabs_prefix: []const u8, atlas_index: ?*const atlas.Index) bool {
         var file_selected = false;
 
         const files = self.getFilesForFolder(folder_path) catch {
@@ -305,9 +314,15 @@ pub const TreeView = struct {
             }
 
             if (file_entry.is_directory) {
-                if (self.renderDirectoryRow(full_path, file_entry.name, managed_paths, components_prefix, prefabs_prefix)) {
+                if (self.renderDirectoryRow(full_path, file_entry.name, managed_paths, components_prefix, prefabs_prefix, atlas_index)) {
                     file_selected = true;
                 }
+            } else if (atlasMatch(atlas_index, full_path)) |loaded| {
+                // Atlas manifest: expand inline as a list of draggable
+                // sprite-key rows instead of treating as a leaf. The
+                // user can still drop directly onto the `sprite_name`
+                // inspector field (#143 phase 8).
+                self.renderAtlasRow(full_path, file_entry.name, loaded);
             } else {
                 var label_buf: [512:0]u8 = undefined;
                 // No leading space — files have no caret column, so their
@@ -385,6 +400,99 @@ pub const TreeView = struct {
         }
 
         return file_selected;
+    }
+
+    /// Render one atlas-manifest file row: a caret + file glyph, and on
+    /// expansion the sorted list of sprite keys, each a drag source
+    /// emitting `SPRITE_TYPE`. Mirrors `renderDirectoryRow`'s caret /
+    /// open-state / vertical guide-line treatment so atlas expansion
+    /// reads the same as folder expansion to the user.
+    fn renderAtlasRow(
+        self: *Self,
+        full_path: [:0]const u8,
+        display_name: []const u8,
+        a: *const atlas.Atlas,
+    ) void {
+        const is_open_state = self.isOpen(full_path);
+        const caret = if (is_open_state) icons.FA_CARET_DOWN else icons.FA_CARET_RIGHT;
+
+        var label_buf: [512:0]u8 = undefined;
+        const label = std.fmt.bufPrintZ(
+            &label_buf,
+            "{s}{s} {s}",
+            .{ caret, FolderIcons.file, display_name },
+        ) catch return;
+
+        zgui.pushStrIdZ(full_path);
+        defer zgui.popId();
+
+        const parent_screen_x = zgui.getCursorScreenPos()[0];
+
+        if (zgui.selectable(label, .{})) {
+            self.toggleOpen(full_path);
+        }
+
+        if (!self.isOpen(full_path)) return;
+
+        zgui.indent(.{});
+        defer zgui.unindent(.{});
+
+        const line_top_y = zgui.getCursorScreenPos()[1];
+
+        // Collect sprite names and sort so render order is stable
+        // across frames — `Atlas.frames` is a HashMap, so its iterator
+        // order can shift after rehash. The user expects an alpha-
+        // ordered list, same as the file tree.
+        var names: std.ArrayListUnmanaged([]const u8) = .empty;
+        defer names.deinit(self.allocator);
+        var it = a.frames.iterator();
+        while (it.next()) |kv| names.append(self.allocator, kv.key_ptr.*) catch break;
+        std.mem.sort([]const u8, names.items, {}, struct {
+            fn lessThan(_: void, lhs: []const u8, rhs: []const u8) bool {
+                return std.mem.lessThan(u8, lhs, rhs);
+            }
+        }.lessThan);
+
+        for (names.items) |sprite_name| {
+            var row_buf: [512:0]u8 = undefined;
+            const row_label = std.fmt.bufPrintZ(
+                &row_buf,
+                "{s} {s}",
+                .{ FolderIcons.file, sprite_name },
+            ) catch continue;
+            // The sprite row is non-actionable on click (no associated
+            // file to open) — its sole purpose is being a drag source
+            // for the `sprite_name` inspector field. Return value is
+            // intentionally discarded.
+            _ = zgui.selectable(row_label, .{});
+            if (zgui.beginDragDropSource(.{})) {
+                defer zgui.endDragDropSource();
+                const payload = dnd.packSprite(sprite_name);
+                _ = zgui.setDragDropPayload(
+                    dnd.SPRITE_TYPE,
+                    std.mem.asBytes(&payload),
+                    .once,
+                );
+                // ◆ glyph distinguishes sprite drags from component
+                // (⚙) and prefab (⌖) drags mid-flight so the user can
+                // see what kind of payload they grabbed.
+                zgui.text("◆ {s}", .{sprite_name});
+            }
+        }
+
+        const line_bottom_y = zgui.getCursorScreenPos()[1];
+
+        const draw_list = zgui.getWindowDrawList();
+        const color_u32 = zgui.colorConvertFloat4ToU32(
+            zgui.getStyle().getColor(.tree_lines),
+        );
+        const line_x = parent_screen_x + zgui.getFontSize() * 0.4;
+        draw_list.addLine(.{
+            .p1 = .{ line_x, line_top_y },
+            .p2 = .{ line_x, line_bottom_y },
+            .col = color_u32,
+            .thickness = 1.0,
+        });
     }
 
     fn getFilesForFolder(self: *Self, folder_path: []const u8) ![]const FileEntry {
@@ -468,4 +576,13 @@ pub fn isPrefabFile(full_path: []const u8, file_name: []const u8, prefabs_prefix
     if (prefabs_prefix.len == 0) return false;
     if (!std.mem.endsWith(u8, file_name, ".jsonc")) return false;
     return std.mem.startsWith(u8, full_path, prefabs_prefix);
+}
+
+/// Return the loaded atlas whose JSON manifest matches `full_path`,
+/// or null when the file isn't a project resource (or the atlas
+/// failed to load). Used by `renderFolder` to decide whether to
+/// expand the file row inline with sprite drag-sources (#143 phase 8).
+fn atlasMatch(atlas_index: ?*const atlas.Index, full_path: []const u8) ?*const atlas.Atlas {
+    const idx = atlas_index orelse return null;
+    return idx.atlasByJsonPath(full_path);
 }


### PR DESCRIPTION
## Summary

Closes #143 phase 8 — the original drag-drop scope deferred when the umbrella pivoted to entity composition.

- Atlas manifest files in the project tree now expand inline (caret + sorted sprite children) instead of rendering as plain leaves.
- Each sprite row is a drag source emitting a `SPRITE_TYPE` payload.
- The Sprite inspector's `sprite_name` input is a drop target — accepting a drop replaces the buffer contents and flips the tab's dirty flag.

Locally verified against `flying-platform-labelle`: dragged `walk/thief_0001.png` from the expanded `assets/characters.json` onto `bandit.jsonc`'s Sprite section; the field updated and the tab marked dirty.

## Implementation notes

- `modules/dnd.zig`: new `SPRITE_TYPE` + `SpritePayload` / `packSprite` / `unpackSprite`, mirroring `PrefabPayload`. Distinct payload type so the inspector field never accepts a prefab or component drop.
- `atlas.zig`: store the manifest's absolute path on each loaded `Atlas`; the viewer-only entry point (`loadFromPaths`) keeps `json_path` empty. New `Index.atlasByJsonPath` lookup.
- `tree_view.zig`: new `?*const atlas.Index` parameter on `render`. Atlas-manifest rows route through a new `renderAtlasRow` that mirrors `renderDirectoryRow`'s caret / open-state / vertical guide-line treatment so atlas expansion reads identically to folder expansion.
- `modules/inspector/sprite.zig`: wrap the `sprite_name` `inputText` in a `beginDragDropTarget` accepting `SPRITE_TYPE`.
- `modules/project_tree.zig`: thread `app.atlas_index` through to `tree_view.render`.

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — 391/391 passing, including 4 new `SpriteDndTests` covering payload round-trip, snake_case + digits, oversize truncation, tail zero-padding
- [x] Manual: expanding `assets/<atlas>.json` lists sorted sprite names with drag-source tooltips
- [x] Manual: drop onto `sprite_name` updates field and marks tab dirty
- [ ] CI: Build, ImGui Test Engine, Launch Smoke, Bugbot