### PR TITLE
fix(flow editor): render data-edge pins for Literal/BinOp/etc + CustomNode positional pins (#189)

### DIFF
--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -1415,14 +1415,28 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
             defer seen_in.deinit();
             var seen_out = PinNameSet.init(allocator);
             defer seen_out.deinit();
+            // On-disk `.flow.jsonc` edges + flow-codegen address CustomNode
+            // inputs *positionally* (`arg0`, `arg1`, …; codegen resolves
+            // `arg{d}`), not by catalog pin name. Render each input pin under
+            // its positional id so data edges resolve, while showing the
+            // catalog label for the human (labelle-gui#189). Static names
+            // keep `recordPin`'s borrowed slice valid past this frame.
+            const arg_pin_names = [_][]const u8{
+                "arg0", "arg1", "arg2",  "arg3",  "arg4",  "arg5",  "arg6",  "arg7",
+                "arg8", "arg9", "arg10", "arg11", "arg12", "arg13", "arg14", "arg15",
+            };
+            var in_idx: usize = 0;
             for (entry.pins) |p| switch (p.dir) {
                 .input => {
-                    const dup = (seen_in.fetchPut(p.name, {}) catch null) != null;
+                    if (in_idx >= arg_pin_names.len) continue;
+                    const arg_name = arg_pin_names[in_idx];
+                    in_idx += 1;
+                    const dup = (seen_in.fetchPut(arg_name, {}) catch null) != null;
                     if (dup) continue;
-                    ne.beginPin(pinId(n.id, p.name, .input), .input);
+                    ne.beginPin(pinId(n.id, arg_name, .input), .input);
                     zgui.text("> {s}: {s}", .{ p.label, p.type_name });
                     ne.endPin();
-                    recordPin(s, n.id, p.name, .input);
+                    recordPin(s, n.id, arg_name, .input);
                 },
                 .output => {
                     const dup = (seen_out.fetchPut(p.name, {}) catch null) != null;
@@ -1435,8 +1449,43 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
             };
         },
         .other => {
-            // Show extras as a compact hint so the user can tell nodes
-            // apart even though the editor can't field-edit them.
+            // Value/expression node kinds the model doesn't field-edit but
+            // that DO carry data pins the edges reference. Pin names mirror
+            // flow-codegen's convention so links resolve (labelle-gui#189).
+            // String literals are static, so `recordPin`'s borrowed slice
+            // stays valid.
+            if (std.mem.eql(u8, n.type_name, "BinOp")) {
+                ne.beginPin(pinId(n.id, "a", .input), .input);
+                zgui.text("> a", .{});
+                ne.endPin();
+                recordPin(s, n.id, "a", .input);
+                ne.beginPin(pinId(n.id, "b", .input), .input);
+                zgui.text("> b", .{});
+                ne.endPin();
+                recordPin(s, n.id, "b", .input);
+                ne.beginPin(pinId(n.id, "result", .output), .output);
+                zgui.text("result >", .{});
+                ne.endPin();
+                recordPin(s, n.id, "result", .output);
+            } else if (std.mem.eql(u8, n.type_name, "Literal") or
+                std.mem.eql(u8, n.type_name, "Identifier"))
+            {
+                ne.beginPin(pinId(n.id, "value", .output), .output);
+                zgui.text("value >", .{});
+                ne.endPin();
+                recordPin(s, n.id, "value", .output);
+            } else if (std.mem.eql(u8, n.type_name, "SetField")) {
+                ne.beginPin(pinId(n.id, "entity", .input), .input);
+                zgui.text("> entity", .{});
+                ne.endPin();
+                recordPin(s, n.id, "entity", .input);
+                ne.beginPin(pinId(n.id, "value", .input), .input);
+                zgui.text("> value", .{});
+                ne.endPin();
+                recordPin(s, n.id, "value", .input);
+            }
+            // Show extras as a compact hint (e.g. BinOp `op`, Literal
+            // `value`) so the user can tell nodes apart.
             for (n.extras) |kv| {
                 zgui.textDisabled("{s}: {s}", .{ kv.key, kv.value_text });
             }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5251,12 +5251,14 @@ pub const PluginEventsRfcTests = struct {
     }
 
     test "bouncing-ball hit_counter.flow.jsonc parses as v2-form (Event node + variables)" {
-        // Real-file ingestion test — flow-codegen `a8be4c1` migrated
-        // this in-tree example to the v2 vocabulary (RFC-FLOW-VOCABULARY
-        // phase 3): the trigger lives ON the canvas as an `Event` node
-        // and the counter is a declared top-level `Variable`, not a
-        // sidecar `.zig`. The editor must load it without the legacy
-        // `event:` header.
+        // Real-file ingestion test. The in-tree example uses the v2
+        // vocabulary (RFC-FLOW-VOCABULARY phase 3): the trigger lives ON
+        // the canvas as an `Event` node and the counter is a declared
+        // top-level `Variable`, not a sidecar `.zig`. The example is now
+        // the explicit data-flow form — Event → GetVariable + Literal →
+        // BinOp(add) → SetVariable, plus a `log_i32` CustomNode — which
+        // exercises the data-node pin rendering this PR adds. Assert by
+        // scanning kinds so the test isn't brittle to node ordering.
         const a = std.testing.allocator;
         const path = "../bouncing-ball/scripts/flows/hit_counter.flow.jsonc";
 
@@ -5272,12 +5274,36 @@ pub const PluginEventsRfcTests = struct {
         // No file-level event header — the trigger is on-canvas now.
         try expect.toBeTrue(!doc.event_present);
 
-        // Two nodes: the `Event` trigger + the `ChangeVariable` action.
-        try expect.equal(doc.nodes.len, @as(usize, 2));
-        try expect.toBeTrue(doc.nodes[0].kind == .event);
-        try expect.toBeTrue(std.mem.eql(u8, doc.nodes[0].event_ref, "box2d.collision_begin"));
-        try expect.toBeTrue(doc.nodes[1].kind == .change_variable);
-        try expect.toBeTrue(std.mem.eql(u8, doc.nodes[1].variable_ref, "hits"));
+        var has_event = false;
+        var has_get = false;
+        var has_set = false;
+        var has_binop = false;
+        var has_log = false;
+        for (doc.nodes) |node| {
+            switch (node.kind) {
+                .event => if (std.mem.eql(u8, node.event_ref, "box2d.collision_begin")) {
+                    has_event = true;
+                },
+                .get_variable => if (std.mem.eql(u8, node.variable_ref, "hits")) {
+                    has_get = true;
+                },
+                .set_variable => if (std.mem.eql(u8, node.variable_ref, "hits")) {
+                    has_set = true;
+                },
+                .custom_node => if (std.mem.eql(u8, node.custom_name, "bouncing_ball.log_i32")) {
+                    has_log = true;
+                },
+                .other => if (std.mem.eql(u8, node.type_name, "BinOp")) {
+                    has_binop = true;
+                },
+                else => {},
+            }
+        }
+        try expect.toBeTrue(has_event);
+        try expect.toBeTrue(has_get);
+        try expect.toBeTrue(has_set);
+        try expect.toBeTrue(has_binop);
+        try expect.toBeTrue(has_log);
 
         // One declared variable.
         try expect.equal(doc.variables.len, @as(usize, 1));


### PR DESCRIPTION
Fixes #189. The `.flow.jsonc` editor drew no data-edge wires for expression graphs because `Literal`/`BinOp`/`Identifier`/`SetField` collapsed to `.other` (no pins), and `CustomNode` rendered catalog-named pins (`label`/`value`) while edges + flow-codegen address inputs positionally (`arg0`/`arg1`).

- Add data pins for `BinOp` (`a`,`b`→`result`), `Literal`/`Identifier` (`value`), `SetField` (`entity`,`value`), matching flow-codegen's edge pin names.
- Render CustomNode inputs under positional `argN` ids (showing the catalog label) so links resolve.
- Update the real-file `hit_counter` ingestion test to the current explicit+log example (kind-scan).

Verified: bouncing-ball's `hit_counter` now renders fully wired in the editor; `zig build test` green.