### PR TITLE
feat(flow editor): render + inspect Compare/Logic nodes (#7)

### DIFF
--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -326,16 +326,26 @@ pub const OtherFieldSpec = struct {
     /// Inspector label shown next to the widget.
     label: []const u8,
     widget: OtherFieldWidget,
+    /// Closed choice list for `.op_combo` (empty for other widgets).
+    choices: []const []const u8 = &.{},
 };
 
 /// The closed list of `BinOp.op` values offered by the combo box.
 pub const bin_ops = [_][]const u8{ "add", "sub", "mul", "div" };
 
+/// `Compare.op` values — comparison operators (flow-codegen#7).
+pub const compare_ops = [_][]const u8{ "eq", "ne", "lt", "le", "gt", "ge" };
+
+/// `Logic.op` values — boolean operators (flow-codegen#7).
+pub const logic_ops = [_][]const u8{ "and", "or", "not" };
+
 /// Recognised `.other` node types and their one editable field. Keeping
 /// this in `flow_io` (next to the model) makes it unit-testable without
 /// a GUI and keeps the editor a thin consumer.
 pub const other_field_specs = [_]OtherFieldSpec{
-    .{ .type_name = "BinOp", .key = "op", .label = "Operator", .widget = .op_combo },
+    .{ .type_name = "BinOp", .key = "op", .label = "Operator", .widget = .op_combo, .choices = &bin_ops },
+    .{ .type_name = "Compare", .key = "op", .label = "Comparison", .widget = .op_combo, .choices = &compare_ops },
+    .{ .type_name = "Logic", .key = "op", .label = "Logic", .widget = .op_combo, .choices = &logic_ops },
     .{ .type_name = "GetComponent", .key = "component", .label = "Component", .widget = .text },
     .{ .type_name = "SetField", .key = "target", .label = "Target", .widget = .text },
     .{ .type_name = "Literal", .key = "value", .label = "Value", .widget = .literal },

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -1454,7 +1454,11 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
             // flow-codegen's convention so links resolve (labelle-gui#189).
             // String literals are static, so `recordPin`'s borrowed slice
             // stays valid.
-            if (std.mem.eql(u8, n.type_name, "BinOp")) {
+            if (std.mem.eql(u8, n.type_name, "BinOp") or
+                std.mem.eql(u8, n.type_name, "Compare"))
+            {
+                // Arithmetic (BinOp) and comparison (Compare) share the
+                // binary a/b -> result shape (flow-codegen#7).
                 ne.beginPin(pinId(n.id, "a", .input), .input);
                 zgui.text("> a", .{});
                 ne.endPin();
@@ -1463,6 +1467,29 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
                 zgui.text("> b", .{});
                 ne.endPin();
                 recordPin(s, n.id, "b", .input);
+                ne.beginPin(pinId(n.id, "result", .output), .output);
+                zgui.text("result >", .{});
+                ne.endPin();
+                recordPin(s, n.id, "result", .output);
+            } else if (std.mem.eql(u8, n.type_name, "Logic")) {
+                // Boolean logic (flow-codegen#7): `not` is unary (`a`
+                // only), `and`/`or` are binary. Read the op from extras to
+                // decide whether to expose the `b` pin.
+                var logic_unary = false;
+                for (n.extras) |kv| {
+                    if (std.mem.eql(u8, kv.key, "op") and
+                        std.mem.eql(u8, kv.value_text, "not")) logic_unary = true;
+                }
+                ne.beginPin(pinId(n.id, "a", .input), .input);
+                zgui.text("> a", .{});
+                ne.endPin();
+                recordPin(s, n.id, "a", .input);
+                if (!logic_unary) {
+                    ne.beginPin(pinId(n.id, "b", .input), .input);
+                    zgui.text("> b", .{});
+                    ne.endPin();
+                    recordPin(s, n.id, "b", .input);
+                }
                 ne.beginPin(pinId(n.id, "result", .output), .output);
                 zgui.text("result >", .{});
                 ne.endPin();
@@ -2552,13 +2579,13 @@ fn renderOtherField(s: *FlowDocState, n: *flow_io.Node, spec: flow_io.OtherField
                 // and could never be committed — the combo would show
                 // `add` without it ever being written to the node.
                 var sel: ?usize = null;
-                for (flow_io.bin_ops, 0..) |op, i| {
+                for (spec.choices, 0..) |op, i| {
                     if (std.mem.eql(u8, op, decoded.text)) sel = i;
                 }
                 var preview_z: IdentBuf = undefined;
-                seedBuf(&preview_z, if (sel) |i| flow_io.bin_ops[i] else "");
+                seedBuf(&preview_z, if (sel) |i| spec.choices[i] else "");
                 if (zgui.beginCombo("##other_op", .{ .preview_value = &preview_z })) {
-                    for (flow_io.bin_ops, 0..) |op, i| {
+                    for (spec.choices, 0..) |op, i| {
                         var op_z: IdentBuf = undefined;
                         seedBuf(&op_z, op);
                         if (zgui.selectable(&op_z, .{ .selected = sel == i })) {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5401,6 +5401,13 @@ pub const FlowIoTests = struct {
         try expect.toBeTrue(flow_io.otherFieldSpec("Literal").?.widget == .literal);
         try expect.toBeTrue(std.mem.eql(u8, flow_io.otherFieldSpec("Identifier").?.key, "name"));
         try expect.toBeTrue(std.mem.eql(u8, flow_io.otherFieldSpec("Call").?.key, "callee"));
+        // Comparison + boolean operators (flow-codegen#7) — op_combo with
+        // their own choice lists, distinct from BinOp's arithmetic ops.
+        try expect.toBeTrue(flow_io.otherFieldSpec("Compare").?.widget == .op_combo);
+        try expect.equal(flow_io.otherFieldSpec("Compare").?.choices.len, @as(usize, 6));
+        try expect.toBeTrue(flow_io.otherFieldSpec("Logic").?.widget == .op_combo);
+        try expect.equal(flow_io.otherFieldSpec("Logic").?.choices.len, @as(usize, 3));
+        try expect.equal(flow_io.otherFieldSpec("BinOp").?.choices.len, @as(usize, 4));
         // A genuinely-unknown node type has no spec → verbatim fallback.
         try expect.toBeTrue(flow_io.otherFieldSpec("MysteryNode") == null);
     }


### PR DESCRIPTION
Editor support for the flow-codegen Compare/Logic operators (flow-codegen#7).

- **Render** data pins: `Compare` (`a`,`b`→`result`) and `Logic` (`a`[,`b`]→`result`; `b` suppressed for the unary `not`, read from the op extra) — so their data edges draw (same parity as #189).
- **Inspect**: generalise the `op_combo` widget from the hardcoded `bin_ops` list to a per-spec `choices` slice; register `Compare` (eq/ne/lt/le/gt/ge) and `Logic` (and/or/not) specs so the op is editable.
- Test extended; `zig build test` green.

Out of scope (separate gap): palette **create** buttons for `.other` nodes — `addNode` has no `.other` path, so BinOp/Compare/Logic/Literal can be rendered/edited but not yet created in-editor. Worth its own issue.