### PR TITLE
feat(flow editor): round-trip + render exec_edges for Branch/loop nodes (#193, #194)

### DIFF
--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -566,6 +566,20 @@ pub const Edge = struct {
     to_pin: []const u8,
 };
 
+/// One control-flow (execution) edge — the top-level `exec_edges` block
+/// (flow-codegen#8, #21). Distinct from a data `Edge`: the source is a
+/// named exec-output pin on a `Branch` (`then`/`else`) or loop
+/// (`ForRange`/`While` → `body`); the target is a *bare* node ref (the
+/// node is *entered*, not wired to an input pin), so there's no
+/// `to_pin`. Mirrors flow-codegen's `ExecEdge`
+/// (`flow-codegen/src/flow_io.zig`), flattened to match the shape of
+/// `Edge` above.
+pub const ExecEdge = struct {
+    from_node: u32,
+    from_pin: []const u8,
+    to_node: u32,
+};
+
 /// The flow's entry point. `type` is a lifecycle event name (e.g.
 /// `OnCreate`) or `OnCall` for a subgraph (RFC §3). `arg_entity` and any
 /// other event keys are captured in `extras` so they round-trip.
@@ -629,6 +643,13 @@ pub const FlowDoc = struct {
     variables: []Variable = &.{},
     nodes: []Node = &.{},
     edges: []Edge = &.{},
+    /// Control-flow (execution) edges (flow-codegen#8, #21). Empty for
+    /// every flow that declares no `Branch`/`ForRange`/`While` node — the
+    /// default and the only shape that existed before control flow.
+    /// Absence in the source file is indistinguishable from
+    /// `"exec_edges": []`; the writer emits the key only when non-empty so
+    /// pre-control-flow files round-trip byte-for-byte.
+    exec_edges: []ExecEdge = &.{},
     /// Highest node id seen — the editor allocates fresh ids above this.
     max_node_id: u32 = 0,
 
@@ -739,6 +760,14 @@ pub fn parse(child_allocator: std.mem.Allocator, raw: []const u8) !FlowDoc {
     if (root.get("edges")) |v| {
         if (v != .array) return ParseError.BadSchema;
         doc.edges = try parseEdges(a, v.array);
+    }
+
+    // ── exec_edges ── (flow-codegen#8, #21) Control-flow edges. Absent →
+    // empty slice; the writer then omits the key so the file round-trips
+    // byte-for-byte.
+    if (root.get("exec_edges")) |v| {
+        if (v != .array) return ParseError.BadSchema;
+        doc.exec_edges = try parseExecEdges(a, v.array);
     }
 
     return doc;
@@ -1032,6 +1061,31 @@ fn parseEndpoint(a: std.mem.Allocator, obj: std.json.ObjectMap) !Endpoint {
     return .{ .node = node, .pin = try a.dupe(u8, pin_v.string) };
 }
 
+/// Parse the top-level `exec_edges` array (flow-codegen#8, #21). Each
+/// entry is `{ "from": { "node", "pin" }, "to": { "node" } }`: `from` is
+/// a full pin ref (the named exec output — `then`/`else`/`body`); `to` is
+/// a *bare* node ref with no `pin` (the target node is entered, not wired
+/// to an input).
+fn parseExecEdges(a: std.mem.Allocator, arr: std.json.Array) ![]ExecEdge {
+    var out: std.ArrayList(ExecEdge) = .empty;
+    for (arr.items) |item| {
+        if (item != .object) return ParseError.BadEdge;
+        const o = item.object;
+        const from = o.get("from") orelse return ParseError.BadEdge;
+        const to = o.get("to") orelse return ParseError.BadEdge;
+        if (from != .object or to != .object) return ParseError.BadEdge;
+        const fe = try parseEndpoint(a, from.object);
+        const to_node_v = to.object.get("node") orelse return ParseError.BadEdge;
+        const to_node = jsonIntId(to_node_v) orelse return ParseError.BadEdge;
+        try out.append(a, .{
+            .from_node = fe.node,
+            .from_pin = fe.pin,
+            .to_node = to_node,
+        });
+    }
+    return out.toOwnedSlice(a);
+}
+
 /// Read a JSON number expected to be a non-negative `u32` node id.
 /// Accepts a plain integer, and also a float (or `number_string`) that
 /// has no fractional part — hand-authored files and exporters often
@@ -1316,10 +1370,17 @@ pub fn render(child_allocator: std.mem.Allocator, doc: FlowDoc) ![]u8 {
     }
 
     // edges
+    //
+    // The `edges` block carries a trailing comma only when an `exec_edges`
+    // block follows it — emitted (below) only when non-empty so
+    // pre-control-flow files round-trip byte-for-byte. This mirrors
+    // flow-codegen's writer (`renderFlowJsonc` → the `flow.exec_edges.len
+    // == 0` branch).
+    const has_exec = doc.exec_edges.len > 0;
     try out.appendSlice(a, indent_unit);
     try out.appendSlice(a, "\"edges\": [");
     if (doc.edges.len == 0) {
-        try out.appendSlice(a, "]\n");
+        try out.appendSlice(a, if (has_exec) "],\n" else "]\n");
     } else {
         try out.append(a, '\n');
         for (doc.edges, 0..) |e, i| {
@@ -1333,11 +1394,48 @@ pub fn render(child_allocator: std.mem.Allocator, doc: FlowDoc) ![]u8 {
             try out.append(a, '\n');
         }
         try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, if (has_exec) "],\n" else "]\n");
+    }
+
+    // exec_edges (flow-codegen#8, #21) — control-flow edges. Emitted only
+    // when non-empty, deterministically sorted to match flow-codegen's
+    // `lessThanExecEdge` (by source node id, then exec pin lexically —
+    // `else` < `then` — then target node) so editor re-saves stay
+    // diff-clean and byte-compatible with codegen's own writer. Each entry
+    // is `{ "from": { "node": N, "pin": "<pin>" }, "to": { "node": M } }`
+    // (bare target node ref, no `pin`).
+    if (has_exec) {
+        const sorted = try a.dupe(ExecEdge, doc.exec_edges);
+        defer a.free(sorted);
+        std.mem.sort(ExecEdge, sorted, {}, execEdgeLessThan);
+
+        try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, "\"exec_edges\": [\n");
+        for (sorted, 0..) |x, i| {
+            try out.appendSlice(a, indent_unit ** 2);
+            try out.print(a, "{{ \"from\": {{ \"node\": {d}, \"pin\": ", .{x.from_node});
+            try writeJsonString(a, &out, x.from_pin);
+            try out.print(a, " }}, \"to\": {{ \"node\": {d} }} }}", .{x.to_node});
+            if (i + 1 < sorted.len) try out.append(a, ',');
+            try out.append(a, '\n');
+        }
+        try out.appendSlice(a, indent_unit);
         try out.appendSlice(a, "]\n");
     }
 
     try out.appendSlice(a, "}\n");
     return out.toOwnedSlice(a);
+}
+
+/// Deterministic order for exec edges (flow-codegen#8) — by source node
+/// id, then exec pin lexically (`else` < `then`; `body` is the loops'
+/// only pin), then target node. Mirrors flow-codegen's `lessThanExecEdge`
+/// so editor re-saves stay byte-compatible with codegen's writer.
+fn execEdgeLessThan(_: void, x: ExecEdge, y: ExecEdge) bool {
+    if (x.from_node != y.from_node) return x.from_node < y.from_node;
+    const fp = std.mem.order(u8, x.from_pin, y.from_pin);
+    if (fp != .eq) return fp == .lt;
+    return x.to_node < y.to_node;
 }
 
 fn renderNode(a: std.mem.Allocator, out: *std.ArrayList(u8), n: Node) !void {
@@ -1626,6 +1724,132 @@ test "empty graph round-trips" {
     const text2 = try render(std.testing.allocator, doc2);
     defer std.testing.allocator.free(text2);
     try std.testing.expectEqualStrings(text, text2);
+}
+
+test "exec_edges round-trip preserves a Branch's then/else control flow" {
+    // A Branch flow: `cond` is a data edge into node 4; `then`/`else` are
+    // exec edges (flow-codegen#8). Loading then saving must NOT drop the
+    // `exec_edges` block — doing so silently corrupts the control flow.
+    const src =
+        \\{
+        \\  "event": { "type": "OnUpdate" },
+        \\  "nodes": [
+        \\    { "id": 1, "type": "Literal", "pos": [0, 0] },
+        \\    { "id": 4, "type": "Branch", "pos": [5, 0] },
+        \\    { "id": 6, "type": "Print", "pos": [10, 0] },
+        \\    { "id": 7, "type": "Print", "pos": [10, 5] }
+        \\  ],
+        \\  "edges": [
+        \\    { "from": { "node": 1, "pin": "value" }, "to": { "node": 4, "pin": "cond" } }
+        \\  ],
+        \\  "exec_edges": [
+        \\    { "from": { "node": 4, "pin": "then" }, "to": { "node": 6 } },
+        \\    { "from": { "node": 4, "pin": "else" }, "to": { "node": 7 } }
+        \\  ]
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), doc.exec_edges.len);
+    // Parsed in source order (sorting happens at render time).
+    try std.testing.expectEqual(@as(u32, 4), doc.exec_edges[0].from_node);
+    try std.testing.expectEqualStrings("then", doc.exec_edges[0].from_pin);
+    try std.testing.expectEqual(@as(u32, 6), doc.exec_edges[0].to_node);
+    try std.testing.expectEqual(@as(u32, 4), doc.exec_edges[1].from_node);
+    try std.testing.expectEqualStrings("else", doc.exec_edges[1].from_pin);
+    try std.testing.expectEqual(@as(u32, 7), doc.exec_edges[1].to_node);
+
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+
+    // The writer must emit the `exec_edges` block, deterministically
+    // sorted (`else` < `then`) to match flow-codegen's `lessThanExecEdge`,
+    // with `to` as a bare node ref (no `pin`).
+    const expected =
+        \\  "exec_edges": [
+        \\    { "from": { "node": 4, "pin": "else" }, "to": { "node": 7 } },
+        \\    { "from": { "node": 4, "pin": "then" }, "to": { "node": 6 } }
+        \\  ]
+    ;
+    try std.testing.expect(std.mem.indexOf(u8, text, expected) != null);
+
+    // Round-trip stability: re-parse + re-render is byte-identical, and
+    // the entries survive unchanged.
+    var doc2 = try parse(std.testing.allocator, text);
+    defer doc2.deinit();
+    try std.testing.expectEqual(@as(usize, 2), doc2.exec_edges.len);
+    const text2 = try render(std.testing.allocator, doc2);
+    defer std.testing.allocator.free(text2);
+    try std.testing.expectEqualStrings(text, text2);
+}
+
+test "exec_edges sort is stable across unsorted input (body + then/else)" {
+    // Deliberately out-of-order input — the writer sorts by from_node,
+    // then pin lexically, then to_node (matching flow-codegen).
+    const src =
+        \\{
+        \\  "nodes": [
+        \\    { "id": 2, "type": "ForRange", "pos": [0, 0] },
+        \\    { "id": 5, "type": "Branch", "pos": [0, 0] }
+        \\  ],
+        \\  "edges": [],
+        \\  "exec_edges": [
+        \\    { "from": { "node": 5, "pin": "then" }, "to": { "node": 9 } },
+        \\    { "from": { "node": 2, "pin": "body" }, "to": { "node": 8 } },
+        \\    { "from": { "node": 5, "pin": "else" }, "to": { "node": 3 } }
+        \\  ]
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+
+    const expected =
+        \\  "exec_edges": [
+        \\    { "from": { "node": 2, "pin": "body" }, "to": { "node": 8 } },
+        \\    { "from": { "node": 5, "pin": "else" }, "to": { "node": 3 } },
+        \\    { "from": { "node": 5, "pin": "then" }, "to": { "node": 9 } }
+        \\  ]
+    ;
+    try std.testing.expect(std.mem.indexOf(u8, text, expected) != null);
+}
+
+test "absence of exec_edges is preserved (no key emitted)" {
+    // A flow with no control-flow nodes must NOT gain an `exec_edges`
+    // key — pre-control-flow files round-trip byte-for-byte, and the
+    // `edges` block keeps its no-trailing-comma close.
+    const src =
+        \\{ "event": { "type": "OnCreate" }, "nodes": [], "edges": [] }
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    try std.testing.expectEqual(@as(usize, 0), doc.exec_edges.len);
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "exec_edges") == null);
+    // `edges` closes with `]` (no trailing comma) when no exec block follows.
+    try std.testing.expect(std.mem.indexOf(u8, text, "\"edges\": []\n") != null);
+}
+
+test "exec_edges parser rejects malformed entries" {
+    // Non-array exec_edges.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "nodes": [], "edges": [], "exec_edges": {} }
+    ));
+    // Missing `to`.
+    try std.testing.expectError(ParseError.BadEdge, parse(std.testing.allocator,
+        \\{ "nodes": [], "edges": [], "exec_edges": [ { "from": { "node": 1, "pin": "then" } } ] }
+    ));
+    // `from` missing pin.
+    try std.testing.expectError(ParseError.BadEdge, parse(std.testing.allocator,
+        \\{ "nodes": [], "edges": [], "exec_edges": [ { "from": { "node": 1 }, "to": { "node": 2 } } ] }
+    ));
+    // `to` missing node.
+    try std.testing.expectError(ParseError.BadEdge, parse(std.testing.allocator,
+        \\{ "nodes": [], "edges": [], "exec_edges": [ { "from": { "node": 1, "pin": "then" }, "to": {} } ] }
+    ));
 }
 
 test "displayNameFromPath strips extension" {

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -1288,7 +1288,14 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
     // re-route an exec arrow, they only see what the topo sort
     // produced.
     const is_command = isCommandNode(n);
-    if (is_command and n.kind != .event) {
+    // The exec-in anchor is where an incoming control arrow lands. Emit it
+    // for command nodes (the derived linear spine) AND for any explicit
+    // `exec_edge` target — a branch/loop body node may be `.other` (e.g. a
+    // nested Branch/loop) and still needs the anchor, else the amber
+    // control arrow has nothing to attach to (labelle-gui#193/#194, bugbot).
+    const needs_exec_in = (is_command or
+        isExplicitExecTarget(s.doc.exec_edges, n.id)) and n.kind != .event;
+    if (needs_exec_in) {
         ne.beginPin(execPinId(n.id, .input), .input);
         zgui.text("▼", .{});
         ne.endPin();

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -610,6 +610,14 @@ fn renderCanvas(s: *FlowDocState, allocator: std.mem.Allocator) void {
     // a graceful reject).
     renderExecEdges(s, allocator);
 
+    // Explicit control-flow arrows (issues #193, #194). The on-disk
+    // `exec_edges` block wires a `Branch`'s `then`/`else` or a loop's
+    // `body` to the entered node. Drawn after the derived spine so a
+    // target node that is an explicit exec-edge destination shows the
+    // real branch/loop arrow instead of (or in addition to) the linear
+    // derived arrow `renderExecEdges` would otherwise imply.
+    renderExplicitExecEdges(s);
+
     // Edge authoring (issue #158) — turn a pin drag into a new
     // `flow_io.Edge`, re-route an existing edge's endpoint, or a delete
     // gesture into an edge removal. All gestures are inspected *after*
@@ -642,6 +650,15 @@ fn renderExecEdges(s: *FlowDocState, allocator: std.mem.Allocator) void {
     while (i < order.len) : (i += 1) {
         const from = order[i - 1];
         const to = order[i];
+        // Reconcile with explicit control flow (issues #193, #194): a
+        // node that is the *target* of an `exec_edge` is entered by a
+        // branch/loop arrow, not by the linear command spine — drawing a
+        // derived arrow into it from its topo predecessor would
+        // double/contradict the control flow. Suppress it; the explicit
+        // arrow is drawn by `renderExplicitExecEdges`. (Branch/loop nodes
+        // themselves are `.other`, already off the command spine, so
+        // their outgoing flow never appears here.)
+        if (isExplicitExecTarget(s.doc.exec_edges, to)) continue;
         const from_pin = execPinId(from, .output);
         const to_pin = execPinId(to, .input);
         _ = ne.link(
@@ -652,6 +669,40 @@ fn renderExecEdges(s: *FlowDocState, allocator: std.mem.Allocator) void {
             2.5,
         );
         s.exec_links_last_frame += 1;
+    }
+}
+
+/// Whether `node_id` is the target of any on-disk `exec_edge` — i.e.
+/// it is entered by a `Branch`/`ForRange`/`While` control arrow rather
+/// than by the linear command spine. Used to suppress a contradictory
+/// derived arrow into it (issues #193, #194).
+pub fn isExplicitExecTarget(exec_edges: []const flow_io.ExecEdge, node_id: u32) bool {
+    for (exec_edges) |x| {
+        if (x.to_node == node_id) return true;
+    }
+    return false;
+}
+
+/// Draw the on-disk `exec_edges` as control arrows (issues #193, #194):
+/// for each edge, a link from the source node's named exec-output pin
+/// (`then`/`else`/`body`, drawn by `renderExecOutPin`) to the TARGET
+/// node's exec-in anchor. Visually distinct from the cyan data edges:
+/// a thick warm-amber arrow (versus the white derived spine and the
+/// cyan data links) so control branches read at a glance. Like the
+/// derived arrows these are read-only — the link ids don't match any
+/// `doc.edges[i]`, so a delete/re-route gesture bottoms out in
+/// "unknown id" and is gracefully rejected.
+fn renderExplicitExecEdges(s: *FlowDocState) void {
+    for (s.doc.exec_edges) |x| {
+        const from_pin = pinId(x.from_node, x.from_pin, .output);
+        const to_pin = execPinId(x.to_node, .input);
+        _ = ne.link(
+            explicitExecLinkId(x.from_node, x.from_pin, x.to_node),
+            from_pin,
+            to_pin,
+            .{ 1.0, 0.65, 0.2, 1.0 },
+            3.0,
+        );
     }
 }
 
@@ -778,6 +829,26 @@ fn execPinId(node_id: u32, dir: PinDir) u64 {
     return if (dir == .output) base | (@as(u64, 1) << 62) else base;
 }
 
+/// Draw a *named* exec OUTPUT pin (`then` / `else` on a `Branch`,
+/// `body` on a `ForRange` / `While`) — the source side of an on-disk
+/// `exec_edge` (issues #193, #194). Distinct from `execPinId`'s
+/// top/bottom command anchors: a named exec output sits inline in the
+/// node body next to its label, so its id is `pinId(node, name,
+/// .output)` (the loop/branch nodes carry no *data* output pin with
+/// these names, so there's no clash — `ForRange.index` is the one data
+/// output and is named differently).
+///
+/// Deliberately *not* `recordPin`'d: like the derived exec anchors,
+/// these are read-only this PR — a drag onto them fails the `findPin`
+/// lookup and the editor rejects it. Authoring exec edges by dragging
+/// is a follow-up (issues #193/#194 "Author"); this PR renders and
+/// round-trips hand-authored / codegen-emitted edges.
+fn renderExecOutPin(node_id: u32, name: []const u8) void {
+    ne.beginPin(pinId(node_id, name, .output), .output);
+    zgui.text("{s} ▸", .{name});
+    ne.endPin();
+}
+
 /// Synthetic link id for a derived exec arrow from `from_node`'s
 /// exec-out to `to_node`'s exec-in. Lives in the link namespace
 /// (bit 63 = 1) like `linkId`, hashed off the two endpoints so the
@@ -794,6 +865,22 @@ fn execPinId(node_id: u32, dir: PinDir) u64 {
 fn execLinkId(from_node: u32, to_node: u32) u64 {
     var h = std.hash.Wyhash.init(0xEC1ED6E);
     h.update(std.mem.asBytes(&from_node));
+    h.update(std.mem.asBytes(&to_node));
+    return (h.final() & 0x7FFF_FFFF_FFFF_FFFF) | (@as(u64, 1) << 63);
+}
+
+/// Synthetic link id for an *explicit* exec arrow from a named exec
+/// output pin (`then`/`else`/`body`) to its target node's exec-in
+/// (issues #193, #194). Distinct seed from `execLinkId` so a derived
+/// and an explicit arrow between the same node pair never collide on
+/// one id; the `from_pin` is mixed in so a Branch's `then` and `else`
+/// arrows to the *same* target stay distinct. Lives in the link
+/// namespace (bit 63 = 1) like `linkId`/`execLinkId`.
+fn explicitExecLinkId(from_node: u32, from_pin: []const u8, to_node: u32) u64 {
+    var h = std.hash.Wyhash.init(0xE6E07);
+    h.update(std.mem.asBytes(&from_node));
+    h.update(from_pin);
+    h.update(&[_]u8{0}); // delimiter, as in `linkId`
     h.update(std.mem.asBytes(&to_node));
     return (h.final() & 0x7FFF_FFFF_FFFF_FFFF) | (@as(u64, 1) << 63);
 }
@@ -1510,6 +1597,49 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
                 zgui.text("> value", .{});
                 ne.endPin();
                 recordPin(s, n.id, "value", .input);
+            } else if (std.mem.eql(u8, n.type_name, "Branch")) {
+                // Control-flow if/then-else (flow-codegen#8, issue #193).
+                // Data INPUT `cond`; two exec OUTPUT pins `then`/`else`.
+                // The `cond` pin is recorded so data edges into it draw
+                // and can be authored; the exec outputs are *not* recorded
+                // (read-only, like the derived exec anchors) — their links
+                // come from the on-disk `exec_edges`, drawn by
+                // `renderExplicitExecEdges`.
+                ne.beginPin(pinId(n.id, "cond", .input), .input);
+                zgui.text("> cond", .{});
+                ne.endPin();
+                recordPin(s, n.id, "cond", .input);
+                renderExecOutPin(n.id, "then");
+                renderExecOutPin(n.id, "else");
+            } else if (std.mem.eql(u8, n.type_name, "ForRange")) {
+                // Counted loop (flow-codegen#21, issue #194). Data inputs
+                // `start`/`end`/`step`; data OUTPUT `index`; exec OUTPUT
+                // `body` (the loop body's entry).
+                ne.beginPin(pinId(n.id, "start", .input), .input);
+                zgui.text("> start", .{});
+                ne.endPin();
+                recordPin(s, n.id, "start", .input);
+                ne.beginPin(pinId(n.id, "end", .input), .input);
+                zgui.text("> end", .{});
+                ne.endPin();
+                recordPin(s, n.id, "end", .input);
+                ne.beginPin(pinId(n.id, "step", .input), .input);
+                zgui.text("> step", .{});
+                ne.endPin();
+                recordPin(s, n.id, "step", .input);
+                ne.beginPin(pinId(n.id, "index", .output), .output);
+                zgui.text("index >", .{});
+                ne.endPin();
+                recordPin(s, n.id, "index", .output);
+                renderExecOutPin(n.id, "body");
+            } else if (std.mem.eql(u8, n.type_name, "While")) {
+                // Conditional loop (flow-codegen#21, issue #194). Data
+                // input `cond`; exec OUTPUT `body`.
+                ne.beginPin(pinId(n.id, "cond", .input), .input);
+                zgui.text("> cond", .{});
+                ne.endPin();
+                recordPin(s, n.id, "cond", .input);
+                renderExecOutPin(n.id, "body");
             }
             // Show extras as a compact hint (e.g. BinOp `op`, Literal
             // `value`) so the user can tell nodes apart.

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -3147,6 +3147,15 @@ fn deleteNode(s: *FlowDocState, id: u32) !void {
         try kept.append(a, e);
     }
     s.doc.edges = try kept.toOwnedSlice(a);
+    // Drop any exec edges touching the deleted node too — otherwise a
+    // dangling `exec_edges` entry survives the delete and corrupts the
+    // control flow on save (flow-codegen#8/#21, bugbot).
+    var kept_exec: std.ArrayList(flow_io.ExecEdge) = .empty;
+    for (s.doc.exec_edges) |x| {
+        if (x.from_node == id or x.to_node == id) continue;
+        try kept_exec.append(a, x);
+    }
+    s.doc.exec_edges = try kept_exec.toOwnedSlice(a);
     s.is_dirty = true;
 }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6557,6 +6557,35 @@ pub const FlowDocSubflowTests = struct {
     }
 };
 
+// ─── flow_doc: explicit exec-edge reconciliation (issues #193, #194) ─────
+
+/// Covers `flow_doc.isExplicitExecTarget` — the predicate that
+/// suppresses a contradictory *derived* exec arrow into a node that is
+/// already entered by an explicit `Branch`/loop control arrow.
+pub const FlowDocExecEdgeTests = struct {
+    test "isExplicitExecTarget flags only nodes that are exec-edge targets" {
+        const edges = [_]flow_io.ExecEdge{
+            .{ .from_node = 4, .from_pin = "then", .to_node = 6 },
+            .{ .from_node = 4, .from_pin = "else", .to_node = 7 },
+            .{ .from_node = 9, .from_pin = "body", .to_node = 10 },
+        };
+        // Targets (6, 7, 10) are entered by a control arrow — suppress
+        // their derived arrow.
+        try expect.toBeTrue(flow_doc.isExplicitExecTarget(&edges, 6));
+        try expect.toBeTrue(flow_doc.isExplicitExecTarget(&edges, 7));
+        try expect.toBeTrue(flow_doc.isExplicitExecTarget(&edges, 10));
+        // Source nodes and unrelated nodes keep the linear spine.
+        try expect.toBeTrue(!flow_doc.isExplicitExecTarget(&edges, 4));
+        try expect.toBeTrue(!flow_doc.isExplicitExecTarget(&edges, 9));
+        try expect.toBeTrue(!flow_doc.isExplicitExecTarget(&edges, 99));
+    }
+
+    test "isExplicitExecTarget is false for a flow with no exec edges" {
+        const none: []const flow_io.ExecEdge = &.{};
+        try expect.toBeTrue(!flow_doc.isExplicitExecTarget(none, 1));
+    }
+};
+
 // ─── flow_cycle: Subflow reference-cycle check (issue #159) ──────────────
 
 /// Covers `flow_cycle.detectCycle` (the pure DFS walk over the


### PR DESCRIPTION
Resolves #193 (Branch) and #194 (ForRange / While loops) — the editor now models the top-level `exec_edges` control-flow block that flow-codegen#8/#21 added to `.flow.jsonc`.

## Part A — round-trip `exec_edges` (data safety)

Before this PR, loading a Branch/loop flow into the editor and saving it **silently dropped the `exec_edges` block**, corrupting the control flow. Fixed in `src/flow_io.zig`:

- New `pub const ExecEdge = struct { from_node: u32, from_pin: []const u8, to_node: u32 }` (flat-field, mirroring the existing `Edge`; `to` is a *bare* node ref — the target is entered, not wired to an input pin).
- `FlowDoc.exec_edges: []ExecEdge = &.{}` alongside `edges`. Absent in source ⇒ empty slice.
- Parser (`parseExecEdges`) reads the `{ "from": { "node", "pin" }, "to": { "node" } }` shape; rejects malformed entries (`BadSchema`/`BadEdge`).
- Deterministic writer **byte-format-matched to flow-codegen's** `renderFlowJsonc` exec_edges emitter:
  - emitted **only when non-empty** (so pre-control-flow files round-trip byte-for-byte; the `edges` block grows a trailing comma only when an exec block follows — same as codegen).
  - sorted to match flow-codegen's `lessThanExecEdge`: by `from_node`, then exec pin **lexically** (`else` < `then`; `body` is the loops' only pin), then `to_node`.
  - shape `{ "from": { "node": N, "pin": "<pin>" }, "to": { "node": M } }`, 2-space indent — identical to codegen's output.

### Tests
- Branch + `exec_edges` round-trip: parse → assert entries → render → assert exact byte block (sorted `else` before `then`) → re-parse + re-render is byte-identical.
- Sort stability across deliberately-unsorted `body`/`then`/`else` input.
- **Absence preserved**: a no-exec_edges flow emits no `exec_edges` key and keeps `"edges": []` with no trailing comma.
- Malformed-entry rejection (non-array, missing `to`, missing pin, missing target node).

## Part B — render the control-flow nodes + their exec edges

`Branch`/`ForRange`/`While` fall into the editor's `.other` node kind. In `src/modules/flow_doc.zig` `renderNodeBody`'s `.other` arm:

- **Branch**: data input `cond`; exec outputs `then ▸` / `else ▸`.
- **ForRange**: data inputs `start`/`end`/`step`; data output `index`; exec output `body ▸`.
- **While**: data input `cond`; exec output `body ▸`.

Data pins use `pinId`/`recordPin` so data edges into `cond`/`start`/`end`/`step` and out of `index` draw and can be authored. The named exec outputs (`renderExecOutPin`) are **read-only** (not `recordPin`'d) — like the existing derived exec anchors — since authoring exec edges by dragging is a follow-up.

`renderExplicitExecEdges` draws each `exec_edge` as a thick **amber** control arrow (visually distinct from cyan data edges and the white derived spine) from the source's named exec-output pin to the target node's exec-in anchor.

### Derived-vs-explicit arrow reconciliation (#172)
A node that is the **target** of an `exec_edge` is entered by a branch/loop control arrow, not by the linear command spine. `renderExecEdges` now skips the derived arrow into any such node (`isExplicitExecTarget`), so the control flow isn't doubled/contradicted. Branch/loop nodes are `.other` (already off the command spine), so their outgoing flow never produces a stray derived arrow either.

## Out of scope (follow-ups)
- Palette **create** buttons for `.other` nodes — #192 (`addNode` has no `.other` path).
- **Authoring** exec edges by dragging — the named exec output pins are intentionally read-only this PR.

## Testing
`zig build test` → **424/424 pass**. `zig build` → clean (full GUI exe compiles, so `flow_doc.zig` builds in the GUI target).