### PR TITLE
feat(flow editor): palette create-buttons for .other node kinds (#192)

### DIFF
--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -400,6 +400,56 @@ pub fn setExtraValue(
     node.extras = out;
 }
 
+/// Append a fresh `.other`-kind node carrying `type_name` plus the seeded
+/// `default_extras`, returning the new node's id. The expression/control
+/// node kinds (`BinOp`, `Compare`, `Logic`, `Literal`, `Identifier`,
+/// `SetField`, `Branch`, `ForRange`, `While`, …) are all `.other`, so they
+/// can't route through `NodeKind.typeName()` (null for `.other`) — the
+/// editor names the type directly and seeds the one editable extra the
+/// inspector exposes via `otherFieldSpec`.
+///
+/// `default_extras` values must already be canonical JSON value text (the
+/// same shape `setExtraValue` / the inspector widgets write): a JSON
+/// string for `op`/`name`/`target` (`"add"`, `""`), a bare JSON literal
+/// for `Literal.value` (`0`). Each key + value is duped onto the doc arena
+/// so the caller's slices needn't outlive this call, and the extras stay
+/// sorted so the deterministic writer emits them unchanged. Control nodes
+/// (`Branch`/`ForRange`/`While`) pass an empty `default_extras` — their
+/// wiring is pins + exec edges, with no editable field.
+///
+/// Pure over `FlowDoc` (no editor/imgui dependency) so it's exercisable in
+/// the `zig build test` target, which excludes the zgui stack.
+pub fn appendOtherNode(
+    doc: *FlowDoc,
+    type_name: []const u8,
+    default_extras: []const KeyValue,
+) !u32 {
+    const a = doc.allocator();
+    const id = doc.nextNodeId();
+
+    // Place new nodes in a staggered cascade so they don't all stack on
+    // the origin — mirrors `flow_doc.addNode`.
+    const offset: f32 = @floatFromInt((doc.nodes.len % 8) * 30);
+    var node: Node = .{
+        .id = id,
+        .type_name = try a.dupe(u8, type_name),
+        .kind = .other,
+        .pos = .{ 40 + offset, 40 + offset },
+    };
+    for (default_extras) |kv| {
+        // `setExtraValue` dupes key + value onto `a` and keeps the slice
+        // sorted; seeding through it keeps the on-disk extras byte-identical
+        // to an inspector-edited node.
+        try setExtraValue(a, &node, kv.key, kv.value_text);
+    }
+
+    const out = try a.alloc(Node, doc.nodes.len + 1);
+    @memcpy(out[0..doc.nodes.len], doc.nodes);
+    out[doc.nodes.len] = node;
+    doc.nodes = out;
+    return id;
+}
+
 /// Decode a JSON-string `extras` value (e.g. `"add"`) back to its raw
 /// inner text for display in a text widget. When the stored value isn't
 /// a JSON string (a `Literal.value` may be a number or bool) the

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -2342,6 +2342,58 @@ fn renderNodePalette(s: *FlowDocState) void {
     zgui.sameLine(.{});
     if (zgui.button("+ Get/Set/Change Variable", .{})) addNode(s, .get_variable) catch |err| nodeAddErr(err);
 
+    // ── Expression / control section (issue #192) ──
+    // The value/expression/control node kinds are all `.other` — they
+    // render + inspect already, but `addNode` can't create them
+    // (`kind.typeName()` is null for `.other`). `addOtherNode` seeds an
+    // `.other` node with the one editable extra each kind's
+    // `flow_io.otherFieldSpec` exposes, so a fresh node is immediately
+    // valid + inspector-editable. Defaults are canonical JSON value text:
+    // a JSON string for `op`/`name`/`target`, a bare literal for `value`.
+    // Control nodes (Branch/ForRange/While) carry no editable field — their
+    // wiring is pins + exec edges (authoring those edges is #196).
+    zgui.spacing();
+    zgui.separator();
+
+    zgui.text("Math / Logic", .{});
+    if (zgui.button("+ BinOp", .{})) {
+        addOtherNode(s, "BinOp", &.{.{ .key = "op", .value_text = "\"add\"" }}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ Compare", .{})) {
+        addOtherNode(s, "Compare", &.{.{ .key = "op", .value_text = "\"eq\"" }}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ Logic", .{})) {
+        addOtherNode(s, "Logic", &.{.{ .key = "op", .value_text = "\"and\"" }}) catch |err| nodeAddErr(err);
+    }
+
+    zgui.text("Values", .{});
+    if (zgui.button("+ Literal", .{})) {
+        addOtherNode(s, "Literal", &.{.{ .key = "value", .value_text = "0" }}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ Identifier", .{})) {
+        addOtherNode(s, "Identifier", &.{.{ .key = "name", .value_text = "\"\"" }}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ SetField", .{})) {
+        addOtherNode(s, "SetField", &.{.{ .key = "target", .value_text = "\"\"" }}) catch |err| nodeAddErr(err);
+    }
+
+    zgui.text("Control", .{});
+    if (zgui.button("+ Branch", .{})) {
+        addOtherNode(s, "Branch", &.{}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ ForRange", .{})) {
+        addOtherNode(s, "ForRange", &.{}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ While", .{})) {
+        addOtherNode(s, "While", &.{}) catch |err| nodeAddErr(err);
+    }
+
     // Raw `Call` escape hatch (RFC §7) — surfaced separately so a user
     // who finds it has knowingly opted into raw Zig source rather than
     // mistaking it for a normal palette entry.
@@ -3124,6 +3176,26 @@ fn addNode(s: *FlowDocState, kind: flow_io.NodeKind) !void {
         .other => unreachable,
     }
     s.doc.nodes = try growNodes(a, s.doc.nodes, node);
+    s.needs_layout = true; // re-seed so the new node's pos is applied
+    s.is_dirty = true;
+}
+
+/// Palette path for the `.other`-kind expression/control nodes (`BinOp`,
+/// `Compare`, `Logic`, `Literal`, `Identifier`, `SetField`, `Branch`,
+/// `ForRange`, `While`). `addNode` can't reach these — it routes through
+/// `kind.typeName()`, which is null for `.other` — so this seeds an
+/// `.other` node with `type_name` plus the editable extras the inspector
+/// exposes via `flow_io.otherFieldSpec`, leaving the node immediately
+/// valid and inspector-editable. The heavy lifting (id allocation,
+/// staggered pos, arena-duped extras) lives in the pure
+/// `flow_io.appendOtherNode`; this only flips the editor's layout/dirty
+/// flags so the new node's position seeds onto the canvas.
+fn addOtherNode(
+    s: *FlowDocState,
+    type_name: []const u8,
+    default_extras: []const flow_io.KeyValue,
+) !void {
+    _ = try flow_io.appendOtherNode(&s.doc, type_name, default_extras);
     s.needs_layout = true; // re-seed so the new node's pos is applied
     s.is_dirty = true;
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5465,6 +5465,88 @@ pub const FlowIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"note\": \"keep me\"") != null);
     }
 
+    // ── appendOtherNode: palette create-buttons for `.other` kinds (#192) ──
+
+    test "appendOtherNode creates an .other node with the seeded op extra" {
+        const a = std.testing.allocator;
+        const src =
+            \\{ "event": { "type": "OnCreate" }, "nodes": [], "edges": [] }
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        const id = try flow_io.appendOtherNode(
+            &doc,
+            "Compare",
+            &.{.{ .key = "op", .value_text = "\"eq\"" }},
+        );
+
+        try expect.equal(doc.nodes.len, @as(usize, 1));
+        const n = doc.nodes[0];
+        try expect.equal(n.id, id);
+        try expect.toBeTrue(n.kind == .other);
+        try expect.toBeTrue(std.mem.eql(u8, n.type_name, "Compare"));
+        // The seeded `op` is recognised by the inspector's field spec and
+        // present as canonical JSON value text.
+        try expect.toBeTrue(flow_io.otherFieldSpec(n.type_name).?.widget == .op_combo);
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.extraValue(n, "op").?, "\"eq\""));
+    }
+
+    test "appendOtherNode allocates fresh ids above the existing max" {
+        const a = std.testing.allocator;
+        const src =
+            \\{ "event": { "type": "OnCreate" },
+            \\  "nodes": [ { "id": 7, "type": "Literal", "value": 1, "pos": [0, 0] } ],
+            \\  "edges": [] }
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        const id1 = try flow_io.appendOtherNode(&doc, "Branch", &.{});
+        const id2 = try flow_io.appendOtherNode(&doc, "While", &.{});
+        // Ids climb above the highest pre-existing id (7) and don't collide.
+        try expect.toBeTrue(id1 > 7);
+        try expect.toBeTrue(id2 > id1);
+        // Control nodes carry no editable extra.
+        try expect.equal(doc.nodes[doc.nodes.len - 1].extras.len, @as(usize, 0));
+    }
+
+    test "an appended .other node round-trips through render with its extra" {
+        const a = std.testing.allocator;
+        const src =
+            \\{ "event": { "type": "OnCreate" }, "nodes": [], "edges": [] }
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        _ = try flow_io.appendOtherNode(
+            &doc,
+            "BinOp",
+            &.{.{ .key = "op", .value_text = "\"add\"" }},
+        );
+        _ = try flow_io.appendOtherNode(
+            &doc,
+            "Literal",
+            &.{.{ .key = "value", .value_text = "0" }},
+        );
+
+        const text1 = try flow_io.render(a, doc);
+        defer a.free(text1);
+
+        // The created nodes (type + seeded value) survive the writer.
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"type\": \"BinOp\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"op\": \"add\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"type\": \"Literal\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"value\": 0") != null);
+
+        // And a re-parse + re-render is byte-identical (deterministic).
+        var doc2 = try flow_io.parse(a, text1);
+        defer doc2.deinit();
+        const text2 = try flow_io.render(a, doc2);
+        defer a.free(text2);
+        try expect.toBeTrue(std.mem.eql(u8, text1, text2));
+    }
+
     test "string value text decodes and re-encodes round-trip" {
         const a = std.testing.allocator;
         const decoded = try flow_io.decodeStringValue(a, "\"Position\"");


### PR DESCRIPTION
## What

Adds palette create-buttons for the `.other`-kind flow node types so a full data-flow graph can be authored in-editor instead of hand-editing `.flow.jsonc`. Resolves #192.

These nodes already **render** (pins draw in `renderNodeBody`'s `.other` arm) and **inspect** (op/value editable via `flow_io.otherFieldSpec` + the `op_combo`/`literal`/`text` widgets) — they just couldn't be **created**: `addNode` routes through `NodeKind.typeName()`, which is `null` for `.other` (`.other => unreachable`).

## How

- **`flow_io.appendOtherNode(doc, type_name, default_extras) !u32`** — pure over `FlowDoc` (no editor/imgui dependency, so it's exercisable in the `zig build test` target which excludes the zgui stack). Allocates a fresh id, dupes `type_name`, sets `kind = .other`, staggers `pos`, and seeds each default extra via `setExtraValue` (arena-duped, sorted, deterministic writer-friendly).
- **`flow_doc.addOtherNode(s, type_name, default_extras)`** — thin wrapper that delegates to `appendOtherNode` and flips `needs_layout` / `is_dirty`.
- **Palette buttons** grouped for readability, matching the existing `zgui.button` + `nodeAddErr` style:
  - **Math / Logic** — `BinOp` (`op: "add"`), `Compare` (`op: "eq"`), `Logic` (`op: "and"`)
  - **Values** — `Literal` (`value: 0`), `Identifier` (`name: ""`), `SetField` (`target: ""`)
  - **Control** — `Branch`, `ForRange`, `While` (no extras — wiring is pins + exec edges)

Defaults are canonical JSON value text (JSON string for `op`/`name`/`target`, bare literal for `value`) so a created node is byte-identical to an inspector-edited one and immediately valid + inspector-editable.

## Tests (`src/tests.zig`)

- `appendOtherNode` creates an `.other` node with the right `type_name`, `kind == .other`, and the seeded extra (`Compare` → `op == "eq"`).
- Fresh ids climb above the existing max; control nodes carry no extra.
- A created node round-trips through `render` (type + `op`/`value` survive) and re-parse + re-render is byte-identical.

`zig build test` → **427 of 427 passed**. `zig build` (full GUI exe) → clean.

## Out of scope

Authoring exec **edges** by dragging is #196. This issue is only about being able to **add** the nodes; a created Branch/loop still needs its exec edges hand-wired (or via #196 later).