### PR TITLE
test(preview): LABELLE_PREVIEW env-var contract (#131)

### DIFF
--- a/src/preview.zig
+++ b/src/preview.zig
@@ -254,6 +254,30 @@ pub fn buildSpawnArgv(
     return argv_buf[0..n];
 }
 
+/// Set the `LABELLE_PREVIEW` environment variable to the loopback
+/// host + port the editor's listener is bound to. The spawned game's
+/// `main` reads this variable and dials back — see the engine-side
+/// `preview_mode.zig` for the consumer half. Extracted from `start()`
+/// so the env-mutation contract (#131) is unit-testable without
+/// spawning a child process. `port` is the editor's listening port.
+/// Returns `error.OutOfMemory` only if formatting the address into
+/// the temp buffer overflows — `"127.0.0.1:65535\x00"` fits in 32
+/// bytes so this is defensive.
+pub fn setPreviewEnv(port: u16) error{OutOfMemory}!void {
+    var addr_buf: [32]u8 = undefined;
+    const addr_str = std.fmt.bufPrintZ(&addr_buf, "127.0.0.1:{d}", .{port}) catch
+        return error.OutOfMemory;
+    _ = setenv("LABELLE_PREVIEW", addr_str.ptr, 1);
+}
+
+/// Clear the `LABELLE_PREVIEW` environment variable. Idempotent —
+/// libc `unsetenv` on an unset key is a no-op. Symmetric with
+/// `setPreviewEnv`. Extracted from `stop()` for the same testability
+/// reason as `setPreviewEnv` (#131).
+pub fn clearPreviewEnv() void {
+    _ = unsetenv("LABELLE_PREVIEW");
+}
+
 pub const PreviewSession = struct {
     allocator: std.mem.Allocator,
     state: State,
@@ -461,7 +485,7 @@ pub const PreviewSession = struct {
         // see LABELLE_PREVIEW even though PATH propagated correctly,
         // suggesting std.process.spawn snapshots env in a way that
         // doesn't pick up runtime setenv calls on Darwin).
-        _ = setenv("LABELLE_PREVIEW", addr_str.ptr, 1); // still set for the simpler propagation path
+        try setPreviewEnv(self.port.?); // still set for the simpler propagation path
         var env_map = std.process.Environ.Map.init(self.allocator);
         defer env_map.deinit();
         // Copy the current environ into the Map. extern environ is
@@ -507,7 +531,7 @@ pub const PreviewSession = struct {
     pub fn stop(self: *Self) void {
         // Symmetric with `start()`'s setenv. Multiple stops are safe
         // (unsetenv on an unset var is a no-op).
-        _ = unsetenv("LABELLE_PREVIEW");
+        clearPreviewEnv();
         if (self.child) |*c| {
             c.kill(io_global.io());
             self.child = null;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3653,6 +3653,96 @@ pub const PreviewSpawnArgvTests = struct {
     }
 };
 
+pub const PreviewEnvTests = struct {
+    // Regression-lock the `LABELLE_PREVIEW` env-var contract that the
+    // editor relies on for the engine to discover the editor's
+    // listener (#131). `start()` calls `setPreviewEnv(port)` before
+    // spawning; `stop()` calls `clearPreviewEnv()` on teardown. The
+    // engine reads `LABELLE_PREVIEW` straight off its own environ at
+    // boot — see the engine-side `preview_mode.zig`. These tests
+    // exercise the env helpers directly so the spawn path doesn't
+    // have to fire.
+
+    extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+
+    fn readEnv() ?[]const u8 {
+        const raw = getenv("LABELLE_PREVIEW") orelse return null;
+        return std.mem.span(raw);
+    }
+
+    test "setPreviewEnv populates LABELLE_PREVIEW with loopback addr" {
+        preview.clearPreviewEnv();
+        defer preview.clearPreviewEnv();
+
+        try preview.setPreviewEnv(54321);
+        const got = readEnv() orelse return error.MissingEnvVar;
+        try std.testing.expectEqualStrings("127.0.0.1:54321", got);
+    }
+
+    test "clearPreviewEnv removes LABELLE_PREVIEW" {
+        try preview.setPreviewEnv(9000);
+        try std.testing.expect(readEnv() != null);
+
+        preview.clearPreviewEnv();
+        try std.testing.expect(readEnv() == null);
+    }
+
+    test "clearPreviewEnv on unset var is a no-op" {
+        // Locks `stop()` being safe to call from `.idle` — same
+        // contract as the issue's bonus bullet "stop() from .idle is
+        // a no-op". libc `unsetenv` already handles this; the test
+        // is here so a future refactor that changes the impl can't
+        // silently regress the idempotency.
+        preview.clearPreviewEnv();
+        preview.clearPreviewEnv();
+        try std.testing.expect(readEnv() == null);
+    }
+
+    test "set → clear → set leaves the env in the second value" {
+        // Mirrors a `start → stop → start` sequence: multiple
+        // sessions in a row must each set up env fresh, no leak
+        // from the previous one. Issue #131 bonus bullet.
+        defer preview.clearPreviewEnv();
+
+        try preview.setPreviewEnv(1111);
+        preview.clearPreviewEnv();
+        try preview.setPreviewEnv(2222);
+
+        const got = readEnv() orelse return error.MissingEnvVar;
+        try std.testing.expectEqualStrings("127.0.0.1:2222", got);
+    }
+
+    test "setPreviewEnv overwrites a previous value rather than appending" {
+        defer preview.clearPreviewEnv();
+
+        try preview.setPreviewEnv(1111);
+        try preview.setPreviewEnv(2222);
+
+        const got = readEnv() orelse return error.MissingEnvVar;
+        try std.testing.expectEqualStrings("127.0.0.1:2222", got);
+    }
+
+    test "setPreviewEnv addr matches a session's bound port" {
+        // Lock the issue's third assertion: the captured port in
+        // `LABELLE_PREVIEW` matches `self.port.?` after
+        // `bindListener`. Goes through `PreviewSession` so the
+        // production wiring (`start()` formats addr from `self.port`)
+        // is exercised end-to-end, just without spawning.
+        defer preview.clearPreviewEnv();
+
+        var sess = preview.PreviewSession.init(std.testing.allocator);
+        defer sess.deinit();
+        try sess.bindListener();
+        const port = sess.port orelse return error.NoPort;
+
+        try preview.setPreviewEnv(port);
+        const got = readEnv() orelse return error.MissingEnvVar;
+        var expected_buf: [32]u8 = undefined;
+        const expected = try std.fmt.bufPrint(&expected_buf, "127.0.0.1:{d}", .{port});
+        try std.testing.expectEqualStrings(expected, got);
+    }
+};
+
 pub const PreviewTransportTests = struct {
     // Drives `PreviewSession` end-to-end against an in-test fake
     // engine that dials the editor's listener and writes JSON


### PR DESCRIPTION
## Summary

Closes #131. The preview spawn path has two contract surfaces:

1. **argv shape** — already locked by `PreviewSpawnArgvTests` (`["labelle", "run", <dir>]`, no `--preview-mode`).
2. **env channel** — `LABELLE_PREVIEW=127.0.0.1:<port>` set before spawn, cleared on stop. **Was untested.** This PR fills that gap.

PR #130 introduced the env-var propagation but only the smoke harness exercised it end-to-end. A locked unit test would have caught the original `--preview-mode` regression and will catch any future shape drift.

## Changes

- `src/preview.zig`: extract `setPreviewEnv(port: u16)` and `clearPreviewEnv()` from the inline `setenv` / `unsetenv` calls in `start()` / `stop()`. Same observable behaviour — the helpers exist to give tests a non-spawning entry point.
- `src/tests.zig`: 6 new `PreviewEnvTests`:
  - `setPreviewEnv` populates `LABELLE_PREVIEW=127.0.0.1:<port>`
  - `clearPreviewEnv` removes it
  - `clearPreviewEnv` on an unset var is a no-op (locks `stop()`-from-`.idle` idempotency)
  - set → clear → set leaves the second value (no leak across sessions)
  - overwrite of a previous value
  - addr matches a `bindListener`-bound port (drives `PreviewSession` end-to-end, no spawn)

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — 393/393, including 6 new env tests
- [ ] CI: Build, ImGui Test Engine, Launch Smoke, Bugbot