### PR TITLE
feat(flow editor): render Switch nodes (#199)

### DIFF
--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -713,6 +713,65 @@ fn controlExecPinNames(type_name: []const u8) []const []const u8 {
     return &.{};
 }
 
+/// Upper bound on the number of `case<N>` exec outputs a `Switch` will
+/// render, so a hand-edited file with an absurd case index can't ask the
+/// editor to draw thousands of pins.
+const max_case_outputs: u32 = 64;
+
+/// Static `case0`..`case<max_case_outputs-1>` pin-name literals. Built at
+/// comptime so each rendered/recorded `case<N>` pin name is a 'static
+/// slice that outlives the frame — `recordExecOutPin` borrows the name
+/// into the pin registry, so a per-frame formatted string would dangle
+/// (mirrors the `arg_pin_names` static table the Call node uses).
+const case_pin_names: [max_case_outputs][]const u8 = blk: {
+    @setEvalBranchQuota(max_case_outputs * 2000);
+    var names: [max_case_outputs][]const u8 = undefined;
+    for (0..max_case_outputs) |i| {
+        names[i] = std.fmt.comptimePrint("case{d}", .{i});
+    }
+    break :blk names;
+};
+
+/// Parse a `case<N>` exec-pin name to its index `N`, or null if `pin`
+/// isn't a well-formed `case<N>` name (`default`, `then`, garbage). The
+/// digit run must be non-empty and all-decimal — matching the shape
+/// `execPinValidFor` accepts. Overflow (an absurdly long digit run)
+/// yields null rather than wrapping.
+pub fn caseIndexOf(pin: []const u8) ?u32 {
+    if (!std.mem.startsWith(u8, pin, "case")) return null;
+    const digits = pin[4..];
+    if (digits.len == 0) return null;
+    return std.fmt.parseInt(u32, digits, 10) catch null;
+}
+
+/// How many `case<N>` exec outputs a `Switch` node should render, given
+/// the document's exec edges. A Switch's cases are dynamic, so we can't
+/// statically enumerate them; instead we derive the count from which
+/// `case<N>` arms are already wired *from this node*, then add one spare
+/// slot so a fresh (or just-extended) Switch is always wireable.
+///
+/// Rule: count = (highest wired `case<N>` index + 1) + 1 spare. The
+/// rendered case pins are then `case0` .. `case<count-1>`, plus a
+/// `default` the caller always draws. Consequences:
+///   - No exec edges → count 1 → renders `case0` (the spare) + default,
+///     so a brand-new Switch is immediately wireable.
+///   - `case0` + `case2` wired (sparse) → highest is 2 → count 4 →
+///     renders `case0`,`case1`,`case2` (filling the gap) + `case3`
+///     (spare) + default.
+/// Bounded by `max_case_outputs` so a hand-edited file with an absurd
+/// index can't ask the editor to draw thousands of pins.
+pub fn switchCaseOutputCount(node_id: u32, exec_edges: []const flow_io.ExecEdge) u32 {
+    var highest: ?u32 = null;
+    for (exec_edges) |x| {
+        if (x.from_node != node_id) continue;
+        const idx = caseIndexOf(x.from_pin) orelse continue;
+        if (highest == null or idx > highest.?) highest = idx;
+    }
+    const wired_span: u32 = if (highest) |h| h + 1 else 0;
+    const count = wired_span + 1; // + one spare empty case slot
+    return @min(count, max_case_outputs);
+}
+
 /// Whether `pin` is a legal exec-output pin name on a node of
 /// `type_name`. Branch/loop pins are matched against
 /// `controlExecPinNames`; `Switch` arm pins (`case<N>` / `default`)
@@ -1876,6 +1935,27 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
                 ne.endPin();
                 recordPin(s, n.id, "cond", .input);
                 renderExecOutPin(s, n.id, "body");
+            } else if (std.mem.eql(u8, n.type_name, "Switch")) {
+                // Multi-way control (flow-codegen#22, issue #199). One
+                // data INPUT `selector` (the value switched on, wired
+                // like Branch's `cond`); N `case<N>` + a `default` exec
+                // OUTPUT pin, each an amber control-flow source drawn
+                // like Branch's `then`/`else` (draggable via #196).
+                //
+                // Cases are dynamic, so the rendered `case<N>` count is
+                // derived from the exec edges already wired *from* this
+                // node, plus one spare slot (so a fresh Switch with no
+                // edges still shows `case0` to wire into) — see
+                // `switchCaseOutputCount`. `default` always renders.
+                ne.beginPin(pinId(n.id, "selector", .input), .input);
+                zgui.text("> selector", .{});
+                ne.endPin();
+                recordPin(s, n.id, "selector", .input);
+                const case_count = switchCaseOutputCount(n.id, s.doc.exec_edges);
+                for (0..case_count) |i| {
+                    renderExecOutPin(s, n.id, case_pin_names[i]);
+                }
+                renderExecOutPin(s, n.id, "default");
             }
             // Show extras as a compact hint (e.g. BinOp `op`, Literal
             // `value`) so the user can tell nodes apart.
@@ -2621,6 +2701,14 @@ fn renderNodePalette(s: *FlowDocState) void {
     zgui.sameLine(.{});
     if (zgui.button("+ While", .{})) {
         addOtherNode(s, "While", &.{}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    // Switch (flow-codegen#22, issue #199). Like the other control
+    // nodes it carries no editable field — its arms are pins + exec
+    // edges. A fresh Switch has no exec edges, so the renderer shows a
+    // single spare `case0` + `default` until the user wires more.
+    if (zgui.button("+ Switch", .{})) {
+        addOtherNode(s, "Switch", &.{}) catch |err| nodeAddErr(err);
     }
 
     // Raw `Call` escape hatch (RFC §7) — surfaced separately so a user

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -767,8 +767,12 @@ pub fn switchCaseOutputCount(node_id: u32, exec_edges: []const flow_io.ExecEdge)
         const idx = caseIndexOf(x.from_pin) orelse continue;
         if (highest == null or idx > highest.?) highest = idx;
     }
-    const wired_span: u32 = if (highest) |h| h + 1 else 0;
-    const count = wired_span + 1; // + one spare empty case slot
+    // Saturating adds: a hand-edited `case<N>` pin can parse to a huge
+    // index (execPinValidFor accepts any `case<digits>`), and an
+    // unchecked `+ 1` would panic in safe builds before the clamp runs
+    // (bugbot). `+|` saturates at u32 max, then `@min` clamps to the cap.
+    const wired_span: u32 = if (highest) |h| h +| 1 else 0;
+    const count = wired_span +| 1; // + one spare empty case slot
     return @min(count, max_case_outputs);
 }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6778,6 +6778,72 @@ pub const FlowDocExecEdgeTests = struct {
                 error.NotAControlSource,
         );
     }
+
+    // ── Switch case-output derivation (#199) ──
+    //
+    // A Switch's cases are dynamic, so the editor derives how many
+    // `case<N>` exec outputs to draw from the exec edges already wired
+    // from the node, plus one spare slot, plus an always-present
+    // `default`. `switchCaseOutputCount` returns just the `case<N>`
+    // count (the renderer draws `case0`..`case<count-1>` then default).
+
+    test "caseIndexOf parses well-formed case pins and rejects others" {
+        try expect.toBeTrue(flow_doc.caseIndexOf("case0").? == 0);
+        try expect.toBeTrue(flow_doc.caseIndexOf("case7").? == 7);
+        try expect.toBeTrue(flow_doc.caseIndexOf("case42").? == 42);
+        // Non-case exec pins and garbage yield null.
+        try expect.toBeTrue(flow_doc.caseIndexOf("default") == null);
+        try expect.toBeTrue(flow_doc.caseIndexOf("then") == null);
+        try expect.toBeTrue(flow_doc.caseIndexOf("case") == null);
+        try expect.toBeTrue(flow_doc.caseIndexOf("casex") == null);
+        try expect.toBeTrue(flow_doc.caseIndexOf("case1x") == null);
+    }
+
+    test "switchCaseOutputCount: no exec edges yields just the spare case0" {
+        const none: []const flow_io.ExecEdge = &.{};
+        // A brand-new Switch (no wired arms) shows one spare `case0`
+        // (plus `default`, which the renderer always adds).
+        try expect.toBeTrue(flow_doc.switchCaseOutputCount(5, none) == 1);
+    }
+
+    test "switchCaseOutputCount: contiguous wired cases get one spare" {
+        // case0 + case1 wired → renders case0, case1, case2 (spare).
+        const edges = [_]flow_io.ExecEdge{
+            .{ .from_node = 5, .from_pin = "case0", .to_node = 6 },
+            .{ .from_node = 5, .from_pin = "case1", .to_node = 7 },
+        };
+        try expect.toBeTrue(flow_doc.switchCaseOutputCount(5, &edges) == 3);
+    }
+
+    test "switchCaseOutputCount: sparse wired cases fill the gap plus a spare" {
+        // case0 + case2 wired (case1 unwired) → highest is 2 → renders
+        // case0, case1, case2 + case3 (spare) = 4 case outputs.
+        const edges = [_]flow_io.ExecEdge{
+            .{ .from_node = 5, .from_pin = "case0", .to_node = 6 },
+            .{ .from_node = 5, .from_pin = "case2", .to_node = 8 },
+        };
+        try expect.toBeTrue(flow_doc.switchCaseOutputCount(5, &edges) == 4);
+    }
+
+    test "switchCaseOutputCount: ignores edges from other nodes and non-case pins" {
+        const edges = [_]flow_io.ExecEdge{
+            // Another Switch's case — must not bleed into node 5's count.
+            .{ .from_node = 9, .from_pin = "case3", .to_node = 6 },
+            // node 5's `default` arm is not a `case<N>`, so it doesn't
+            // raise the case count.
+            .{ .from_node = 5, .from_pin = "default", .to_node = 7 },
+        };
+        // node 5 has no wired `case<N>` → just the spare case0.
+        try expect.toBeTrue(flow_doc.switchCaseOutputCount(5, &edges) == 1);
+    }
+
+    test "switchCaseOutputCount: clamps an absurd hand-edited index" {
+        const edges = [_]flow_io.ExecEdge{
+            .{ .from_node = 5, .from_pin = "case100000", .to_node = 6 },
+        };
+        // Bounded so a pathological file can't request thousands of pins.
+        try expect.toBeTrue(flow_doc.switchCaseOutputCount(5, &edges) == 64);
+    }
 };
 
 // ─── flow_cycle: Subflow reference-cycle check (issue #159) ──────────────

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6825,6 +6825,16 @@ pub const FlowDocExecEdgeTests = struct {
         try expect.toBeTrue(flow_doc.switchCaseOutputCount(5, &edges) == 4);
     }
 
+    test "switchCaseOutputCount: huge case index saturates, never overflows (bugbot)" {
+        // A hand-edited `case<near-u32-max>` pin must not overflow the
+        // `+ 1` adds — that would panic in safe builds before the clamp.
+        // Reaching this assertion (no panic) IS the regression guard.
+        const edges = [_]flow_io.ExecEdge{
+            .{ .from_node = 5, .from_pin = "case4294967295", .to_node = 6 },
+        };
+        try expect.toBeTrue(flow_doc.switchCaseOutputCount(5, &edges) <= 64);
+    }
+
     test "switchCaseOutputCount: ignores edges from other nodes and non-case pins" {
         const edges = [_]flow_io.ExecEdge{
             // Another Switch's case — must not bleed into node 5's count.


### PR DESCRIPTION
Resolves #199.

## What
flow-codegen#22 added the `Switch` node (one `selector` data input + N `case<N>` exec outputs + a `default` exec output) *after* the editor's control-flow rendering pass (#195/#193/#194), so the GUI fell into the `.other` node kind drawing no pins. This adds a `Switch` branch to `renderNodeBody`'s `.other` arm, mirroring the `Branch`/loop rendering:

- **`selector`** — data INPUT pin (same `pinId`/`recordPin` path as Branch's `cond`).
- **`case<N>` + `default`** — named exec OUTPUT pins via `renderExecOutPin`, so they are amber control-flow sources and become draggable through #196's machinery (which already recognizes `case<N>`/`default` by shape).

## Case-count rule (the one design choice)
A Switch's cases are dynamic, so the rendered `case<N>` count is derived from the exec edges already wired *from this node* by `switchCaseOutputCount`:

> count = (highest wired `case<N>` index + 1) + **one spare** slot; `default` always renders.

- No exec edges → `case0` (spare) + `default` — a fresh Switch is immediately wireable.
- `case0`+`case1` wired → `case0`,`case1`,`case2` (spare) + `default`.
- Sparse (`case0`+`case2`) → fills the gap: `case0`,`case1`,`case2` + `case3` (spare) + `default`.

Bounded by `max_case_outputs` (64) so a hand-edited file with an absurd index can't request thousands of pins. `case<N>` names come from a comptime-built static table so the borrowed pin-name slices outlive the frame (mirrors the Call node's `arg_pin_names`).

## Palette
#192 added `+ Branch`/`+ ForRange`/`+ While` to the Control group but **not** `+ Switch` — added it here (no default extras, like the other control nodes).

## Tests
Factored the case-index logic into pure helpers and unit-tested them in `src/tests.zig` (`FlowDocExecEdgeTests`):
- `caseIndexOf` — parses `case<N>`, rejects `default`/`then`/`case`/`casex`/`case1x`.
- `switchCaseOutputCount` — no edges → spare `case0`; contiguous +1 spare; sparse gap-fill + spare; cross-node and non-`case` pins ignored; absurd index clamped to 64.

`zig build test` → 440/440 passed. `zig build` (full GUI exe) → green.