### PR TITLE
feat(flow editor): Once / Cooldown / Delay palette nodes

### DIFF
--- a/src/flow_io.zig
+++ b/src/flow_io.zig
@@ -351,6 +351,13 @@ pub const other_field_specs = [_]OtherFieldSpec{
     .{ .type_name = "Literal", .key = "value", .label = "Value", .widget = .literal },
     .{ .type_name = "Identifier", .key = "name", .label = "Name", .widget = .text },
     .{ .type_name = "Call", .key = "callee", .label = "Callee", .widget = .text },
+    // Time-control command nodes (flow-codegen#47, #48). `Cooldown` and
+    // `Delay` each carry one `seconds` field (a JSON-native `f64` literal,
+    // e.g. `1.0`) edited verbatim through the `.literal` widget so it
+    // normalises + round-trips like any other numeric extra. `Once` has no
+    // field, so it needs no spec — its inspector shows the verbatim view.
+    .{ .type_name = "Cooldown", .key = "seconds", .label = "Seconds", .widget = .literal },
+    .{ .type_name = "Delay", .key = "seconds", .label = "Seconds", .widget = .literal },
 };
 
 /// Return the editable-field spec for a node `type_name`, or null when

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -2939,11 +2939,11 @@ fn renderNodePalette(s: *FlowDocState) void {
     }
     zgui.sameLine(.{});
     if (zgui.button("+ Cooldown", .{})) {
-        addOtherNode(s, "Cooldown", &.{.{ .key = "seconds", .value_text = "1.0" }}) catch |err| nodeAddErr(err);
+        addOtherNode(s, "Cooldown", &.{.{ .key = "seconds", .value_text = "1" }}) catch |err| nodeAddErr(err);
     }
     zgui.sameLine(.{});
     if (zgui.button("+ Delay", .{})) {
-        addOtherNode(s, "Delay", &.{.{ .key = "seconds", .value_text = "1.0" }}) catch |err| nodeAddErr(err);
+        addOtherNode(s, "Delay", &.{.{ .key = "seconds", .value_text = "1" }}) catch |err| nodeAddErr(err);
     }
 
     // Raw `Call` escape hatch (RFC §7) — surfaced separately so a user

--- a/src/modules/flow_doc.zig
+++ b/src/modules/flow_doc.zig
@@ -728,6 +728,12 @@ fn controlExecPinNames(type_name: []const u8) []const []const u8 {
     if (std.mem.eql(u8, type_name, "Branch")) return &.{ "then", "else" };
     if (std.mem.eql(u8, type_name, "ForRange")) return &.{"body"};
     if (std.mem.eql(u8, type_name, "While")) return &.{"body"};
+    // Time-control command nodes (flow-codegen#47, #48). Each has a single
+    // `body` exec output — the codegen contract — that wires to the guarded
+    // step (`Delay`'s `body` must reach a `Subflow`, enforced by codegen).
+    if (std.mem.eql(u8, type_name, "Once")) return &.{"body"};
+    if (std.mem.eql(u8, type_name, "Cooldown")) return &.{"body"};
+    if (std.mem.eql(u8, type_name, "Delay")) return &.{"body"};
     return &.{};
 }
 
@@ -1704,7 +1710,14 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
     // It is recorded as an `.exec` input for *every* such node — not just
     // existing targets — so a control drag can land on a node that has no
     // incoming exec edge yet (authoring the first one, issue #196).
-    const needs_exec_in = (is_command or
+    // Control nodes (Branch/ForRange/While/Switch and the time-control
+    // Once/Cooldown/Delay, flow-codegen#47/#48) are `.other`-kind, so
+    // `isCommandNode` is false for them — but they sit on the exec spine
+    // and must expose an exec-in anchor even when freshly placed, else the
+    // first incoming control arrow has nothing to land on and the node
+    // silently can't be wired. Treat any control node as needing the
+    // anchor, the same way a command node does.
+    const needs_exec_in = (is_command or isControlNode(n) or
         isExplicitExecTarget(s.doc.exec_edges, n.id)) and n.kind != .event;
     if (needs_exec_in) {
         ne.beginPin(execPinId(n.id, .input), .input);
@@ -2057,6 +2070,19 @@ fn renderNodeBody(s: *FlowDocState, allocator: std.mem.Allocator, n: flow_io.Nod
                 zgui.text("> cond", .{});
                 ne.endPin();
                 recordPin(s, n.id, "cond", .input);
+                renderExecOutPin(s, n.id, "body");
+            } else if (std.mem.eql(u8, n.type_name, "Once") or
+                std.mem.eql(u8, n.type_name, "Cooldown") or
+                std.mem.eql(u8, n.type_name, "Delay"))
+            {
+                // Time-control command nodes (flow-codegen#47, #48). No data
+                // pins; one exec OUTPUT `body` (the guarded step). The
+                // exec-IN anchor is emitted by the generic command/control
+                // header above (`needs_exec_in`), so these render as
+                // rectangular command nodes with an exec-in + `body`
+                // exec-out — matching ForRange/While's silhouette. The
+                // `Cooldown`/`Delay` `seconds` field shows in the inspector
+                // (a `.literal` widget) and in the extras hint below.
                 renderExecOutPin(s, n.id, "body");
             } else if (std.mem.eql(u8, n.type_name, "Switch")) {
                 // Multi-way control (flow-codegen#22, issue #199). One
@@ -2898,6 +2924,26 @@ fn renderNodePalette(s: *FlowDocState) void {
     // single spare `case0` + `default` until the user wires more.
     if (zgui.button("+ Switch", .{})) {
         addOtherNode(s, "Switch", &.{}) catch |err| nodeAddErr(err);
+    }
+
+    // ── Time section (flow-codegen#47, #48) ──
+    // Time-control command nodes. `Once` gates its `body` to fire a single
+    // time; `Cooldown`/`Delay` carry a `seconds` (f64) field seeded to
+    // `1.0` — the same canonical JSON value text codegen parses
+    // (`{ "type": "Cooldown", "seconds": 1.0 }`). Like the other control
+    // nodes their wiring is the `body` exec edge; `Delay`'s `body` is meant
+    // to reach a `Subflow` (enforced by codegen, not the editor).
+    zgui.text("Time", .{});
+    if (zgui.button("+ Once", .{})) {
+        addOtherNode(s, "Once", &.{}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ Cooldown", .{})) {
+        addOtherNode(s, "Cooldown", &.{.{ .key = "seconds", .value_text = "1.0" }}) catch |err| nodeAddErr(err);
+    }
+    zgui.sameLine(.{});
+    if (zgui.button("+ Delay", .{})) {
+        addOtherNode(s, "Delay", &.{.{ .key = "seconds", .value_text = "1.0" }}) catch |err| nodeAddErr(err);
     }
 
     // Raw `Call` escape hatch (RFC §7) — surfaced separately so a user

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -6986,6 +6986,167 @@ pub const FlowDocExecEdgeTests = struct {
         );
     }
 
+    // ── Time-control nodes: Once / Cooldown / Delay (flow-codegen#47, #48) ──
+    //
+    // Editor-side palette work for the three time-control command nodes.
+    // They are `.other`-kind command nodes with a single `body` exec
+    // output (the codegen contract) — the same exec-pin shape as
+    // `ForRange`/`While`. `Cooldown`/`Delay` carry a `seconds` (f64) field.
+
+    test "appendOtherNode creates a fieldless Once node" {
+        const a = std.testing.allocator;
+        const src =
+            \\{ "event": { "type": "OnCreate" }, "nodes": [], "edges": [] }
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        const id = try flow_io.appendOtherNode(&doc, "Once", &.{});
+
+        try expect.equal(doc.nodes.len, @as(usize, 1));
+        const n = doc.nodes[0];
+        try expect.equal(n.id, id);
+        try expect.toBeTrue(n.kind == .other);
+        try expect.toBeTrue(std.mem.eql(u8, n.type_name, "Once"));
+        // Once has no editable field — no spec, no seeded extras.
+        try expect.toBeTrue(flow_io.otherFieldSpec(n.type_name) == null);
+        try expect.equal(n.extras.len, @as(usize, 0));
+    }
+
+    test "appendOtherNode seeds Cooldown / Delay with a seconds field" {
+        const a = std.testing.allocator;
+        const src =
+            \\{ "event": { "type": "OnCreate" }, "nodes": [], "edges": [] }
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        const cd = try flow_io.appendOtherNode(
+            &doc,
+            "Cooldown",
+            &.{.{ .key = "seconds", .value_text = "1.0" }},
+        );
+        const dl = try flow_io.appendOtherNode(
+            &doc,
+            "Delay",
+            &.{.{ .key = "seconds", .value_text = "1.0" }},
+        );
+
+        const cooldown = doc.nodes[0];
+        try expect.equal(cooldown.id, cd);
+        try expect.toBeTrue(std.mem.eql(u8, cooldown.type_name, "Cooldown"));
+        // The `seconds` field is the inspector-editable literal field and
+        // is seeded verbatim (matching codegen's `{ "seconds": 1.0 }`).
+        try expect.toBeTrue(flow_io.otherFieldSpec(cooldown.type_name).?.widget == .literal);
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.otherFieldSpec(cooldown.type_name).?.key, "seconds"));
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.extraValue(cooldown, "seconds").?, "1.0"));
+
+        const delay = doc.nodes[1];
+        try expect.equal(delay.id, dl);
+        try expect.toBeTrue(std.mem.eql(u8, delay.type_name, "Delay"));
+        try expect.toBeTrue(flow_io.otherFieldSpec(delay.type_name).?.widget == .literal);
+        try expect.toBeTrue(std.mem.eql(u8, flow_io.extraValue(delay, "seconds").?, "1.0"));
+    }
+
+    test "validateExecEdge accepts a body edge from Once / Cooldown / Delay" {
+        const a = std.testing.allocator;
+        const src =
+            \\{
+            \\  "event": { "type": "OnUpdate" },
+            \\  "nodes": [
+            \\    { "id": 1, "type": "Once", "pos": [0, 0] },
+            \\    { "id": 2, "type": "Cooldown", "seconds": 1.0, "pos": [0, 5] },
+            \\    { "id": 3, "type": "Delay", "seconds": 1.0, "pos": [0, 10] },
+            \\    { "id": 4, "type": "Print", "pos": [10, 0] },
+            \\    { "id": 5, "type": "Print", "pos": [10, 5] },
+            \\    { "id": 6, "type": "Subflow", "flow": "child", "pos": [10, 10] }
+            \\  ],
+            \\  "edges": []
+            \\}
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+        // Each time node exposes exactly the `body` exec output.
+        try flow_doc.validateExecEdge(doc.nodes, doc.exec_edges, 1, "body", 4);
+        try flow_doc.validateExecEdge(doc.nodes, doc.exec_edges, 2, "body", 5);
+        try flow_doc.validateExecEdge(doc.nodes, doc.exec_edges, 3, "body", 6);
+        // `then`/`else` aren't pins on these nodes.
+        try expect.toBeTrue(
+            flow_doc.validateExecEdge(doc.nodes, doc.exec_edges, 1, "then", 4) ==
+                error.NotAControlSource,
+        );
+        try expect.toBeTrue(
+            flow_doc.validateExecEdge(doc.nodes, doc.exec_edges, 2, "else", 5) ==
+                error.NotAControlSource,
+        );
+    }
+
+    test "time-control nodes round-trip through parse / render with seconds" {
+        const a = std.testing.allocator;
+        const src =
+            \\{ "event": { "type": "OnCreate" }, "nodes": [], "edges": [] }
+        ;
+        var doc = try flow_io.parse(a, src);
+        defer doc.deinit();
+
+        _ = try flow_io.appendOtherNode(&doc, "Once", &.{});
+        _ = try flow_io.appendOtherNode(
+            &doc,
+            "Cooldown",
+            &.{.{ .key = "seconds", .value_text = "1.0" }},
+        );
+        _ = try flow_io.appendOtherNode(
+            &doc,
+            "Delay",
+            &.{.{ .key = "seconds", .value_text = "1.0" }},
+        );
+
+        const text1 = try flow_io.render(a, doc);
+        defer a.free(text1);
+
+        // The node types survive the writer, and the freshly-seeded
+        // `seconds` is emitted as the codegen contract's `1.0` literal —
+        // codegen parses it into the node's `f64` field.
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"type\": \"Once\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"type\": \"Cooldown\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"type\": \"Delay\"") != null);
+        try expect.toBeTrue(std.mem.indexOf(u8, text1, "\"seconds\": 1.0") != null);
+
+        // The editor's numeric canonical form drops a trailing `.0` (the
+        // same rule `Literal.value` uses), so a JSON `1.0` normalises to
+        // `1` on its first parse — semantically the same `f64`. After that
+        // first normalisation the file is stable, so a *loaded* flow
+        // round-trips byte-for-byte (load → save → load → save).
+        var doc2 = try flow_io.parse(a, text1);
+        defer doc2.deinit();
+        const text2 = try flow_io.render(a, doc2);
+        defer a.free(text2);
+
+        var doc3 = try flow_io.parse(a, text2);
+        defer doc3.deinit();
+        const text3 = try flow_io.render(a, doc3);
+        defer a.free(text3);
+        // load → save is idempotent from the second cycle onward.
+        try expect.toBeTrue(std.mem.eql(u8, text2, text3));
+
+        // The `seconds` field persists through the load → save cycle
+        // (its canonical text is `1`, the normalised form of `1.0`).
+        var saw_cooldown_seconds = false;
+        var saw_delay_seconds = false;
+        for (doc2.nodes) |n| {
+            if (std.mem.eql(u8, n.type_name, "Cooldown")) {
+                const v = flow_io.extraValue(n, "seconds") orelse continue;
+                saw_cooldown_seconds = std.mem.eql(u8, v, "1");
+            }
+            if (std.mem.eql(u8, n.type_name, "Delay")) {
+                const v = flow_io.extraValue(n, "seconds") orelse continue;
+                saw_delay_seconds = std.mem.eql(u8, v, "1");
+            }
+        }
+        try expect.toBeTrue(saw_cooldown_seconds);
+        try expect.toBeTrue(saw_delay_seconds);
+    }
+
     // ── Switch case-output derivation (#199) ──
     //
     // A Switch's cases are dynamic, so the editor derives how many


### PR DESCRIPTION
Adds the three time-control built-in nodes to the flow editor palette so they're usable in the editor (codegen shipped in flow-codegen#47/#48).

## What
- **Palette** — a new "Time" cluster: `+ Once`, `+ Cooldown` / `+ Delay` (seeding `seconds = 1.0`).
- **Exec pins** — all three are command nodes with an exec-in and a single `body` exec-out, via `controlExecPinNames` (which `isControlNode`/`execPinValidFor`/`validateExecEdge` all derive from). New render arm draws the `body` out.
- **`seconds` field** — `Cooldown`/`Delay` expose an editable `seconds` via the generic `.other`-field path (`.literal` widget, same as `Literal.value`); round-trips to `.flow.jsonc` matching the codegen contract (`{"type":"Cooldown","seconds":1.0}`). `Once` has no fields.

## Latent bug fixed along the way
`needs_exec_in` only covered `isCommandNode` (true for plugin/CustomNodes), but the built-in control nodes (`Branch`/`ForRange`/`While`/`Switch` and now the time nodes) are `.other`-kind → `isCommandNode` was false, so a freshly-placed control node had **no exec-in anchor** until something already targeted it. Now gated on `isControlNode` too — fixes the new nodes and that pre-existing gap.

## Tests
`zig build test` → **456/456**; `zig build gui-test` → **26/26**; `zig build` clean. New tests: add each node (type + seeded `seconds`), exec-pin validity returns `body`, and save/load round-trip preserving `seconds`.

Parent: labelle-toolkit/labelle-gui#187. Pairs with the demo ticket #204.