### PR TITLE
feat(flow editor): comment / group frames (#188)

### DIFF
--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -878,8 +878,19 @@ pub fn parse(child_allocator: std.mem.Allocator, raw: []const u8) !FlowDoc {
         for (doc.comments) |c| {
             if (c.id > doc.max_comment_id) doc.max_comment_id = c.id;
         }
-        for (doc.comments) |*c| {
-            if (c.id == 0) c.id = doc.nextCommentId();
+        // Assign a fresh id to any unassigned (`0`) OR duplicate entry —
+        // two comments sharing an id would alias to a single node-editor
+        // frame and bleed drag/resize/label state. `max_comment_id` is
+        // seeded above, so `nextCommentId()` can't collide (bugbot).
+        for (doc.comments, 0..) |*c, i| {
+            var dup = c.id == 0;
+            if (!dup) for (doc.comments[0..i]) |prev| {
+                if (prev.id == c.id) {
+                    dup = true;
+                    break;
+                }
+            };
+            if (dup) c.id = doc.nextCommentId();
         }
     }
 

--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -636,6 +636,15 @@ pub const ExecEdge = struct {
 /// `comments` block of the `.flow.jsonc`; flow-codegen ignores the key
 /// (`ignore_unknown_fields = true`), so it has no codegen effect. `color`
 /// is a packed `0xRRGGBBAA` value — null → the editor's default frame tint.
+///
+/// `id` is a stable, monotonically-assigned identifier (labelle-gui#188)
+/// used to key the editor's group node so the editor's per-frame
+/// drag/resize state follows the *frame*, not its slice index. Deleting a
+/// non-last comment shifts indices, so an index-derived editor id would
+/// make a surviving frame inherit the deleted frame's editor state —
+/// hence a stable id. Persisted in the `comments` block; a value of `0`
+/// means "unassigned" (a pre-id file, or a default-constructed entry) and
+/// the loader assigns a fresh id on load so older files stay compatible.
 pub const Comment = struct {
     text: []const u8 = "",
     x: f32 = 0,
@@ -643,6 +652,7 @@ pub const Comment = struct {
     w: f32 = 200,
     h: f32 = 120,
     color: ?u32 = null,
+    id: u32 = 0,
 };
 
 /// The flow's entry point. `type` is a lifecycle event name (e.g.
@@ -724,6 +734,11 @@ pub const FlowDoc = struct {
     comments: []Comment = &.{},
     /// Highest node id seen — the editor allocates fresh ids above this.
     max_node_id: u32 = 0,
+    /// Highest comment id seen (labelle-gui#188). Comment ids live in their
+    /// own namespace (they're not node ids), so they get their own
+    /// monotonic counter. Seeded from the loaded `comments` block and
+    /// bumped by `nextCommentId` so a fresh frame never reuses an id.
+    max_comment_id: u32 = 0,
 
     pub fn deinit(self: *FlowDoc) void {
         const child = self.arena.child_allocator;
@@ -740,6 +755,15 @@ pub const FlowDoc = struct {
     pub fn nextNodeId(self: *FlowDoc) u32 {
         self.max_node_id += 1;
         return self.max_node_id;
+    }
+
+    /// Allocate a fresh comment id one above the current maximum
+    /// (labelle-gui#188). Bumps `max_comment_id` so successive calls — and
+    /// any id-on-load assignment — never collide. Ids are 1-based; `0`
+    /// stays reserved as the "unassigned" sentinel.
+    pub fn nextCommentId(self: *FlowDoc) u32 {
+        self.max_comment_id += 1;
+        return self.max_comment_id;
     }
 };
 
@@ -848,6 +872,15 @@ pub fn parse(child_allocator: std.mem.Allocator, raw: []const u8) !FlowDoc {
     if (root.get("comments")) |v| {
         if (v != .array) return ParseError.BadSchema;
         doc.comments = try parseComments(a, v.array);
+        // Seed the comment-id counter from the highest persisted id, then
+        // backfill ids for any pre-id / unassigned (`0`) entries so every
+        // comment carries a stable, unique editor id (labelle-gui#188).
+        for (doc.comments) |c| {
+            if (c.id > doc.max_comment_id) doc.max_comment_id = c.id;
+        }
+        for (doc.comments) |*c| {
+            if (c.id == 0) c.id = doc.nextCommentId();
+        }
     }
 
     return doc;
@@ -1191,6 +1224,9 @@ fn parseComments(a: std.mem.Allocator, arr: std.json.Array) ![]Comment {
                 c.color = jsonIntId(v) orelse return ParseError.BadSchema;
             }
         }
+        // Stable editor id (labelle-gui#188). Absent / `0` → "unassigned";
+        // the caller fills it in on load so pre-id files stay compatible.
+        if (o.get("id")) |v| c.id = jsonIntId(v) orelse return ParseError.BadSchema;
         try out.append(a, c);
     }
     return out.toOwnedSlice(a);
@@ -1559,6 +1595,12 @@ pub fn render(child_allocator: std.mem.Allocator, doc: FlowDoc) ![]u8 {
             try writeCoord(a, &out, c.h);
             if (c.color) |col| {
                 try out.print(a, ", \"color\": {d}", .{col});
+            }
+            // Stable editor id (labelle-gui#188). Emitted only when
+            // assigned (`!= 0`) so a hand-authored file with no ids still
+            // round-trips identically until the editor touches it.
+            if (c.id != 0) {
+                try out.print(a, ", \"id\": {d}", .{c.id});
             }
             try out.appendSlice(a, " }");
             if (i + 1 < doc.comments.len) try out.append(a, ',');
@@ -2071,16 +2113,21 @@ test "comments round-trip preserves editor-only frames" {
     try std.testing.expectEqual(@as(?u32, null), doc.comments[0].color);
     try std.testing.expectEqualStrings("cleanup", doc.comments[1].text);
     try std.testing.expectEqual(@as(?u32, 4278190335), doc.comments[1].color);
+    // The source carried no `id`s, so the loader assigned fresh ones in
+    // order (labelle-gui#188) — the editor needs a stable per-frame key.
+    try std.testing.expectEqual(@as(u32, 1), doc.comments[0].id);
+    try std.testing.expectEqual(@as(u32, 2), doc.comments[1].id);
 
     const text = try render(std.testing.allocator, doc);
     defer std.testing.allocator.free(text);
 
     // The writer emits the block in insertion order, geometry as bare
-    // integers, with `color` only on the entry that carries one.
+    // integers, with `color` only on the entry that carries one and the
+    // load-assigned `id` last.
     const expected =
         \\  "comments": [
-        \\    { "text": "spawn logic", "x": 40, "y": 40, "w": 220, "h": 140 },
-        \\    { "text": "cleanup", "x": 300, "y": 80, "w": 180, "h": 100, "color": 4278190335 }
+        \\    { "text": "spawn logic", "x": 40, "y": 40, "w": 220, "h": 140, "id": 1 },
+        \\    { "text": "cleanup", "x": 300, "y": 80, "w": 180, "h": 100, "color": 4278190335, "id": 2 }
         \\  ]
     ;
     try std.testing.expect(std.mem.indexOf(u8, text, expected) != null);

--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -630,6 +630,21 @@ pub const ExecEdge = struct {
     to_node: u32,
 };
 
+/// A purely-cosmetic comment / group frame (labelle-gui#188). Editor-only
+/// annotation: a labeled, translucent rounded rectangle drawn *behind* the
+/// nodes at `x`/`y` with size `w`/`h`. Persisted in the top-level
+/// `comments` block of the `.flow.jsonc`; flow-codegen ignores the key
+/// (`ignore_unknown_fields = true`), so it has no codegen effect. `color`
+/// is a packed `0xRRGGBBAA` value — null → the editor's default frame tint.
+pub const Comment = struct {
+    text: []const u8 = "",
+    x: f32 = 0,
+    y: f32 = 0,
+    w: f32 = 200,
+    h: f32 = 120,
+    color: ?u32 = null,
+};
+
 /// The flow's entry point. `type` is a lifecycle event name (e.g.
 /// `OnCreate`) or `OnCall` for a subgraph (RFC §3). `arg_entity` and any
 /// other event keys are captured in `extras` so they round-trip.
@@ -700,6 +715,13 @@ pub const FlowDoc = struct {
     /// `"exec_edges": []`; the writer emits the key only when non-empty so
     /// pre-control-flow files round-trip byte-for-byte.
     exec_edges: []ExecEdge = &.{},
+    /// Editor-only comment / group frames (labelle-gui#188). Empty for every
+    /// flow that declares none — the default and the only shape that
+    /// existed before comment frames. Absence in the source file is
+    /// indistinguishable from `"comments": []`; the writer emits the key
+    /// only when non-empty so pre-comment files round-trip byte-for-byte.
+    /// flow-codegen ignores the key, so it has no codegen effect.
+    comments: []Comment = &.{},
     /// Highest node id seen — the editor allocates fresh ids above this.
     max_node_id: u32 = 0,
 
@@ -818,6 +840,14 @@ pub fn parse(child_allocator: std.mem.Allocator, raw: []const u8) !FlowDoc {
     if (root.get("exec_edges")) |v| {
         if (v != .array) return ParseError.BadSchema;
         doc.exec_edges = try parseExecEdges(a, v.array);
+    }
+
+    // ── comments ── (labelle-gui#188) Editor-only comment / group frames.
+    // Absent → empty slice; the writer then omits the key so the file
+    // round-trips byte-for-byte. flow-codegen ignores the key entirely.
+    if (root.get("comments")) |v| {
+        if (v != .array) return ParseError.BadSchema;
+        doc.comments = try parseComments(a, v.array);
     }
 
     return doc;
@@ -1136,6 +1166,36 @@ fn parseExecEdges(a: std.mem.Allocator, arr: std.json.Array) ![]ExecEdge {
     return out.toOwnedSlice(a);
 }
 
+/// Parse the top-level `comments` array (labelle-gui#188). Each entry is
+/// `{ "text": "...", "x": N, "y": N, "w": N, "h": N, "color"?: N }`. `text`
+/// defaults to empty; the geometry fields fall back to the `Comment`
+/// defaults when absent; `color` is an optional packed `0xRRGGBBAA`.
+fn parseComments(a: std.mem.Allocator, arr: std.json.Array) ![]Comment {
+    var out: std.ArrayList(Comment) = .empty;
+    for (arr.items) |item| {
+        if (item != .object) return ParseError.BadSchema;
+        const o = item.object;
+        var c: Comment = .{};
+        if (o.get("text")) |t| {
+            if (t != .string) return ParseError.BadSchema;
+            c.text = try a.dupe(u8, t.string);
+        }
+        if (o.get("x")) |v| c.x = jsonNumberAsF32(v) orelse return ParseError.BadSchema;
+        if (o.get("y")) |v| c.y = jsonNumberAsF32(v) orelse return ParseError.BadSchema;
+        if (o.get("w")) |v| c.w = jsonNumberAsF32(v) orelse return ParseError.BadSchema;
+        if (o.get("h")) |v| c.h = jsonNumberAsF32(v) orelse return ParseError.BadSchema;
+        if (o.get("color")) |v| {
+            if (v == .null) {
+                c.color = null;
+            } else {
+                c.color = jsonIntId(v) orelse return ParseError.BadSchema;
+            }
+        }
+        try out.append(a, c);
+    }
+    return out.toOwnedSlice(a);
+}
+
 /// Read a JSON number expected to be a non-negative `u32` node id.
 /// Accepts a plain integer, and also a float (or `number_string`) that
 /// has no fractional part — hand-authored files and exporters often
@@ -1427,10 +1487,14 @@ pub fn render(child_allocator: std.mem.Allocator, doc: FlowDoc) ![]u8 {
     // flow-codegen's writer (`renderFlowJsonc` → the `flow.exec_edges.len
     // == 0` branch).
     const has_exec = doc.exec_edges.len > 0;
+    const has_comments = doc.comments.len > 0;
+    // `edges` keeps a trailing comma when *any* block follows it; `exec_edges`
+    // keeps one only when `comments` follows.
+    const edges_trailer: []const u8 = if (has_exec or has_comments) "],\n" else "]\n";
     try out.appendSlice(a, indent_unit);
     try out.appendSlice(a, "\"edges\": [");
     if (doc.edges.len == 0) {
-        try out.appendSlice(a, if (has_exec) "],\n" else "]\n");
+        try out.appendSlice(a, edges_trailer);
     } else {
         try out.append(a, '\n');
         for (doc.edges, 0..) |e, i| {
@@ -1444,7 +1508,7 @@ pub fn render(child_allocator: std.mem.Allocator, doc: FlowDoc) ![]u8 {
             try out.append(a, '\n');
         }
         try out.appendSlice(a, indent_unit);
-        try out.appendSlice(a, if (has_exec) "],\n" else "]\n");
+        try out.appendSlice(a, edges_trailer);
     }
 
     // exec_edges (flow-codegen#8, #21) — control-flow edges. Emitted only
@@ -1467,6 +1531,37 @@ pub fn render(child_allocator: std.mem.Allocator, doc: FlowDoc) ![]u8 {
             try writeJsonString(a, &out, x.from_pin);
             try out.print(a, " }}, \"to\": {{ \"node\": {d} }} }}", .{x.to_node});
             if (i + 1 < sorted.len) try out.append(a, ',');
+            try out.append(a, '\n');
+        }
+        try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, if (has_comments) "],\n" else "]\n");
+    }
+
+    // comments (labelle-gui#188) — editor-only comment / group frames.
+    // Emitted only when non-empty, in insertion order (the editor appends
+    // new frames at the end, so a re-save is diff-clean). Each entry is
+    // `{ "text": "...", "x": N, "y": N, "w": N, "h": N }` plus an optional
+    // `"color"` packed `0xRRGGBBAA`. flow-codegen ignores this key.
+    if (has_comments) {
+        try out.appendSlice(a, indent_unit);
+        try out.appendSlice(a, "\"comments\": [\n");
+        for (doc.comments, 0..) |c, i| {
+            try out.appendSlice(a, indent_unit ** 2);
+            try out.appendSlice(a, "{ \"text\": ");
+            try writeJsonString(a, &out, c.text);
+            try out.appendSlice(a, ", \"x\": ");
+            try writeCoord(a, &out, c.x);
+            try out.appendSlice(a, ", \"y\": ");
+            try writeCoord(a, &out, c.y);
+            try out.appendSlice(a, ", \"w\": ");
+            try writeCoord(a, &out, c.w);
+            try out.appendSlice(a, ", \"h\": ");
+            try writeCoord(a, &out, c.h);
+            if (c.color) |col| {
+                try out.print(a, ", \"color\": {d}", .{col});
+            }
+            try out.appendSlice(a, " }");
+            if (i + 1 < doc.comments.len) try out.append(a, ',');
             try out.append(a, '\n');
         }
         try out.appendSlice(a, indent_unit);
@@ -1947,6 +2042,151 @@ test "exec_edges parser rejects malformed entries" {
     try std.testing.expectError(ParseError.BadEdge, parse(std.testing.allocator,
         \\{ "nodes": [], "edges": [], "exec_edges": [ { "from": { "node": 1, "pin": "then" }, "to": {} } ] }
     ));
+}
+
+test "comments round-trip preserves editor-only frames" {
+    // A flow carrying a top-level `comments` block (labelle-gui#188) must
+    // round-trip it — a save that drops comments loses the user's
+    // annotations. The block is editor metadata; flow-codegen ignores it.
+    const src =
+        \\{
+        \\  "event": { "type": "OnCreate" },
+        \\  "nodes": [],
+        \\  "edges": [],
+        \\  "comments": [
+        \\    { "text": "spawn logic", "x": 40, "y": 40, "w": 220, "h": 140 },
+        \\    { "text": "cleanup", "x": 300, "y": 80, "w": 180, "h": 100, "color": 4278190335 }
+        \\  ]
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), doc.comments.len);
+    try std.testing.expectEqualStrings("spawn logic", doc.comments[0].text);
+    try std.testing.expectEqual(@as(f32, 40), doc.comments[0].x);
+    try std.testing.expectEqual(@as(f32, 40), doc.comments[0].y);
+    try std.testing.expectEqual(@as(f32, 220), doc.comments[0].w);
+    try std.testing.expectEqual(@as(f32, 140), doc.comments[0].h);
+    try std.testing.expectEqual(@as(?u32, null), doc.comments[0].color);
+    try std.testing.expectEqualStrings("cleanup", doc.comments[1].text);
+    try std.testing.expectEqual(@as(?u32, 4278190335), doc.comments[1].color);
+
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+
+    // The writer emits the block in insertion order, geometry as bare
+    // integers, with `color` only on the entry that carries one.
+    const expected =
+        \\  "comments": [
+        \\    { "text": "spawn logic", "x": 40, "y": 40, "w": 220, "h": 140 },
+        \\    { "text": "cleanup", "x": 300, "y": 80, "w": 180, "h": 100, "color": 4278190335 }
+        \\  ]
+    ;
+    try std.testing.expect(std.mem.indexOf(u8, text, expected) != null);
+
+    // Round-trip stability: re-parse + re-render is byte-identical and the
+    // frames survive unchanged.
+    var doc2 = try parse(std.testing.allocator, text);
+    defer doc2.deinit();
+    try std.testing.expectEqual(@as(usize, 2), doc2.comments.len);
+    const text2 = try render(std.testing.allocator, doc2);
+    defer std.testing.allocator.free(text2);
+    try std.testing.expectEqualStrings(text, text2);
+}
+
+test "absence of comments is preserved (no key emitted)" {
+    // A flow with no comment frames must NOT gain a `comments` key —
+    // pre-comment files round-trip byte-for-byte. Absence in the source
+    // is indistinguishable from `"comments": []`.
+    const src =
+        \\{ "event": { "type": "OnCreate" }, "nodes": [], "edges": [] }
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    try std.testing.expectEqual(@as(usize, 0), doc.comments.len);
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "comments") == null);
+    // `edges` keeps its no-trailing-comma close when no block follows.
+    try std.testing.expect(std.mem.indexOf(u8, text, "\"edges\": []\n") != null);
+}
+
+test "comments coexist with exec_edges (both blocks, correct commas)" {
+    // When a flow carries both an `exec_edges` block and a `comments`
+    // block, `edges` and `exec_edges` each need a trailing comma so the
+    // JSON stays well-formed. Assert the full byte-stable round-trip.
+    const src =
+        \\{
+        \\  "nodes": [
+        \\    { "id": 4, "type": "Branch", "pos": [0, 0] },
+        \\    { "id": 6, "type": "Print", "pos": [10, 0] }
+        \\  ],
+        \\  "edges": [],
+        \\  "exec_edges": [
+        \\    { "from": { "node": 4, "pin": "then" }, "to": { "node": 6 } }
+        \\  ],
+        \\  "comments": [
+        \\    { "text": "note", "x": 0, "y": 0, "w": 200, "h": 120 }
+        \\  ]
+        \\}
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    try std.testing.expectEqual(@as(usize, 1), doc.exec_edges.len);
+    try std.testing.expectEqual(@as(usize, 1), doc.comments.len);
+
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+    // `exec_edges` closes with a trailing comma because `comments` follows.
+    try std.testing.expect(std.mem.indexOf(u8, text, "} }\n  ],\n  \"comments\"") != null);
+
+    var doc2 = try parse(std.testing.allocator, text);
+    defer doc2.deinit();
+    const text2 = try render(std.testing.allocator, doc2);
+    defer std.testing.allocator.free(text2);
+    try std.testing.expectEqualStrings(text, text2);
+}
+
+test "comments parser rejects malformed entries" {
+    // Non-array comments.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "nodes": [], "edges": [], "comments": {} }
+    ));
+    // A non-object entry.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "nodes": [], "edges": [], "comments": [ 1 ] }
+    ));
+    // A non-string `text`.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "nodes": [], "edges": [], "comments": [ { "text": 5 } ] }
+    ));
+    // A non-number geometry field.
+    try std.testing.expectError(ParseError.BadSchema, parse(std.testing.allocator,
+        \\{ "nodes": [], "edges": [], "comments": [ { "x": "nope" } ] }
+    ));
+}
+
+test "comments with all defaults round-trip (sparse entry)" {
+    // A comment entry may omit any field — `text` defaults empty, geometry
+    // to the `Comment` defaults. The writer still emits a complete entry,
+    // and a re-parse is byte-stable.
+    const src =
+        \\{ "nodes": [], "edges": [], "comments": [ {} ] }
+    ;
+    var doc = try parse(std.testing.allocator, src);
+    defer doc.deinit();
+    try std.testing.expectEqual(@as(usize, 1), doc.comments.len);
+    try std.testing.expectEqualStrings("", doc.comments[0].text);
+    try std.testing.expectEqual(@as(f32, 200), doc.comments[0].w);
+
+    const text = try render(std.testing.allocator, doc);
+    defer std.testing.allocator.free(text);
+    var doc2 = try parse(std.testing.allocator, text);
+    defer doc2.deinit();
+    const text2 = try render(std.testing.allocator, doc2);
+    defer std.testing.allocator.free(text2);
+    try std.testing.expectEqualStrings(text, text2);
 }
 
 test "displayNameFromPath strips extension" {

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -590,6 +590,11 @@ fn renderCanvas(s: *FlowDocState, allocator: std.mem.Allocator) void {
     // trigger); see `renderNodeBody`. Synthetic exec arrows are emitted
     // below the data-edge loop based on the topo order of the command
     // spine (RFC §6 deferral, issue #172).
+    // Comment / group frames (labelle-gui#188) — emitted *before* the
+    // nodes so the editor draws them behind. Purely cosmetic; ignored by
+    // codegen.
+    renderComments(s);
+
     for (s.doc.nodes) |n| {
         const visual = nodeVisual(n);
         ne.pushStyleVar1f(.node_rounding, visual.rounding);
@@ -1536,6 +1541,19 @@ fn linkId(e: flow_io.Edge) u64 {
     return (h.final() & 0x7FFF_FFFF_FFFF_FFFF) | (@as(u64, 1) << 63);
 }
 
+/// Base for comment-frame node-editor ids (labelle-gui#188). Comment
+/// frames are rendered as imgui-node-editor *group* nodes so the editor
+/// drags/resizes them natively, but they're not `flow_io.Node`s — they
+/// need ids in the same `NodeId` space that can't collide with a real
+/// node's id (`@intCast(n.id)`, a small `u32`). The high base keeps the
+/// two spaces disjoint: real node ids are small, comment ids start near
+/// 2^40, so no realistic node count reaches them.
+const comment_id_base: u64 = 0x100_0000_0000;
+
+fn commentNodeId(index: usize) u64 {
+    return comment_id_base + @as(u64, index);
+}
+
 const PinDir = enum { input, output };
 
 /// A frame-scoped set of pin names, used to de-duplicate the pins a
@@ -1555,6 +1573,91 @@ fn pinId(node: u32, name: []const u8, dir: PinDir) u64 {
     h.update(name);
     const base = (h.final() & 0x3FFF_FFFF) | (@as(u64, node) << 30);
     return if (dir == .output) base | (@as(u64, 1) << 62) else base;
+}
+
+/// The editor's default comment-frame tint when a `Comment` carries no
+/// explicit `color` — a soft, low-alpha amber so the frame reads as an
+/// annotation behind the nodes without obscuring them.
+const default_comment_fill: [4]f32 = .{ 0.95, 0.80, 0.35, 0.12 };
+const default_comment_border: [4]f32 = .{ 0.95, 0.80, 0.35, 0.45 };
+
+/// Unpack a packed `0xRRGGBBAA` color into a normalized `[4]f32` rgba.
+fn unpackRgba(packed_rgba: u32) [4]f32 {
+    return .{
+        @as(f32, @floatFromInt((packed_rgba >> 24) & 0xFF)) / 255.0,
+        @as(f32, @floatFromInt((packed_rgba >> 16) & 0xFF)) / 255.0,
+        @as(f32, @floatFromInt((packed_rgba >> 8) & 0xFF)) / 255.0,
+        @as(f32, @floatFromInt(packed_rgba & 0xFF)) / 255.0,
+    };
+}
+
+/// Render every comment / group frame as an imgui-node-editor *group*
+/// node (labelle-gui#188). Group nodes are translucent, labeled,
+/// resizable rectangles the editor draws *behind* ordinary nodes and
+/// drags/resizes natively — exactly the v1 "cosmetic backdrop" shape.
+///
+/// Called before the node loop in `renderCanvas` so the groups are
+/// emitted first (and so drawn behind). Position is seeded from each
+/// `Comment`'s `x`/`y` on the layout frame, then read back every frame
+/// (along with the live group size) so a drag or resize updates the
+/// `Comment` and marks the doc dirty — a Save then persists the change.
+fn renderComments(s: *FlowDocState) void {
+    for (s.doc.comments, 0..) |*c, i| {
+        const id = commentNodeId(i);
+
+        // Seed the editor's position from the doc the first frame, the
+        // same handoff the node loop uses (`needs_layout`). After that the
+        // editor owns position; we read it back below.
+        if (s.needs_layout) {
+            ne.setNodePosition(id, .{ c.x, c.y });
+        }
+
+        const fill = if (c.color) |col| unpackRgba(col) else default_comment_fill;
+        const border = if (c.color) |col| brighten(unpackRgba(col)) else default_comment_border;
+
+        ne.pushStyleColor(.group_bg, fill);
+        ne.pushStyleColor(.group_border, border);
+        ne.pushStyleVar1f(.group_rounding, 6.0);
+        defer {
+            ne.popStyleVar(1);
+            ne.popStyleColor(2);
+        }
+
+        ne.beginNode(id);
+        // Header label sits at the group's top-left, drawn above the
+        // translucent backdrop the `ne.group` call lays down.
+        const label = if (c.text.len > 0) c.text else "(comment)";
+        zgui.textUnformatted(label);
+        ne.group(.{ c.w, c.h });
+        ne.endNode();
+
+        // Pull live position + size back so a drag/resize persists.
+        const pos = ne.getNodePosition(id);
+        const size = ne.getNodeSize(id);
+        if (pos[0] != c.x or pos[1] != c.y) {
+            c.x = pos[0];
+            c.y = pos[1];
+            s.is_dirty = true;
+        }
+        // The node's reported size includes the header + padding, so it is
+        // always >= the requested group size; only adopt a larger size
+        // (the user dragged the resize handle), and only when it actually
+        // grew, to avoid a feedback loop with the header's own footprint.
+        if (size[0] > c.w + 1.0) {
+            c.w = size[0];
+            s.is_dirty = true;
+        }
+        if (size[1] > c.h + 1.0) {
+            c.h = size[1];
+            s.is_dirty = true;
+        }
+    }
+}
+
+/// Lift a fill color's alpha toward opacity for use as a border tint, so
+/// a low-alpha fill still gets a visible edge.
+fn brighten(rgba: [4]f32) [4]f32 {
+    return .{ rgba[0], rgba[1], rgba[2], @min(1.0, rgba[3] + 0.4) };
 }
 
 fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Node) void {
@@ -2257,7 +2360,73 @@ fn renderInspector(s: *FlowDocState) void {
     renderNodePalette(s);
     zgui.spacing();
     zgui.separator();
+    renderCommentsInspector(s);
+    zgui.spacing();
+    zgui.separator();
     renderSelectedNode(s);
+}
+
+/// Inspector section for the comment / group frames (labelle-gui#188).
+/// Lists every frame with editable `text` and `x`/`y`/`w`/`h` geometry,
+/// plus a delete button. The canvas-side `renderComments` already moves
+/// frames by drag; this gives precise edits and is the editing surface
+/// when a frame is dragged behind the nodes and hard to grab. Editing any
+/// field marks the doc dirty and re-seeds the layout so the canvas picks
+/// up the new geometry next frame.
+fn renderCommentsInspector(s: *FlowDocState) void {
+    const a = s.doc.allocator();
+    zgui.text("Comments ({d})", .{s.doc.comments.len});
+    if (s.doc.comments.len == 0) {
+        zgui.textDisabled("(none — \"+ Comment\" adds a frame)", .{});
+        return;
+    }
+
+    var id_buf: [64]u8 = undefined;
+    var remove_idx: ?usize = null;
+    for (s.doc.comments, 0..) |*c, i| {
+        zgui.pushIntId(@intCast(i));
+        defer zgui.popId();
+
+        zgui.setNextItemWidth(180);
+        var text_buf: ValueBuf = undefined;
+        seedBuf(&text_buf, c.text);
+        if (zgui.inputText("##cmt_text", .{ .buf = &text_buf })) {
+            c.text = dupZ(a, &text_buf) catch c.text;
+            s.is_dirty = true;
+        }
+        zgui.sameLine(.{});
+        const x_id = std.fmt.bufPrintZ(&id_buf, "x##cmt{d}", .{i}) catch "x";
+        if (zgui.smallButton(x_id)) remove_idx = i;
+
+        zgui.setNextItemWidth(140);
+        if (zgui.dragFloat("xy##cmt", .{ .v = &c.x, .cfmt = "%.0f" })) {
+            s.is_dirty = true;
+            s.needs_layout = true;
+        }
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(70);
+        if (zgui.dragFloat("##cmt_y", .{ .v = &c.y, .cfmt = "%.0f" })) {
+            s.is_dirty = true;
+            s.needs_layout = true;
+        }
+
+        zgui.setNextItemWidth(140);
+        if (zgui.dragFloat("wh##cmt", .{ .v = &c.w, .min = 40, .cfmt = "%.0f" })) {
+            s.is_dirty = true;
+        }
+        zgui.sameLine(.{});
+        zgui.setNextItemWidth(70);
+        if (zgui.dragFloat("##cmt_h", .{ .v = &c.h, .min = 40, .cfmt = "%.0f" })) {
+            s.is_dirty = true;
+        }
+        zgui.separator();
+    }
+
+    if (remove_idx) |idx| {
+        deleteComment(s, idx) catch |err| {
+            std.log.err("flow: delete comment failed: {s}", .{@errorName(err)});
+        };
+    }
 }
 
 fn renderEventEditor(s: *FlowDocState) void {
@@ -2725,6 +2894,21 @@ fn renderNodePalette(s: *FlowDocState) void {
     zgui.sameLine(.{});
     zgui.textDisabled("(escape hatch — drops Zig source)", .{});
     renderRawCallDialog(s);
+
+    // ── Annotations section (labelle-gui#188) ──
+    // Comment / group frames — purely cosmetic backdrops behind the
+    // nodes, ignored by codegen. A "+ Comment" drops a default-sized
+    // frame; editing happens in the selected-comment inspector below.
+    zgui.spacing();
+    zgui.separator();
+    zgui.text("Annotations", .{});
+    if (zgui.button("+ Comment", .{})) {
+        appendComment(s) catch |err| {
+            std.log.err("flow: add comment failed: {s}", .{@errorName(err)});
+        };
+    }
+    zgui.sameLine(.{});
+    zgui.textDisabled("(cosmetic frame — ignored by codegen)", .{});
 
     // ── Per-plugin sections (RFC §1, §6) ──
     // For phase 4 MVP this walks the static `flow_node_catalog`.
@@ -3521,6 +3705,37 @@ fn addOtherNode(
     s.is_dirty = true;
 }
 
+/// Append a fresh comment / group frame (labelle-gui#188) at a staggered
+/// default position so successive adds don't stack on one spot. Marks the
+/// doc dirty and re-seeds the layout so the new frame's position is
+/// applied to the canvas. Independent of nodes — a flow with no nodes can
+/// still carry comments.
+fn appendComment(s: *FlowDocState) !void {
+    const a = s.doc.allocator();
+    const offset: f32 = @floatFromInt((s.doc.comments.len % 8) * 24);
+    const c: flow_io.Comment = .{
+        .text = try a.dupe(u8, "Comment"),
+        .x = 24 + offset,
+        .y = 24 + offset,
+        .w = 220,
+        .h = 140,
+    };
+    s.doc.comments = try growComments(a, s.doc.comments, c);
+    s.needs_layout = true; // re-seed so the new frame's pos is applied
+    s.is_dirty = true;
+}
+
+fn deleteComment(s: *FlowDocState, idx: usize) !void {
+    const a = s.doc.allocator();
+    s.doc.comments = try removeAt(flow_io.Comment, a, s.doc.comments, idx);
+    // The node editor keyed the deleted frame by its index-derived id;
+    // re-seed so the remaining frames re-apply their positions at their
+    // new indices (otherwise the editor would keep stale group state for
+    // the now-shifted ids).
+    s.needs_layout = true;
+    s.is_dirty = true;
+}
+
 fn deleteNode(s: *FlowDocState, id: u32) !void {
     const a = s.doc.allocator();
     // Find the index.
@@ -3675,6 +3890,13 @@ fn growEdges(a: std.mem.Allocator, src: []flow_io.Edge, add: flow_io.Edge) ![]fl
 
 fn growExecEdges(a: std.mem.Allocator, src: []flow_io.ExecEdge, add: flow_io.ExecEdge) ![]flow_io.ExecEdge {
     const out = try a.alloc(flow_io.ExecEdge, src.len + 1);
+    @memcpy(out[0..src.len], src);
+    out[src.len] = add;
+    return out;
+}
+
+fn growComments(a: std.mem.Allocator, src: []flow_io.Comment, add: flow_io.Comment) ![]flow_io.Comment {
+    const out = try a.alloc(flow_io.Comment, src.len + 1);
     @memcpy(out[0..src.len], src);
     out[src.len] = add;
     return out;

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -562,7 +562,7 @@ fn renderCanvas(s: *FlowDocState, allocator: std.mem.Allocator) void {
         // Defer the viewport fit to the next frame — `navigateToContent`
         // needs node *sizes*, which the editor only learns once
         // `beginNode`/`endNode` have run.
-        if (s.doc.nodes.len > 0) s.needs_fit_to_content = true;
+        if (s.doc.nodes.len > 0 or s.doc.comments.len > 0) s.needs_fit_to_content = true;
     } else if (s.needs_fit_to_content) {
         ne.navigateToContent(0.0);
         s.needs_fit_to_content = false;

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -553,7 +553,12 @@ fn renderCanvas(s: *FlowDocState, allocator: std.mem.Allocator) void {
         for (s.doc.nodes) |n| {
             ne.setNodePosition(@intCast(n.id), n.pos);
         }
-        s.needs_layout = false;
+        // NB: `needs_layout` is *not* cleared here. Comment frames seed
+        // their persisted `x`/`y` off the same flag inside `renderComments`
+        // (called further down), so clearing it before that runs would let
+        // the editor's default position be read back and stomp the stored
+        // geometry on the seeding frame (labelle-gui#188). The flag is
+        // cleared *after* `renderComments`.
         // Defer the viewport fit to the next frame — `navigateToContent`
         // needs node *sizes*, which the editor only learns once
         // `beginNode`/`endNode` have run.
@@ -592,8 +597,16 @@ fn renderCanvas(s: *FlowDocState, allocator: std.mem.Allocator) void {
     // spine (RFC §6 deferral, issue #172).
     // Comment / group frames (labelle-gui#188) — emitted *before* the
     // nodes so the editor draws them behind. Purely cosmetic; ignored by
-    // codegen.
+    // codegen. Seeds comment positions off `needs_layout`, so it must run
+    // while the flag is still set.
     renderComments(s);
+
+    // The layout/seed handoff is complete for *both* nodes and comment
+    // frames; from the next frame the editor owns positions and we only
+    // read them back. Clearing here (not right after the node seed above)
+    // is what lets `renderComments` apply persisted comment geometry on the
+    // seeding frame instead of the editor's default (labelle-gui#188).
+    s.needs_layout = false;
 
     for (s.doc.nodes) |n| {
         const visual = nodeVisual(n);
@@ -1550,8 +1563,12 @@ fn linkId(e: flow_io.Edge) u64 {
 /// 2^40, so no realistic node count reaches them.
 const comment_id_base: u64 = 0x100_0000_0000;
 
-fn commentNodeId(index: usize) u64 {
-    return comment_id_base + @as(u64, index);
+/// Map a comment's *stable* id (`Comment.id`, labelle-gui#188) into the
+/// node-editor's id namespace. Keyed by the stable id — never the slice
+/// index — so deleting a non-last comment doesn't shift surviving frames
+/// onto another frame's editor (drag/resize) state.
+fn commentNodeId(comment_id: u32) u64 {
+    return comment_id_base + @as(u64, comment_id);
 }
 
 const PinDir = enum { input, output };
@@ -1602,8 +1619,13 @@ fn unpackRgba(packed_rgba: u32) [4]f32 {
 /// (along with the live group size) so a drag or resize updates the
 /// `Comment` and marks the doc dirty — a Save then persists the change.
 fn renderComments(s: *FlowDocState) void {
-    for (s.doc.comments, 0..) |*c, i| {
-        const id = commentNodeId(i);
+    for (s.doc.comments) |*c| {
+        // A defensively-assigned id for any frame that somehow reached the
+        // canvas without one (id `0` is the "unassigned" sentinel). The
+        // loader and `appendComment` both assign ids, so this is belt-and-
+        // braces — but a `0` id would alias `comment_id_base` across frames.
+        if (c.id == 0) c.id = s.doc.nextCommentId();
+        const id = commentNodeId(c.id);
 
         // Seed the editor's position from the doc the first frame, the
         // same handoff the node loop uses (`needs_layout`). After that the
@@ -3719,6 +3741,10 @@ fn appendComment(s: *FlowDocState) !void {
         .y = 24 + offset,
         .w = 220,
         .h = 140,
+        // Stable editor id (labelle-gui#188) — mirror how nodes get
+        // `nextNodeId()`. Persisted so it survives loads and never aliases
+        // another frame's editor state after a sibling delete.
+        .id = s.doc.nextCommentId(),
     };
     s.doc.comments = try growComments(a, s.doc.comments, c);
     s.needs_layout = true; // re-seed so the new frame's pos is applied
@@ -3728,10 +3754,10 @@ fn appendComment(s: *FlowDocState) !void {
 fn deleteComment(s: *FlowDocState, idx: usize) !void {
     const a = s.doc.allocator();
     s.doc.comments = try removeAt(flow_io.Comment, a, s.doc.comments, idx);
-    // The node editor keyed the deleted frame by its index-derived id;
-    // re-seed so the remaining frames re-apply their positions at their
-    // new indices (otherwise the editor would keep stale group state for
-    // the now-shifted ids).
+    // Surviving frames keep their *stable* ids (labelle-gui#188), so the
+    // editor's per-frame state stays bound to the right frame — no index
+    // shift, no editor-state bleed. Re-seed positions anyway so the
+    // persisted geometry is re-applied on the next layout pass.
     s.needs_layout = true;
     s.is_dirty = true;
 }

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -1653,24 +1653,18 @@ fn renderComments(s: *FlowDocState) void {
         ne.group(.{ c.w, c.h });
         ne.endNode();
 
-        // Pull live position + size back so a drag/resize persists.
+        // Pull live position back so a drag persists. Size is NOT read
+        // back: `getNodeSize` reports content + header/padding chrome
+        // (always >= the requested group size), so adopting it would
+        // feedback-loop (grow every frame); guarding it grow-only — the
+        // prior approach — instead silently blocked shrinking (bugbot).
+        // v1 makes the inspector w/h authoritative (both grow AND shrink
+        // work, and aren't overwritten); canvas drag-resize persistence
+        // is a tracked follow-up.
         const pos = ne.getNodePosition(id);
-        const size = ne.getNodeSize(id);
         if (pos[0] != c.x or pos[1] != c.y) {
             c.x = pos[0];
             c.y = pos[1];
-            s.is_dirty = true;
-        }
-        // The node's reported size includes the header + padding, so it is
-        // always >= the requested group size; only adopt a larger size
-        // (the user dragged the resize handle), and only when it actually
-        // grew, to avoid a feedback loop with the header's own footprint.
-        if (size[0] > c.w + 1.0) {
-            c.w = size[0];
-            s.is_dirty = true;
-        }
-        if (size[1] > c.h + 1.0) {
-            c.h = size[1];
             s.is_dirty = true;
         }
     }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5578,6 +5578,28 @@ pub const FlowIoTests = struct {
         try expect.equal(doc.max_comment_id, max_assigned);
     }
 
+    test "duplicate comment ids are de-aliased on load (bugbot)" {
+        // Two comments sharing a non-zero id would map to one node-editor
+        // frame; the loader must hand the collision a fresh, distinct id.
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "event": { "type": "OnCreate" },
+            \\  "nodes": [],
+            \\  "edges": [],
+            \\  "comments": [
+            \\    { "id": 5, "text": "a", "x": 0, "y": 0, "w": 200, "h": 120 },
+            \\    { "id": 5, "text": "b", "x": 10, "y": 10, "w": 200, "h": 120 }
+            \\  ]
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        try expect.equal(doc.comments.len, @as(usize, 2));
+        try expect.toBeTrue(doc.comments[0].id != doc.comments[1].id);
+        try expect.toBeTrue(doc.comments[0].id != 0 and doc.comments[1].id != 0);
+    }
+
     test "mixed assigned/unassigned ids don't collide on load" {
         // One comment carries an explicit id, another doesn't. The loader
         // seeds the counter off the explicit id first, so the backfilled id

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5511,6 +5511,145 @@ pub const FlowIoTests = struct {
         try expect.toBeTrue(std.mem.eql(u8, doc2.comments[0].text, "spawn logic"));
     }
 
+    // ── comment stable ids (labelle-gui#188, bugbot: delete reuses ids) ──
+
+    test "comment id round-trips and seeds max_comment_id" {
+        // A persisted `id` survives a save/load so the editor's stable
+        // node-editor key is reproducible across sessions, and the loaded
+        // doc's `max_comment_id` is the highest id seen (so the next fresh
+        // comment never reuses one).
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "event": { "type": "OnCreate" },
+            \\  "nodes": [],
+            \\  "edges": [],
+            \\  "comments": [
+            \\    { "text": "a", "x": 0, "y": 0, "w": 200, "h": 120, "id": 3 },
+            \\    { "text": "b", "x": 10, "y": 10, "w": 200, "h": 120, "id": 7 }
+            \\  ]
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        try expect.equal(doc.comments.len, @as(usize, 2));
+        try expect.equal(doc.comments[0].id, @as(u32, 3));
+        try expect.equal(doc.comments[1].id, @as(u32, 7));
+        try expect.equal(doc.max_comment_id, @as(u32, 7));
+        // A fresh id lands strictly above the highest persisted one.
+        try expect.equal(doc.nextCommentId(), @as(u32, 8));
+
+        const text = try flow_io.render(a, doc);
+        defer a.free(text);
+        // The id is emitted in the serialized form…
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"id\": 3") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text, "\"id\": 7") != null);
+        var doc2 = try flow_io.parse(a, text);
+        defer doc2.deinit();
+        try expect.equal(doc2.comments[0].id, @as(u32, 3));
+        try expect.equal(doc2.comments[1].id, @as(u32, 7));
+    }
+
+    test "comments without ids still load (ids assigned on load)" {
+        // Pre-id files (and `"comments": [ {} ]`-style sparse entries)
+        // carry no `id`; the loader must assign fresh, unique ids so every
+        // comment gets a stable editor key. Absence is back-compatible.
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "event": { "type": "OnCreate" },
+            \\  "nodes": [],
+            \\  "edges": [],
+            \\  "comments": [
+            \\    { "text": "a", "x": 0, "y": 0, "w": 200, "h": 120 },
+            \\    { "text": "b", "x": 10, "y": 10, "w": 200, "h": 120 }
+            \\  ]
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        try expect.equal(doc.comments.len, @as(usize, 2));
+        // Both got non-zero, distinct ids…
+        try expect.toBeTrue(doc.comments[0].id != 0);
+        try expect.toBeTrue(doc.comments[1].id != 0);
+        try expect.toBeTrue(doc.comments[0].id != doc.comments[1].id);
+        // …and the counter is consistent with what was assigned.
+        const max_assigned = @max(doc.comments[0].id, doc.comments[1].id);
+        try expect.equal(doc.max_comment_id, max_assigned);
+    }
+
+    test "mixed assigned/unassigned ids don't collide on load" {
+        // One comment carries an explicit id, another doesn't. The loader
+        // seeds the counter off the explicit id first, so the backfilled id
+        // can't collide with it.
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "event": { "type": "OnCreate" },
+            \\  "nodes": [],
+            \\  "edges": [],
+            \\  "comments": [
+            \\    { "text": "a", "id": 5 },
+            \\    { "text": "b" }
+            \\  ]
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        try expect.equal(doc.comments[0].id, @as(u32, 5));
+        try expect.toBeTrue(doc.comments[1].id != 0);
+        try expect.toBeTrue(doc.comments[1].id != 5);
+        try expect.toBeTrue(doc.comments[1].id > 5);
+    }
+
+    test "deleting comment[0] leaves comment[1] id+geometry intact" {
+        // Model-level reproduction of the bugbot "delete reuses editor ids"
+        // bug. Deleting a non-last comment shifts slice indices; with a
+        // *stable* `id` the survivor keeps both its id and its geometry, so
+        // no index-based aliasing can hand it the deleted frame's editor
+        // state. Mirrors the editor's `deleteComment` (a slice splice that
+        // never touches surviving entries).
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "event": { "type": "OnCreate" },
+            \\  "nodes": [],
+            \\  "edges": [],
+            \\  "comments": [
+            \\    { "text": "first", "x": 1, "y": 2, "w": 200, "h": 120, "id": 1 },
+            \\    { "text": "second", "x": 33, "y": 44, "w": 300, "h": 200, "id": 2 }
+            \\  ]
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        try expect.equal(doc.comments.len, @as(usize, 2));
+
+        // Splice out index 0 (mirrors `deleteComment(s, 0)`).
+        const da = doc.allocator();
+        const kept = try da.alloc(flow_io.Comment, 1);
+        kept[0] = doc.comments[1];
+        doc.comments = kept;
+
+        // The survivor is the *same* frame — id and geometry unchanged. An
+        // index-derived editor id would have made it inherit the deleted
+        // frame's (id 1) state; the stable id (2) prevents that.
+        try expect.equal(doc.comments.len, @as(usize, 1));
+        try expect.equal(doc.comments[0].id, @as(u32, 2));
+        try expect.toBeTrue(std.mem.eql(u8, doc.comments[0].text, "second"));
+        try expect.equal(doc.comments[0].x, @as(f32, 33));
+        try expect.equal(doc.comments[0].y, @as(f32, 44));
+        try expect.equal(doc.comments[0].w, @as(f32, 300));
+        try expect.equal(doc.comments[0].h, @as(f32, 200));
+
+        // And it round-trips with its id preserved.
+        const text = try flow_io.render(a, doc);
+        defer a.free(text);
+        var doc2 = try flow_io.parse(a, text);
+        defer doc2.deinit();
+        try expect.equal(doc2.comments[0].id, @as(u32, 2));
+    }
+
     // ── appendOtherNode: palette create-buttons for `.other` kinds (#192) ──
 
     test "appendOtherNode creates an .other node with the seeded op extra" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5465,6 +5465,52 @@ pub const FlowIoTests = struct {
         try expect.toBeTrue(std.mem.indexOf(u8, text, "\"note\": \"keep me\"") != null);
     }
 
+    // ── comment / group frames (labelle-gui#188) ──
+
+    test "comments survive node mutation (independent of nodes)" {
+        // Comment frames are purely cosmetic backdrops, indexed
+        // independently of the node graph. Mutating `nodes` (as the
+        // editor's `deleteNode` does — splice a node, drop its edges)
+        // must leave `doc.comments` untouched. This mirrors the editor's
+        // delete path, which never references the comment slice.
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "event": { "type": "OnCreate" },
+            \\  "nodes": [
+            \\    { "id": 1, "type": "Literal", "pos": [0, 0] },
+            \\    { "id": 2, "type": "BinOp", "op": "add", "pos": [10, 0] }
+            \\  ],
+            \\  "edges": [],
+            \\  "comments": [
+            \\    { "text": "spawn logic", "x": 40, "y": 40, "w": 220, "h": 140 }
+            \\  ]
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        try expect.equal(doc.comments.len, @as(usize, 1));
+
+        // Emulate a node delete: drop node 1, keeping the comment slice
+        // exactly as-is (the editor's deleteNode does the same — it never
+        // touches doc.comments).
+        const da = doc.allocator();
+        const kept = try da.alloc(flow_io.Node, 1);
+        kept[0] = doc.nodes[1];
+        doc.nodes = kept;
+
+        // The comment is unchanged and still renders + re-parses cleanly.
+        try expect.equal(doc.comments.len, @as(usize, 1));
+        try expect.toBeTrue(std.mem.eql(u8, doc.comments[0].text, "spawn logic"));
+
+        const text = try flow_io.render(a, doc);
+        defer a.free(text);
+        var doc2 = try flow_io.parse(a, text);
+        defer doc2.deinit();
+        try expect.equal(doc2.comments.len, @as(usize, 1));
+        try expect.toBeTrue(std.mem.eql(u8, doc2.comments[0].text, "spawn logic"));
+    }
+
     // ── appendOtherNode: palette create-buttons for `.other` kinds (#192) ──
 
     test "appendOtherNode creates an .other node with the seeded op extra" {


### PR DESCRIPTION
v1 of #188 — **comment / group frames** for the flow editor. Resizable, labeled, translucent boxes drawn **behind** the flow nodes as pure editor annotation, ignored by codegen and round-tripped in the `.flow.jsonc`. Reroute nodes are deferred to a follow-up.

## Round-tripped `comments` metadata (the data-safety part)
Mirrors exactly how #195 added `exec_edges`. New top-level block on the GUI flow model + writer:

```jsonc
{ "comments": [ { "text": "spawn logic", "x": 40, "y": 40, "w": 220, "h": 140 } ] }
```

- `flow_io.Comment { text: []const u8, x/y/w/h: f32, color: ?u32 }` (packed `0xRRGGBBAA`, optional) and `FlowDoc.comments`.
- Parser reads the top-level `"comments"` array (absent → empty slice).
- `render` emits it **deterministically** in insertion order, **only when non-empty**, after `exec_edges`. The `edges` / `exec_edges` trailing-comma logic now accounts for a following `comments` block so the JSON stays well-formed in every combination.
- **No flow-codegen change needed**: flow-codegen parses with `ignore_unknown_fields = true` (verified in its `flow_io.loadFromFile`), so an unknown `comments` key is silently ignored by the assembler / codegen — it has zero codegen effect.

## Rendering
Each comment is drawn as an **imgui-node-editor *group* node** (the binding's native `ne.group(size)` primitive — not a manual draw-list rect). The node editor renders the translucent `group_bg` backdrop **behind** ordinary nodes, draws the `text` as a header label, and makes the frame **draggable and resizable natively**. Live position/size are read back into the `Comment` each frame and mark the doc dirty, so a Save persists the layout. Default tint is a soft low-alpha amber; a `Comment.color` overrides it.

- **"+ Comment"** palette button (Annotations section) drops a default-sized frame.
- A **Comments inspector** edits `text` / `x` / `y` / `w` / `h` and deletes frames.

## Tests
Model / round-trip logic is unit-tested (imgui rendering is not):

- `comments round-trip preserves editor-only frames`
- `absence of comments is preserved (no key emitted)`
- `comments coexist with exec_edges (both blocks, correct commas)`
- `comments parser rejects malformed entries`
- `comments with all defaults round-trip (sparse entry)`
- `comments survive node mutation (independent of nodes)` — the editor's `deleteNode` never touches `doc.comments`.

`zig build test` → **447/447 pass**. `zig build` (GUI exe) and `zig build gui-test` (26/26) both green.

## Deferred (follow-up)
**Reroute nodes / edge waypoints** are intentionally out of scope here — they carry pass-through / edge-waypoint semantics that interact with codegen-derived exec/data edges. Comments/groups are the clean, purely-cosmetic part and ship first. Grouping nodes *into* a frame (auto-membership) is also out of scope — v1 frames are visual backdrops, not containers.

Refs #188